### PR TITLE
test: document io behaviors

### DIFF
--- a/api/s2n.h
+++ b/api/s2n.h
@@ -1993,7 +1993,7 @@ S2N_API extern int s2n_connection_set_recv_buffering(struct s2n_connection *conn
  * In case 3, additional bytes (another record, complete or incomplete) were
  * also read off the wire. In this case `s2n_peek_buffered` will return the length
  * of ciphertext bytes buffered in "additional". This is the only case in which
- * `peek_buffered_len` will return a non-zero result.
+ * `s2n_peek_buffered` will return a non-zero result.
  *
  * @param conn A pointer to the s2n_connection object
  * @returns The number of buffered encrypted bytes

--- a/api/s2n.h
+++ b/api/s2n.h
@@ -1956,18 +1956,44 @@ S2N_API extern int s2n_connection_prefer_low_latency(struct s2n_connection *conn
 S2N_API extern int s2n_connection_set_recv_buffering(struct s2n_connection *conn, bool enabled);
 
 /**
- * Reports how many bytes of unprocessed TLS records are buffered due to the optimization
- * enabled by `s2n_connection_set_recv_buffering`.
+ * Reports how many bytes of unprocessed TLS records are buffered after the current
+ * record.
+ * 
+ * This is only useful when `s2n_connection_set_recv_buffering` is enabled, and 
+ * will return 0 otherwise.
+ * 
+ * `s2n_peek_buffered` is not a replacement for `s2n_peek`. While `s2n_peek` reports
+ * application data that is ready for the application to read with no additional
+ * processing, `s2n_peek_buffered` reports raw TLS records that still need to be
+ * parsed and likely decrypted. Those records may contain application data, but
+ * they may also only contain TLS control messages.
+ * 
+ * When receive buffering is enabled, it is useful to imagine that an s2n-tls
+ * connection behaves as if it has two buffers, one for the "current record",
+ * and one for "additional data".
+ * ```text
+ * c -> ciphertext
+ * p -> plaintext
  *
- * `s2n_peek_buffered` is not a replacement for `s2n_peek`.
- * While `s2n_peek` reports application data that is ready for the application
- * to read with no additional processing, `s2n_peek_buffered` reports raw TLS
- * records that still need to be parsed and likely decrypted. Those records may
- * contain application data, but they may also only contain TLS control messages.
+ *          |-----current record-----|-------additional------------|
+ * case 1 - |ccccccccccccc
+ * case 2 - |pppppppppppppppppppppppp|
+ * case 3 - |pppppppppppppppppppppppp|ccccccccccccccccccc
+ * ```
+ * In case 1, we received a record fragment. Records can only be decrypted
+ * once the full record is available. So "current record" just stores the record
+ * fragment (ciphertext). There are currently no APIs to determine if there
+ * is a record fragment stored. https://github.com/aws/s2n-tls/issues/5863. `s2n_peek_buffered`
+ * and `s2n_peek` will both return 0 in this case.
  *
- * If an application needs to determine whether there is any data left to handle
- * (for example, before calling `poll` to wait on the read file descriptor) then
- * that application must check both `s2n_peek` and `s2n_peek_buffered`.
+ * In case 2, we received a full record, which is decrypted and stored in current
+ * record. `s2n_peek` will return the count of plaintext bytes
+ * yet to be read from "current record", and `s2n_peek_buffered` will return 0
+ *
+ * In case 3, additional bytes (another record, complete or incomplete) were
+ * also read off the wire. In this case `s2n_peek_buffered` will return the length
+ * of ciphertext bytes buffered in "additional". This is the only case in which
+ * `peek_buffered_len` will return a non-zero result.
  *
  * @param conn A pointer to the s2n_connection object
  * @returns The number of buffered encrypted bytes

--- a/api/s2n.h
+++ b/api/s2n.h
@@ -3957,7 +3957,14 @@ S2N_API int s2n_connection_serialization_length(struct s2n_connection *conn, uin
  * @note This API will error if the handshake is not yet complete. Additionally it will error if there
  * is still application data in the IO buffers given that this data does not get serialized by s2n-tls.
  * You can use `s2n_send` to drain the send buffer and `s2n_peek` + `s2n_recv` to drain the read buffer.
- * @note Serialization is unsupported for SSLv3 connections. See: https://github.com/aws/s2n-tls/issues/5538.
+ * Note that s2n-tls will buffer record fragments until the complete record is available. `s2n_peek` 
+ * will _not_ report buffered record fragments. To avoid buffered record fragments, applications should
+ * continue to call s2n_recv until a non-blocked status is returned, after which point s2n_peek and s2n_recv
+ * can be used to drain the read buffer.
+ * @warning Due to the above read/buffering interaction, this API must not be used
+ * with recv_buffering (s2n_connection_set_recv_buffering), because there is no
+ * way to ensure that an s2n-tls connection hasn't buffered any record fragments.
+ * @note Serialization is unsupported for TLS 1.0 & SSLv3 connections. See: https://github.com/aws/s2n-tls/issues/5538.
  *
  * @param conn A pointer to the connection object.
  * @param buffer A pointer to the buffer where the serialized connection will be written.

--- a/bindings/rust/extended/s2n-tls/src/connection.rs
+++ b/bindings/rust/extended/s2n-tls/src/connection.rs
@@ -736,6 +736,49 @@ impl Connection {
         unsafe { s2n_peek(self.connection.as_ptr()) as usize }
     }
 
+    /// Gets the number of additional ciphertext bytes available to be read.
+    ///
+    /// <div class="warning">
+    ///
+    /// This API is _not_ intuitive, and probably doesn't do what you think
+    /// it does. You should rigorously test your assumptions about its behavior.
+    ///
+    /// </div>
+    ///
+    /// The API will return 0 in the "standard" IO mode, and is only useful when
+    /// [Connection::set_receive_buffering] is enabled.
+    ///
+    /// When receive buffering is enabled, it is useful to imagine that an s2n-tls
+    /// connection behaves as if it has two buffers, one for the "current record",
+    /// and one for additional data.
+    /// ```text
+    /// c -> ciphertext
+    /// p -> plaintext
+    ///
+    ///          |-----current record-----|-------additional------------|
+    /// case 1 - |ccccccccccccc
+    /// case 2 - |pppppppppppppppppppppppp|
+    /// case 3 - |pppppppppppppppppppppppp|ccccccccccccccccccc
+    /// ```
+    /// In case 1, we received a record fragment. Records can only be decrypted
+    /// once the full record is available. So current-record just stores the record
+    /// fragment (ciphertext). There are currently no APIs to determine if there
+    /// is a record fragment stored. https://github.com/aws/s2n-tls/issues/5863
+    ///
+    /// In case 2, we received a full record, which is decrypted and stored in current
+    /// record. [`Connection::peek_len`] will return the count of plaintext bytes
+    /// yet to be read from "current record".
+    ///
+    /// In case 3, additional bytes (another record, complete or incomplete) were
+    /// also been read off the wire. In  this case [`Connection::peek_buffered_len`]
+    /// will return the length of ciphertext bytes buffered in "additional". This is
+    /// the only case in which `peek_buffered_len` will return a non-zero result.
+    ///
+    /// Corresponds to [`s2n_peek_buffered`].
+    pub fn peek_buffered_len(&self) -> usize {
+        unsafe { s2n_peek_buffered(self.connection.as_ptr()) as usize }
+    }
+
     /// Attempts a graceful shutdown of the TLS connection.
     ///
     /// The shutdown is not complete until the necessary shutdown messages

--- a/bindings/rust/extended/s2n-tls/src/connection.rs
+++ b/bindings/rust/extended/s2n-tls/src/connection.rs
@@ -745,35 +745,6 @@ impl Connection {
     ///
     /// </div>
     ///
-    /// The API will return 0 in the "standard" IO mode, and is only useful when
-    /// [Connection::set_receive_buffering] is enabled.
-    ///
-    /// When receive buffering is enabled, it is useful to imagine that an s2n-tls
-    /// connection behaves as if it has two buffers, one for the "current record",
-    /// and one for additional data.
-    /// ```text
-    /// c -> ciphertext
-    /// p -> plaintext
-    ///
-    ///          |-----current record-----|-------additional------------|
-    /// case 1 - |ccccccccccccc
-    /// case 2 - |pppppppppppppppppppppppp|
-    /// case 3 - |pppppppppppppppppppppppp|ccccccccccccccccccc
-    /// ```
-    /// In case 1, we received a record fragment. Records can only be decrypted
-    /// once the full record is available. So current-record just stores the record
-    /// fragment (ciphertext). There are currently no APIs to determine if there
-    /// is a record fragment stored. https://github.com/aws/s2n-tls/issues/5863
-    ///
-    /// In case 2, we received a full record, which is decrypted and stored in current
-    /// record. [`Connection::peek_len`] will return the count of plaintext bytes
-    /// yet to be read from "current record".
-    ///
-    /// In case 3, additional bytes (another record, complete or incomplete) were
-    /// also read off the wire. In this case [`Connection::peek_buffered_len`]
-    /// will return the length of ciphertext bytes buffered in "additional". This is
-    /// the only case in which `peek_buffered_len` will return a non-zero result.
-    ///
     /// Corresponds to [`s2n_peek_buffered`].
     pub fn peek_buffered_len(&self) -> usize {
         unsafe { s2n_peek_buffered(self.connection.as_ptr()) as usize }

--- a/bindings/rust/extended/s2n-tls/src/connection.rs
+++ b/bindings/rust/extended/s2n-tls/src/connection.rs
@@ -770,7 +770,7 @@ impl Connection {
     /// yet to be read from "current record".
     ///
     /// In case 3, additional bytes (another record, complete or incomplete) were
-    /// also been read off the wire. In  this case [`Connection::peek_buffered_len`]
+    /// also read off the wire. In this case [`Connection::peek_buffered_len`]
     /// will return the length of ciphertext bytes buffered in "additional". This is
     /// the only case in which `peek_buffered_len` will return a non-zero result.
     ///

--- a/bindings/rust/standard/integration/src/handshake/serialization.rs
+++ b/bindings/rust/standard/integration/src/handshake/serialization.rs
@@ -111,7 +111,7 @@ fn run_serialization_test(case: &TestCase) -> Result<(), Box<dyn std::error::Err
 }
 
 #[test]
-fn serialization_parameters() {
+fn serialization() {
     for case in TEST_CASES {
         let capabilities = case.required_capabilities();
         required_capability(&capabilities, || {

--- a/bindings/rust/standard/integration/src/handshake/serialization.rs
+++ b/bindings/rust/standard/integration/src/handshake/serialization.rs
@@ -111,7 +111,7 @@ fn run_serialization_test(case: &TestCase) -> Result<(), Box<dyn std::error::Err
 }
 
 #[test]
-fn serialization() {
+fn serialization_parameters() {
     for case in TEST_CASES {
         let capabilities = case.required_capabilities();
         required_capability(&capabilities, || {

--- a/bindings/rust/standard/integration/src/record/io_behaviors.rs
+++ b/bindings/rust/standard/integration/src/record/io_behaviors.rs
@@ -1,9 +1,205 @@
-#[test]
-fn read_behaviors() {
-    // when we successfully read data but the record is incomplete, poll pending 
-    // is returned and peek len returns 0
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
 
-    // when we successfully read data and the record is complete, poll complete
-    // is returned and peek len returns the length of the plaintext data to be
-    // read.
+use s2n_tls::{
+    security::Policy,
+    testing::{self, TestPair},
+};
+use std::task::Poll;
+
+/// The TLS record header is 5 bytes
+const TLS_RECORD_HEADER_LEN: usize = 5;
+
+/// Policy arbitrarily selected to negotiate TLS 1.2. We negotiate TLS 1.2 as a 
+/// convenience to avoid the TLS 1.3 required capability logic.
+const TEST_POLICY: &str = "20240501";
+
+fn new_pair() -> TestPair {
+    let config = testing::build_config(&Policy::from_version(TEST_POLICY).unwrap()).unwrap();
+    let mut pair = TestPair::from_config(&config);
+    pair.handshake().unwrap();
+    pair
+}
+
+fn new_buffered_recv_pair() -> TestPair {
+    let config = testing::build_config(&Policy::from_version(TEST_POLICY).unwrap()).unwrap();
+    let mut pair = TestPair::from_config(&config);
+    pair.server.set_receive_buffering(true).unwrap();
+    pair.handshake().unwrap();
+    pair
+}
+
+#[test]
+fn read_behaviors_with_standard_io() {
+    // read incomplete header
+    {
+        let mut pair = new_pair();
+        assert!(pair.client.poll_send(&[1; 100]).is_ready());
+
+        // Leave only 2 bytes available (incomplete 5-byte header)
+        pair.io.client_tx_stream.borrow_mut().truncate(2);
+
+        let result = pair.server.poll_recv(&mut [0; 100]);
+        assert!(pair.io.client_tx_stream.borrow().is_empty());
+        assert!(matches!(result, Poll::Pending));
+        assert_eq!(pair.server.peek_len(), 0);
+        assert_eq!(pair.server.peek_buffered_len(), 0);
+    }
+
+    // read incomplete record
+    {
+        let mut pair = new_pair();
+        assert!(pair.client.poll_send(&[2; 100]).is_ready());
+
+        // Leave header + 1 byte of body (incomplete record)
+        pair.io
+            .client_tx_stream
+            .borrow_mut()
+            .truncate(TLS_RECORD_HEADER_LEN + 1);
+
+        let result = pair.server.poll_recv(&mut [0; 100]);
+        assert!(matches!(result, Poll::Pending));
+        assert_eq!(pair.server.peek_len(), 0);
+        assert_eq!(pair.server.peek_buffered_len(), 0);
+    }
+
+    // read complete record
+    {
+        let mut pair = new_pair();
+        assert!(pair.client.poll_send(&[1; 100]).is_ready());
+
+        let mut buf = [0u8; 200];
+        let result = pair.server.poll_recv(&mut buf);
+        assert!(matches!(result, Poll::Ready(Ok(100))));
+        assert_eq!(&buf[..100], &[1; 100]);
+        assert_eq!(pair.server.peek_len(), 0);
+        assert_eq!(pair.server.peek_buffered_len(), 0);
+    }
+
+    // read complete record off wire, application buffer too small for full record
+    {
+        let mut pair = new_pair();
+        assert!(pair.client.poll_send(&[1; 100]).is_ready());
+
+        // Read with a buffer smaller than the record payload
+        let mut buf = [0u8; 10];
+        let result = pair.server.poll_recv(&mut buf);
+        assert!(matches!(result, Poll::Ready(Ok(10))));
+        assert_eq!(&buf, &[1; 10]);
+        // Remaining decrypted data is available via peek
+        assert_eq!(pair.server.peek_len(), 90);
+        assert_eq!(pair.server.peek_buffered_len(), 0);
+    }
+
+    // read complete record off wire, pending record in wire buffer, application
+    // buffer large enough for more data
+    {
+        let mut pair = new_pair();
+        // Send two separate records
+        assert!(pair.client.poll_send(&[1; 100]).is_ready());
+        assert!(pair.client.poll_send(&[2; 100]).is_ready());
+
+        // Application buffer is large enough for both records, but only one record
+        // is read. The other remains on the wire.
+        let mut buf = [0u8; 200];
+        let result = pair.server.poll_recv(&mut buf);
+        assert!(matches!(result, Poll::Ready(Ok(100))));
+        assert_eq!(&buf[..100], &[1; 100]);
+        // 129 -> 100 byte record + header/auth overhead
+        assert_eq!(pair.io.client_tx_stream.borrow().len(), 129);
+        assert_eq!(pair.server.peek_len(), 0);
+        assert_eq!(pair.server.peek_buffered_len(), 0);
+
+        // A second poll_recv is needed to read the next record
+        let result = pair.server.poll_recv(&mut buf);
+        assert!(matches!(result, Poll::Ready(Ok(100))));
+        assert_eq!(&buf[..100], &[2; 100]);
+        assert_eq!(pair.server.peek_len(), 0);
+        assert_eq!(pair.server.peek_buffered_len(), 0);
+    }
+}
+
+#[test]
+fn read_behaviors_with_buffered_io() {
+    // read incomplete header
+    {
+        let mut pair = new_buffered_recv_pair();
+        assert!(pair.client.poll_send(&[1; 100]).is_ready());
+
+        // Leave only 2 bytes available (incomplete 5-byte header)
+        let stream = &pair.io.client_tx_stream;
+        stream.borrow_mut().truncate(2);
+
+        let result = pair.server.poll_recv(&mut [0; 100]);
+        assert!(matches!(result, Poll::Pending));
+        assert_eq!(pair.server.peek_len(), 0);
+        assert_eq!(pair.server.peek_buffered_len(), 0);
+    }
+
+    // read incomplete record
+    {
+        let mut pair = new_buffered_recv_pair();
+        assert!(pair.client.poll_send(&[1; 100]).is_ready());
+
+        // Leave header + 1 byte of body (incomplete record)
+        let stream = &pair.io.client_tx_stream;
+        stream.borrow_mut().truncate(TLS_RECORD_HEADER_LEN + 1);
+
+        let result = pair.server.poll_recv(&mut [0; 100]);
+        assert!(matches!(result, Poll::Pending));
+        assert_eq!(pair.server.peek_len(), 0);
+        assert_eq!(pair.server.peek_buffered_len(), 0);
+    }
+
+    // read complete record
+    {
+        let mut pair = new_buffered_recv_pair();
+        assert!(pair.client.poll_send(&[1; 100]).is_ready());
+
+        let mut buf = [0u8; 200];
+        let result = pair.server.poll_recv(&mut buf);
+        assert!(matches!(result, Poll::Ready(Ok(100))));
+        assert_eq!(&buf[..100], &[1; 100]);
+        assert_eq!(pair.server.peek_len(), 0);
+        assert_eq!(pair.server.peek_buffered_len(), 0);
+    }
+
+    // read complete record off wire, application buffer too small for full record
+    {
+        let mut pair = new_buffered_recv_pair();
+        assert!(pair.client.poll_send(&[1; 100]).is_ready());
+
+        // Read with a buffer smaller than the record payload
+        let mut buf = [0u8; 10];
+        let result = pair.server.poll_recv(&mut buf);
+        assert!(matches!(result, Poll::Ready(Ok(10))));
+        assert_eq!(&buf, &[1; 10]);
+        // Remaining decrypted data is available via peek
+        assert_eq!(pair.server.peek_len(), 90);
+        assert_eq!(pair.server.peek_buffered_len(), 0);
+    }
+
+    // read complete record off wire, pending record in wire buffer, application
+    // buffer large enough for more data
+    {
+        let mut pair = new_buffered_recv_pair();
+        // Send two separate records
+        assert!(pair.client.poll_send(&[1; 100]).is_ready());
+        assert!(pair.client.poll_send(&[2; 100]).is_ready());
+
+        let mut buf = [0u8; 200];
+        let result = pair.server.poll_recv(&mut buf);
+        // both records were read off the wire, only one was decrypted
+        assert!(matches!(result, Poll::Ready(Ok(100))));
+        assert_eq!(&buf[..100], &[1; 100]);
+        assert_eq!(pair.server.peek_len(), 0);
+        // the second record is internally buffered, but not decrypted
+        assert_eq!(pair.server.peek_buffered_len(), 129);
+
+        let result = pair.server.poll_recv(&mut buf);
+        assert!(matches!(result, Poll::Ready(Ok(100))));
+        assert_eq!(&buf[..100], &[2; 100]);
+        assert_eq!(pair.server.peek_len(), 0);
+        assert_eq!(pair.server.peek_buffered_len(), 0);
+    }
 }

--- a/bindings/rust/standard/integration/src/record/io_behaviors.rs
+++ b/bindings/rust/standard/integration/src/record/io_behaviors.rs
@@ -1,0 +1,9 @@
+#[test]
+fn read_behaviors() {
+    // when we successfully read data but the record is incomplete, poll pending 
+    // is returned and peek len returns 0
+
+    // when we successfully read data and the record is complete, poll complete
+    // is returned and peek len returns the length of the plaintext data to be
+    // read.
+}

--- a/bindings/rust/standard/integration/src/record/io_behaviors.rs
+++ b/bindings/rust/standard/integration/src/record/io_behaviors.rs
@@ -10,7 +10,7 @@ use std::task::Poll;
 /// The TLS record header is 5 bytes
 const TLS_RECORD_HEADER_LEN: usize = 5;
 
-/// Policy arbitrarily selected to negotiate TLS 1.2. We negotiate TLS 1.2 as a 
+/// Policy arbitrarily selected to negotiate TLS 1.2. We negotiate TLS 1.2 as a
 /// convenience to avoid the TLS 1.3 required capability logic.
 const TEST_POLICY: &str = "20240501";
 

--- a/bindings/rust/standard/integration/src/record/io_behaviors.rs
+++ b/bindings/rust/standard/integration/src/record/io_behaviors.rs
@@ -7,12 +7,15 @@ use s2n_tls::{
 };
 use std::task::Poll;
 
-/// The TLS record header is 5 bytes
-const TLS_RECORD_HEADER_LEN: usize = 5;
-
 /// Policy arbitrarily selected to negotiate TLS 1.2. We negotiate TLS 1.2 as a
 /// convenience to avoid the TLS 1.3 required capability logic.
 const TEST_POLICY: &str = "20240501";
+
+/// An arbitrarily chosen record payload, far less than the max record payload
+const PAYLOAD: &[u8; PAYLOAD_SIZE] = &[1; PAYLOAD_SIZE];
+const PAYLOAD_SIZE: usize = 256;
+/// The final size of a TLS 1.2 record containing [`PAYLOAD_SIZE`]
+const ENCAPSULATED_SIZE: usize = 285;
 
 fn new_pair() -> TestPair {
     let config = testing::build_config(&Policy::from_version(TEST_POLICY).unwrap()).unwrap();
@@ -29,177 +32,192 @@ fn new_buffered_recv_pair() -> TestPair {
     pair
 }
 
-#[test]
-fn read_behaviors_with_standard_io() {
-    // read incomplete header
-    {
+struct IOScenario {
+    /// used to setup the scenario, e.g. "load" records or fragments onto the wire
+    pair_setup: fn(&mut TestPair),
+    /// called with a server that does not have receive buffering enabled
+    default_io_assertions: fn(&mut TestPair),
+    /// called with a server that has receive buffering enabled
+    buffered_io_assertions: fn(&mut TestPair),
+}
+
+impl IOScenario {
+    fn execute(self) {
+        println!("checking standard IO");
         let mut pair = new_pair();
-        assert!(pair.client.poll_send(&[1; 100]).is_ready());
+        (self.pair_setup)(&mut pair);
+        (self.default_io_assertions)(&mut pair);
 
-        // Leave only 2 bytes available (incomplete 5-byte header)
-        pair.io.client_tx_stream.borrow_mut().truncate(2);
-
-        let result = pair.server.poll_recv(&mut [0; 100]);
-        assert!(pair.io.client_tx_stream.borrow().is_empty());
-        assert!(matches!(result, Poll::Pending));
-        assert_eq!(pair.server.peek_len(), 0);
-        assert_eq!(pair.server.peek_buffered_len(), 0);
+        println!("checking buffered recv IO");
+        let mut pair = new_buffered_recv_pair();
+        (self.pair_setup)(&mut pair);
+        (self.buffered_io_assertions)(&mut pair);
     }
 
-    // read incomplete record
-    {
-        let mut pair = new_pair();
-        assert!(pair.client.poll_send(&[2; 100]).is_ready());
-
-        // Leave header + 1 byte of body (incomplete record)
-        pair.io
-            .client_tx_stream
-            .borrow_mut()
-            .truncate(TLS_RECORD_HEADER_LEN + 1);
-
-        let result = pair.server.poll_recv(&mut [0; 100]);
-        assert!(matches!(result, Poll::Pending));
-        assert_eq!(pair.server.peek_len(), 0);
-        assert_eq!(pair.server.peek_buffered_len(), 0);
-    }
-
-    // read complete record
-    {
-        let mut pair = new_pair();
-        assert!(pair.client.poll_send(&[1; 100]).is_ready());
-
-        let mut buf = [0u8; 200];
-        let result = pair.server.poll_recv(&mut buf);
-        assert!(matches!(result, Poll::Ready(Ok(100))));
-        assert_eq!(&buf[..100], &[1; 100]);
-        assert_eq!(pair.server.peek_len(), 0);
-        assert_eq!(pair.server.peek_buffered_len(), 0);
-    }
-
-    // read complete record off wire, application buffer too small for full record
-    {
-        let mut pair = new_pair();
-        assert!(pair.client.poll_send(&[1; 100]).is_ready());
-
-        // Read with a buffer smaller than the record payload
-        let mut buf = [0u8; 10];
-        let result = pair.server.poll_recv(&mut buf);
-        assert!(matches!(result, Poll::Ready(Ok(10))));
-        assert_eq!(&buf, &[1; 10]);
-        // Remaining decrypted data is available via peek
-        assert_eq!(pair.server.peek_len(), 90);
-        assert_eq!(pair.server.peek_buffered_len(), 0);
-    }
-
-    // read complete record off wire, pending record in wire buffer, application
-    // buffer large enough for more data
-    {
-        let mut pair = new_pair();
-        // Send two separate records
-        assert!(pair.client.poll_send(&[1; 100]).is_ready());
-        assert!(pair.client.poll_send(&[2; 100]).is_ready());
-
-        // Application buffer is large enough for both records, but only one record
-        // is read. The other remains on the wire.
-        let mut buf = [0u8; 200];
-        let result = pair.server.poll_recv(&mut buf);
-        assert!(matches!(result, Poll::Ready(Ok(100))));
-        assert_eq!(&buf[..100], &[1; 100]);
-        // 129 -> 100 byte record + header/auth overhead
-        assert_eq!(pair.io.client_tx_stream.borrow().len(), 129);
-        assert_eq!(pair.server.peek_len(), 0);
-        assert_eq!(pair.server.peek_buffered_len(), 0);
-
-        // A second poll_recv is needed to read the next record
-        let result = pair.server.poll_recv(&mut buf);
-        assert!(matches!(result, Poll::Ready(Ok(100))));
-        assert_eq!(&buf[..100], &[2; 100]);
-        assert_eq!(pair.server.peek_len(), 0);
-        assert_eq!(pair.server.peek_buffered_len(), 0);
+    /// use this to construct an IO scenario where the buffered and default cases
+    /// should have the same behavior.
+    fn same_behavior(pair_setup: fn(&mut TestPair), io_assertions: fn(&mut TestPair)) -> Self {
+        Self {
+            pair_setup,
+            default_io_assertions: io_assertions,
+            buffered_io_assertions: io_assertions,
+        }
     }
 }
 
+/// s2n-tls has a separate buffer for record headers, so we test the behavior as
+/// a different mode than a plain "incomplete record"
 #[test]
-fn read_behaviors_with_buffered_io() {
-    // read incomplete header
-    {
-        let mut pair = new_buffered_recv_pair();
-        assert!(pair.client.poll_send(&[1; 100]).is_ready());
+fn read_incomplete_header() {
+    let io = IOScenario::same_behavior(
+        |pair| {
+            assert!(pair.client.poll_send(PAYLOAD).is_ready());
 
-        // Leave only 2 bytes available (incomplete 5-byte header)
-        let stream = &pair.io.client_tx_stream;
-        stream.borrow_mut().truncate(2);
+            // Leave only 2 bytes available (incomplete 5-byte header)
+            let stream = &pair.io.client_tx_stream;
+            stream.borrow_mut().truncate(2);
+        },
+        |pair| {
+            let result = pair.server.poll_recv(&mut [0; PAYLOAD_SIZE]);
+            assert!(matches!(result, Poll::Pending));
+            assert_eq!(pair.server.peek_len(), 0);
+            assert_eq!(pair.server.peek_buffered_len(), 0);
+        },
+    );
+    io.execute();
+}
 
-        let result = pair.server.poll_recv(&mut [0; 100]);
-        assert!(matches!(result, Poll::Pending));
-        assert_eq!(pair.server.peek_len(), 0);
-        assert_eq!(pair.server.peek_buffered_len(), 0);
-    }
+#[test]
+fn read_incomplete_record() {
+    let io = IOScenario::same_behavior(
+        |pair| {
+            assert!(pair.client.poll_send(PAYLOAD).is_ready());
 
-    // read incomplete record
-    {
-        let mut pair = new_buffered_recv_pair();
-        assert!(pair.client.poll_send(&[1; 100]).is_ready());
+            // remove the last byte (incomplete record)
+            pair.io.client_tx_stream.borrow_mut().pop_back().unwrap();
+        },
+        |pair| {
+            let result = pair.server.poll_recv(&mut [0; PAYLOAD_SIZE]);
+            assert!(matches!(result, Poll::Pending));
+            assert_eq!(pair.server.peek_len(), 0);
+            assert_eq!(pair.server.peek_buffered_len(), 0);
+        },
+    );
+    io.execute();
+}
 
-        // Leave header + 1 byte of body (incomplete record)
-        let stream = &pair.io.client_tx_stream;
-        stream.borrow_mut().truncate(TLS_RECORD_HEADER_LEN + 1);
+#[test]
+fn read_complete_record() {
+    let io = IOScenario::same_behavior(
+        |pair| {
+            assert!(pair.client.poll_send(PAYLOAD).is_ready());
+        },
+        |pair| {
+            let mut buf = [0u8; PAYLOAD_SIZE];
+            let result = pair.server.poll_recv(&mut buf);
+            assert!(matches!(result, Poll::Ready(Ok(PAYLOAD_SIZE))));
+            assert_eq!(&buf[..PAYLOAD_SIZE], PAYLOAD);
+            assert_eq!(pair.server.peek_len(), 0);
+            assert_eq!(pair.server.peek_buffered_len(), 0);
+        },
+    );
+    io.execute();
+}
 
-        let result = pair.server.poll_recv(&mut [0; 100]);
-        assert!(matches!(result, Poll::Pending));
-        assert_eq!(pair.server.peek_len(), 0);
-        assert_eq!(pair.server.peek_buffered_len(), 0);
-    }
+/// When a small application buffer is used, poll_recv will return the size of
+/// the buffer, and peek_len will return the remaining data to be read.
+#[test]
+fn read_complete_record_with_small_application_buffer() {
+    /// one quarter of the size of the payload
+    const SMALL_BUFFER_SIZE: usize = PAYLOAD_SIZE.div_ceil(4);
 
-    // read complete record
-    {
-        let mut pair = new_buffered_recv_pair();
-        assert!(pair.client.poll_send(&[1; 100]).is_ready());
+    let io = IOScenario::same_behavior(
+        |pair| {
+            assert!(pair.client.poll_send(PAYLOAD).is_ready());
+        },
+        |pair| {
+            let mut buf = [0u8; SMALL_BUFFER_SIZE];
+            let result = pair.server.poll_recv(&mut buf);
+            assert!(matches!(result, Poll::Ready(Ok(SMALL_BUFFER_SIZE))));
+            assert_eq!(pair.server.peek_len(), PAYLOAD_SIZE - SMALL_BUFFER_SIZE);
+            assert_eq!(pair.server.peek_buffered_len(), 0);
+        },
+    );
+    io.execute();
+}
 
-        let mut buf = [0u8; 200];
-        let result = pair.server.poll_recv(&mut buf);
-        assert!(matches!(result, Poll::Ready(Ok(100))));
-        assert_eq!(&buf[..100], &[1; 100]);
-        assert_eq!(pair.server.peek_len(), 0);
-        assert_eq!(pair.server.peek_buffered_len(), 0);
-    }
+/// When there are multiple records available on the wire, IO depends on the configured
+/// IO behavior.
+///
+/// In all cases, poll_recv will only ever decapsulate one record at a time. However
+/// if recv_buffering is enabled than all of the bytes will be read off the wire
+#[test]
+fn read_two_complete_records() {
+    let io = IOScenario {
+        pair_setup: |pair| {
+            assert!(pair.client.poll_send(PAYLOAD).is_ready());
+            assert!(pair.client.poll_send(PAYLOAD).is_ready());
+        },
+        default_io_assertions: |pair| {
+            let mut buf = [0u8; PAYLOAD_SIZE * 2];
+            let result = pair.server.poll_recv(&mut buf);
+            assert!(matches!(result, Poll::Ready(Ok(PAYLOAD_SIZE))));
+            assert_eq!(pair.server.peek_len(), 0);
+            assert_eq!(pair.server.peek_buffered_len(), 0);
+            // the second record is still on the wire
+            assert_eq!(pair.io.client_tx_stream.borrow().len(), ENCAPSULATED_SIZE);
+        },
+        buffered_io_assertions: |pair| {
+            let mut buf = [0u8; PAYLOAD_SIZE * 2];
+            let result = pair.server.poll_recv(&mut buf);
+            assert!(matches!(result, Poll::Ready(Ok(PAYLOAD_SIZE))));
+            assert_eq!(pair.server.peek_len(), 0);
+            // the second record is in the connection buffer
+            assert_eq!(pair.server.peek_buffered_len(), ENCAPSULATED_SIZE);
+            assert!(pair.io.client_tx_stream.borrow().is_empty());
+        },
+    };
+    io.execute();
+}
 
-    // read complete record off wire, application buffer too small for full record
-    {
-        let mut pair = new_buffered_recv_pair();
-        assert!(pair.client.poll_send(&[1; 100]).is_ready());
+/// This test demonstrates an unfortunate behavior of `peek_buffered`, where data
+/// appears to disappear if it's a record fragment.
+#[test]
+fn read_complete_record_and_fragment() {
+    let io = IOScenario {
+        pair_setup: |pair| {
+            assert!(pair.client.poll_send(PAYLOAD).is_ready());
+            assert!(pair.client.poll_send(PAYLOAD).is_ready());
+            // drop the last byte, so the second record is a fragment
+            pair.io.client_tx_stream.borrow_mut().pop_back().unwrap();
+        },
+        default_io_assertions: |pair| {
+            let mut buf = [0u8; PAYLOAD_SIZE * 2];
+            let result = pair.server.poll_recv(&mut buf);
+            assert!(matches!(result, Poll::Ready(Ok(PAYLOAD_SIZE))));
+            assert_eq!(pair.server.peek_len(), 0);
+            assert_eq!(pair.server.peek_buffered_len(), 0);
+            // the record fragment is on the wire
+            assert_eq!(
+                pair.io.client_tx_stream.borrow().len(),
+                ENCAPSULATED_SIZE - 1
+            );
+        },
+        buffered_io_assertions: |pair| {
+            let mut buf = [0u8; PAYLOAD_SIZE * 2];
+            let result = pair.server.poll_recv(&mut buf);
+            assert!(matches!(result, Poll::Ready(Ok(PAYLOAD_SIZE))));
+            assert_eq!(pair.server.peek_len(), 0);
+            // we report that there is buffered data
+            assert_eq!(pair.server.peek_buffered_len(), ENCAPSULATED_SIZE - 1);
+            assert!(pair.io.client_tx_stream.borrow().is_empty());
 
-        // Read with a buffer smaller than the record payload
-        let mut buf = [0u8; 10];
-        let result = pair.server.poll_recv(&mut buf);
-        assert!(matches!(result, Poll::Ready(Ok(10))));
-        assert_eq!(&buf, &[1; 10]);
-        // Remaining decrypted data is available via peek
-        assert_eq!(pair.server.peek_len(), 90);
-        assert_eq!(pair.server.peek_buffered_len(), 0);
-    }
-
-    // read complete record off wire, pending record in wire buffer, application
-    // buffer large enough for more data
-    {
-        let mut pair = new_buffered_recv_pair();
-        // Send two separate records
-        assert!(pair.client.poll_send(&[1; 100]).is_ready());
-        assert!(pair.client.poll_send(&[2; 100]).is_ready());
-
-        let mut buf = [0u8; 200];
-        let result = pair.server.poll_recv(&mut buf);
-        // both records were read off the wire, only one was decrypted
-        assert!(matches!(result, Poll::Ready(Ok(100))));
-        assert_eq!(&buf[..100], &[1; 100]);
-        assert_eq!(pair.server.peek_len(), 0);
-        // the second record is internally buffered, but not decrypted
-        assert_eq!(pair.server.peek_buffered_len(), 129);
-
-        let result = pair.server.poll_recv(&mut buf);
-        assert!(matches!(result, Poll::Ready(Ok(100))));
-        assert_eq!(&buf[..100], &[2; 100]);
-        assert_eq!(pair.server.peek_len(), 0);
-        assert_eq!(pair.server.peek_buffered_len(), 0);
-    }
+            // but after the next call to poll recv it is effectively hidden because
+            // we don't surface any apis to inspect buffered record fragments
+            assert!(pair.server.poll_recv(&mut [0]).is_pending());
+            assert_eq!(pair.server.peek_len(), 0);
+            assert_eq!(pair.server.peek_buffered_len(), 0);
+        },
+    };
+    io.execute();
 }

--- a/bindings/rust/standard/integration/src/record/mod.rs
+++ b/bindings/rust/standard/integration/src/record/mod.rs
@@ -3,3 +3,4 @@
 mod dynamic_record_sizing;
 mod prefer_low_latency;
 mod record_padding;
+mod serialization;

--- a/bindings/rust/standard/integration/src/record/mod.rs
+++ b/bindings/rust/standard/integration/src/record/mod.rs
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 mod dynamic_record_sizing;
+mod io_behaviors;
 mod prefer_low_latency;
 mod record_padding;
 mod serialization;

--- a/bindings/rust/standard/integration/src/record/serialization.rs
+++ b/bindings/rust/standard/integration/src/record/serialization.rs
@@ -12,13 +12,12 @@ use std::task::Poll;
 /// The TLS record header is 5 bytes: 1 (content type) + 2 (protocol version) + 2 (length)
 const TLS_RECORD_HEADER_LEN: usize = 5;
 
-/// Policy arbitrarily selected to negotiate TLS 1.2. We negotiate TLS 1.2 as a 
+/// Policy arbitrarily selected to negotiate TLS 1.2. We negotiate TLS 1.2 as a
 /// convenience to avoid the TLS 1.3 required capability logic.
 const TEST_POLICY: &str = "20240501";
 
 fn build_serializable_config() -> s2n_tls::config::Config {
-    let mut builder =
-        testing::config_builder(&Policy::from_version(TEST_POLICY).unwrap()).unwrap();
+    let mut builder = testing::config_builder(&Policy::from_version(TEST_POLICY).unwrap()).unwrap();
     builder
         .set_serialization_version(SerializationVersion::V1)
         .unwrap();

--- a/bindings/rust/standard/integration/src/record/serialization.rs
+++ b/bindings/rust/standard/integration/src/record/serialization.rs
@@ -12,9 +12,13 @@ use std::task::Poll;
 /// The TLS record header is 5 bytes: 1 (content type) + 2 (protocol version) + 2 (length)
 const TLS_RECORD_HEADER_LEN: usize = 5;
 
+/// Policy arbitrarily selected to negotiate TLS 1.2. We negotiate TLS 1.2 as a 
+/// convenience to avoid the TLS 1.3 required capability logic.
+const TEST_POLICY: &str = "20240501";
+
 fn build_serializable_config() -> s2n_tls::config::Config {
     let mut builder =
-        testing::config_builder(&Policy::from_version("default_tls13").unwrap()).unwrap();
+        testing::config_builder(&Policy::from_version(TEST_POLICY).unwrap()).unwrap();
     builder
         .set_serialization_version(SerializationVersion::V1)
         .unwrap();
@@ -38,6 +42,9 @@ fn try_serialize(conn: &s2n_tls::connection::Connection) -> Result<(), s2n_tls::
     conn.serialize(&mut buf)
 }
 
+/// This test servers as documentation/confirmation of some sharp edges around
+/// serialization failure. Specifically, there is no detecting whether a record
+/// fragment has been ingested. https://github.com/aws/s2n-tls/issues/5863
 #[test]
 fn serialization_io_edge_cases() {
     let config = build_serializable_config();
@@ -53,13 +60,13 @@ fn serialization_io_edge_cases() {
         assert!(pair.client.poll_send(&[0; 100]).is_ready());
 
         // Truncate the buffer to only 2 bytes (incomplete 5-byte header)
-        let stream = &pair.io.client_tx_stream;
-        let total = stream.borrow().len();
-        assert!(total > TLS_RECORD_HEADER_LEN);
-        stream.borrow_mut().truncate(2);
+        pair.io.client_tx_stream.borrow_mut().truncate(2);
 
         // Server attempts to read but only gets a partial header
-        assert!(matches!(pair.server.poll_recv(&mut [0; 100]), Poll::Pending));
+        assert!(matches!(
+            pair.server.poll_recv(&mut [0; 100]),
+            Poll::Pending
+        ));
         // This is "invisible" data, not yet decrypted
         assert_eq!(pair.server.peek_len(), 0);
 
@@ -76,14 +83,16 @@ fn serialization_io_edge_cases() {
         assert!(pair.client.poll_send(&[0; 100]).is_ready());
 
         // Truncate the buffer to header + 1 byte of body (partial record)
-        let stream = &pair.io.client_tx_stream;
-        let total = stream.borrow().len();
-        let keep = TLS_RECORD_HEADER_LEN + 1;
-        assert!(total > keep);
-        stream.borrow_mut().truncate(keep);
+        pair.io
+            .client_tx_stream
+            .borrow_mut()
+            .truncate(TLS_RECORD_HEADER_LEN + 1);
 
         // Server attempts to read but only gets a partial record
-        assert!(matches!(pair.server.poll_recv(&mut [0; 100]), Poll::Pending));
+        assert!(matches!(
+            pair.server.poll_recv(&mut [0; 100]),
+            Poll::Pending
+        ));
         // This is "invisible" data, not yet decrypted
         assert_eq!(pair.server.peek_len(), 0);
 
@@ -101,14 +110,17 @@ fn serialization_io_edge_cases() {
 
         // Server reads with a 1-byte buffer: decrypts the full record but only
         // returns 1 byte to the application, leaving the rest buffered internally
-        assert!(matches!(pair.server.poll_recv(&mut [0; 1]), Poll::Ready(Ok(1))));
+        assert!(matches!(
+            pair.server.poll_recv(&mut [0; 1]),
+            Poll::Ready(Ok(1))
+        ));
         assert_eq!(pair.server.peek_len(), 99);
 
         // Serialization must fail because conn->in has pending decrypted data
         assert_invalid_state_error(try_serialize(&pair.server).unwrap_err());
 
         // read the rest of the data, serialization then succeeds
-        assert!(pair.server.poll_recv(&mut[0;100]).is_ready());
+        assert!(pair.server.poll_recv(&mut [0; 100]).is_ready());
         assert!(pair.server.serialize(&mut [0; 1_024]).is_ok());
     }
 }

--- a/bindings/rust/standard/integration/src/record/serialization.rs
+++ b/bindings/rust/standard/integration/src/record/serialization.rs
@@ -41,8 +41,8 @@ fn try_serialize(conn: &s2n_tls::connection::Connection) -> Result<(), s2n_tls::
     conn.serialize(&mut buf)
 }
 
-/// This test servers as documentation/confirmation of some sharp edges around
-/// serialization failure. Specifically, there is no detecting whether a record
+/// This test server as documentation/confirmation of some sharp edges around
+/// serialization failure. Specifically, there is no way to detect whether a record
 /// fragment has been ingested. https://github.com/aws/s2n-tls/issues/5863
 #[test]
 fn serialization_io_edge_cases() {

--- a/bindings/rust/standard/integration/src/record/serialization.rs
+++ b/bindings/rust/standard/integration/src/record/serialization.rs
@@ -41,7 +41,7 @@ fn try_serialize(conn: &s2n_tls::connection::Connection) -> Result<(), s2n_tls::
     conn.serialize(&mut buf)
 }
 
-/// This test server as documentation/confirmation of some sharp edges around
+/// This test serves as documentation/confirmation of some sharp edges around
 /// serialization failure. Specifically, there is no way to detect whether a record
 /// fragment has been ingested. https://github.com/aws/s2n-tls/issues/5863
 #[test]

--- a/bindings/rust/standard/integration/src/record/serialization.rs
+++ b/bindings/rust/standard/integration/src/record/serialization.rs
@@ -1,0 +1,114 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use s2n_tls::{
+    enums::SerializationVersion,
+    error::ErrorType,
+    security::Policy,
+    testing::{self, TestPair},
+};
+use std::task::Poll;
+
+/// The TLS record header is 5 bytes: 1 (content type) + 2 (protocol version) + 2 (length)
+const TLS_RECORD_HEADER_LEN: usize = 5;
+
+fn build_serializable_config() -> s2n_tls::config::Config {
+    let mut builder =
+        testing::config_builder(&Policy::from_version("default_tls13").unwrap()).unwrap();
+    builder
+        .set_serialization_version(SerializationVersion::V1)
+        .unwrap();
+    builder.build().unwrap()
+}
+
+fn assert_invalid_state_error(err: s2n_tls::error::Error) {
+    assert_eq!(err.kind(), ErrorType::UsageError);
+    assert_eq!(err.name(), "S2N_ERR_INVALID_STATE");
+    assert_eq!(
+        err.message(),
+        "Invalid state, this is the result of invalid use of an API. \
+         Check the API documentation for the function that raised this error for more info"
+    );
+}
+
+/// Attempt to serialize the connection. Returns the result.
+fn try_serialize(conn: &s2n_tls::connection::Connection) -> Result<(), s2n_tls::error::Error> {
+    let length = conn.serialization_length()?;
+    let mut buf = vec![0u8; length];
+    conn.serialize(&mut buf)
+}
+
+#[test]
+fn serialization_io_edge_cases() {
+    let config = build_serializable_config();
+
+    // case 1: buffer contains incomplete header
+    // s2n-tls has a separate buffer for header so we test this separately from
+    // the "partial record" case.
+    {
+        let mut pair = TestPair::from_config(&config);
+        pair.handshake().unwrap();
+
+        // Client sends data, producing encrypted TLS records in client_tx_stream
+        assert!(pair.client.poll_send(&[0; 100]).is_ready());
+
+        // Truncate the buffer to only 2 bytes (incomplete 5-byte header)
+        let stream = &pair.io.client_tx_stream;
+        let total = stream.borrow().len();
+        assert!(total > TLS_RECORD_HEADER_LEN);
+        stream.borrow_mut().truncate(2);
+
+        // Server attempts to read but only gets a partial header
+        assert!(matches!(pair.server.poll_recv(&mut [0; 100]), Poll::Pending));
+        // This is "invisible" data, not yet decrypted
+        assert_eq!(pair.server.peek_len(), 0);
+
+        // Serialization must fail because header_in has pending data
+        assert_invalid_state_error(try_serialize(&pair.server).unwrap_err());
+    }
+
+    // case 2: buffer contains partial record, waiting for complete record
+    {
+        let mut pair = TestPair::from_config(&config);
+        pair.handshake().unwrap();
+
+        // Client sends data
+        assert!(pair.client.poll_send(&[0; 100]).is_ready());
+
+        // Truncate the buffer to header + 1 byte of body (partial record)
+        let stream = &pair.io.client_tx_stream;
+        let total = stream.borrow().len();
+        let keep = TLS_RECORD_HEADER_LEN + 1;
+        assert!(total > keep);
+        stream.borrow_mut().truncate(keep);
+
+        // Server attempts to read but only gets a partial record
+        assert!(matches!(pair.server.poll_recv(&mut [0; 100]), Poll::Pending));
+        // This is "invisible" data, not yet decrypted
+        assert_eq!(pair.server.peek_len(), 0);
+
+        // Serialization must fail because conn->in has pending partial record data
+        assert_invalid_state_error(try_serialize(&pair.server).unwrap_err());
+    }
+
+    // case 3: buffer contains decrypted record, waiting for application read
+    {
+        let mut pair = TestPair::from_config(&config);
+        pair.handshake().unwrap();
+
+        // Client sends data
+        assert!(pair.client.poll_send(&[0; 100]).is_ready());
+
+        // Server reads with a 1-byte buffer: decrypts the full record but only
+        // returns 1 byte to the application, leaving the rest buffered internally
+        assert!(matches!(pair.server.poll_recv(&mut [0; 1]), Poll::Ready(Ok(1))));
+        assert_eq!(pair.server.peek_len(), 99);
+
+        // Serialization must fail because conn->in has pending decrypted data
+        assert_invalid_state_error(try_serialize(&pair.server).unwrap_err());
+
+        // read the rest of the data, serialization then succeeds
+        assert!(pair.server.poll_recv(&mut[0;100]).is_ready());
+        assert!(pair.server.serialize(&mut [0; 1_024]).is_ok());
+    }
+}


### PR DESCRIPTION
# Goal
Document IO behaviors

## Why
I was helping a customer debug why serialization was failing, and wrote these tests while confirming my own understanding.

Also the documentation kind of made it sound like `s2n_peek_buffered` would solve my problem, but when I wrote some more tests I discovered that wasn't the case either.

## How
Commit the tests, which documents our behavior and ensures that we don't accidentally change things in the future.

## Testing
They are tests 🙂 

### Related
https://github.com/aws/s2n-tls/issues/5863

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
