### PR TITLE
ci: update to CBMC 6.9.0

### DIFF
--- a/.github/workflows/proof_ci.yaml
+++ b/.github/workflows/proof_ci.yaml
@@ -19,7 +19,7 @@ on:
 # .github/workflows/proof_ci_resources/config.yaml
 #
 # If you want the CI to use a different GitHub-hosted runner (which must still
-# be running Ubuntu 20.04), modify the value of this key:
+# be running Ubuntu 24.04), modify the value of this key:
 # jobs.run_cbmc_proofs.runs-on
 
 jobs:
@@ -83,7 +83,7 @@ jobs:
         run: |
           # Search within 5 most recent releases for latest available package
           CBMC_REL="https://api.github.com/repos/diffblue/cbmc/releases?page=1&per_page=5"
-          CBMC_DEB=$(curl -s $CBMC_REL --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' | jq -r '.[]|select(.prerelease|not).assets[].browser_download_url' | grep -e 'ubuntu-20.04' | head -n 1)
+          CBMC_DEB=$(curl -s $CBMC_REL --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' | jq -r '.[]|select(.prerelease|not).assets[].browser_download_url' | grep -e 'ubuntu-24.04-cbmc' | head -n 1)
           CBMC_ARTIFACT_NAME=$(basename $CBMC_DEB)
           curl -o $CBMC_ARTIFACT_NAME -L $CBMC_DEB
           sudo dpkg -i $CBMC_ARTIFACT_NAME
@@ -93,7 +93,7 @@ jobs:
         shell: bash
         run: |
           curl -o cbmc.deb -L \
-            https://github.com/diffblue/cbmc/releases/download/cbmc-${{ env.CBMC_VERSION }}/ubuntu-20.04-cbmc-${{ env.CBMC_VERSION }}-Linux.deb
+            https://github.com/diffblue/cbmc/releases/download/cbmc-${{ env.CBMC_VERSION }}/ubuntu-24.04-cbmc-${{ env.CBMC_VERSION }}-Linux.deb
           sudo dpkg -i ./cbmc.deb
           rm ./cbmc.deb
       - name: Install latest CBMC viewer

--- a/.github/workflows/proof_ci_resources/config.yaml
+++ b/.github/workflows/proof_ci_resources/config.yaml
@@ -1,5 +1,5 @@
 cadical-tag: latest
-cbmc-version: "6.2.0"
+cbmc-version: "6.9.0"
 cbmc-viewer-version: latest
 kissat-tag: "rel-4.0.3"
 litani-version: latest


### PR DESCRIPTION
# Goal

Bump the CBMC version used by the proof CI from 6.2.0 to 6.9.0.

## Why

Keeping CBMC current picks up upstream bug fixes, performance improvements, and solver updates, and keeps the proof CI aligned with what the wider CBMC/model-checking ecosystem is testing against.

## How

- Bump `cbmc-version` in `.github/workflows/proof_ci_resources/config.yaml` from `6.2.0` to `6.9.0`.
- Update the CBMC install steps in `.github/workflows/proof_ci.yaml` to pull the `ubuntu-24.04-cbmc-<version>-Linux.deb` package. CBMC 6.9.0 no longer ships an `ubuntu-20.04` .deb (the set is now `ubuntu-22.04`, `ubuntu-24.04`, and `ubuntu-24.04-arm64`), and the self-hosted runner behind `cbmc_ubuntu-latest_64-core` is running Ubuntu 24.04.4, so the 24.04 .deb is the right match.
- Tighten the `latest` branch's `grep` from `ubuntu-20.04` to `ubuntu-24.04-cbmc` so it doesn't accidentally match the new `ubuntu-24.04-arm64` artifact on an x86_64 runner.
- Update the header comment in `proof_ci.yaml` to reflect the 24.04 expectation.

## Callouts

- The self-hosted runner OS was verified as Ubuntu 24.04.4 before choosing the 24.04 .deb variant. If the runner image ever moves off 24.04, the install steps will need to change with it.
- CBMC releases for 6.9.0 still provide a `ubuntu-22.04` package as well, so rolling back to a 22.04 runner is still an option if needed.

## Testing

Proof CI on this PR will exercise the new version end-to-end — the `dpkg -i` step will fail fast if the package is incompatible with the runner, and the proofs themselves will surface any solver/behavior regressions from the version bump.

### Related

resolves #5849

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
