### PR TITLE
ci: fix OpenSSL 1.0.2u download in Rust bindings CI

### DIFF
--- a/.github/workflows/ci_rust.yml
+++ b/.github/workflows/ci_rust.yml
@@ -216,7 +216,11 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ~/openssl-102/install
-          key: ${{ runner.os }}-openssl-102
+          # The sha256 suffix pins the cache to a specific source tarball.
+          # Bumping the tarball (or version) busts the cache automatically,
+          # which also prevents a stale cache entry from masking a broken
+          # download step.
+          key: ${{ runner.os }}-openssl-1.0.2u-ecd0c6ff
 
       - if: ${{ steps.cache-openssl.outputs.cache-hit != 'true' }}
         name: Install OpenSSL 1.0.2
@@ -227,7 +231,16 @@ jobs:
           mkdir install
           install_dir="$(pwd)"/install
 
-          wget https://www.openssl.org/source/old/1.0.2/openssl-1.0.2u.tar.gz
+          # OpenSSL moved release hosting to GitHub in 2024. The openssl.org
+          # redirect for the 1.0.2 series points at a non-existent asset
+          # (openssl/openssl under the tag `openssl-1.0.2u`), so fetch directly
+          # from the tag that actually exists (`OpenSSL_1_0_2u`).
+          tarball_url="https://github.com/openssl/openssl/releases/download/OpenSSL_1_0_2u/openssl-1.0.2u.tar.gz"
+          expected_sha256="ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16"
+
+          curl --fail --location --silent --show-error \
+               --output openssl-1.0.2u.tar.gz "${tarball_url}"
+          echo "${expected_sha256}  openssl-1.0.2u.tar.gz" | sha256sum --check --strict
           tar -xzvf openssl-1.0.2u.tar.gz
 
           pushd openssl-1.0.2u


### PR DESCRIPTION
# Goal

Fix the `generate-openssl-102` job in `ci_rust.yml`, which currently fails to fetch OpenSSL 1.0.2u whenever the cache does not restore.

## Why

Two latent problems combined to break CI on PRs where the OpenSSL cache does not restore cleanly.

1. **Broken download URL.** In April 2024, OpenSSL [announced](https://www.openssl.org/blog/blog/2024/04/30/releases-distribution-changes/) they were moving release hosting to GitHub. At some point between mid-2024 and late 2025 the redirect for `www.openssl.org/source/old/1.0.2/openssl-1.0.2u.tar.gz` went live, pointing at `github.com/openssl/openssl/releases/download/openssl-1.0.2u/openssl-1.0.2u.tar.gz`. That target has never existed — the actual GitHub tag for the release is `OpenSSL_1_0_2u` (underscores), not `openssl-1.0.2u` (dashes). So `wget`ing the openssl.org URL today gets a 301 → 404.

2. **Masked by the cache.** The existing cache key `${{ runner.os }}-openssl-102` has no version/URL component. Once the install had succeeded once (the current `Linux-openssl-102` entry was created 2025-04-02), every subsequent CI run restored `~/openssl-102/install` and the install step's `if: cache-hit != 'true'` guard skipped the broken `wget`. The cache entry has been kept alive by regular access ever since — GitHub's [documented policy](https://docs.github.com/en/enterprise-cloud@latest/actions/reference/workflows-and-actions/dependency-caching#default-limits) evicts entries that haven't been accessed in 7 days, so a workflow that runs frequently can extend a cache entry's life indefinitely.

Recently, the failing CBMC-PR run (#5867) showed this log sequence for the cache step:

Cache hit for: Linux-openssl-102 ##[warning]Failed to restore: Cache not found for input keys: Linux-openssl-102


The metadata lookup succeeds but the archive restore fails, which leaves `cache-hit != 'true'` and runs the install step — exposing the broken URL. The same symptom pattern is being reported upstream in [actions/cache#1735](https://github.com/actions/cache/issues/1735) (open, unresolved, with reports as recent as May 5, 2026). I don't have a confirmed root cause, but the symptom match is close and the upstream issue is worth linking as related.

## How

- Switch the download to the GitHub releases asset that actually exists: `https://github.com/openssl/openssl/releases/download/OpenSSL_1_0_2u/openssl-1.0.2u.tar.gz`. The tarball is byte-identical to the historical openssl.org one (sha256 `ecd0c6ff...669d16` matches the published checksum).
- Use `curl --fail` and verify the sha256 after download, so a silent tarball substitution or a future URL migration fails loudly instead of getting cached.
- Rename the cache key to `${{ runner.os }}-openssl-1.0.2u-ecd0c6ff`. This (a) invalidates the existing stale cache entry so the fix takes effect on existing runners, and (b) pins the cache to a specific source tarball so any future version/URL change busts the cache rather than masking another broken install step.

## Callouts

- The new cache key forces one rebuild on every runner — a one-time cost (~4 MB installed size, a few minutes to build OpenSSL 1.0.2).
- Switched `wget` to `curl --fail` partly for consistency with other install steps and partly because `curl --fail` reliably turns HTTP error responses into a non-zero exit.

## Testing

Will be verified by the `generate-openssl-102` job on this PR itself:

- On first run, cache-miss path executes the new `curl` + sha256 verify + `make install`, then saves under the new key.
- On subsequent runs, the new cache key restores cleanly and the install step is skipped.

### Related

- [actions/cache#1735](https://github.com/actions/cache/issues/1735) — same cache-restore symptom reported elsewhere. Relation is symptomatic, not confirmed causal.
- Symptom first observed in [run 25511293833](https://github.com/aws/s2n-tls/actions/runs/25511293833/job/74874076252) on the #5867 branch.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.