### PR TITLE
feat(metrics-subscriber): Public access to types for deserialization

### DIFF
--- a/bindings/rust/standard/s2n-tls-metrics-subscriber/Cargo.toml
+++ b/bindings/rust/standard/s2n-tls-metrics-subscriber/Cargo.toml
@@ -30,4 +30,4 @@ fuzzing = []
 [dev-dependencies]
 s2n-tls-sys-internal = { path = "../s2n-tls-sys-internal" }
 serde_json = "1.0.141"
-serde_cbor = "0.11"
+ciborium = "0.2"

--- a/bindings/rust/standard/s2n-tls-metrics-subscriber/Cargo.toml
+++ b/bindings/rust/standard/s2n-tls-metrics-subscriber/Cargo.toml
@@ -30,3 +30,4 @@ fuzzing = []
 [dev-dependencies]
 s2n-tls-sys-internal = { path = "../s2n-tls-sys-internal" }
 serde_json = "1.0.141"
+serde_cbor = "0.11"

--- a/bindings/rust/standard/s2n-tls-metrics-subscriber/src/counter.rs
+++ b/bindings/rust/standard/s2n-tls-metrics-subscriber/src/counter.rs
@@ -95,6 +95,14 @@ impl<const N: usize, T: FiniteCounter<N>> std::fmt::Debug for FrozenCounter<N, T
 }
 
 impl<const N: usize, T: FiniteCounter<N>> FrozenCounter<N, T> {
+    /// Creates a `FrozenCounter` from raw slot values.
+    pub fn from_slots(slots: [u64; N]) -> Self {
+        Self {
+            slots,
+            element: PhantomData,
+        }
+    }
+
     /// The underlying slot array in element order.
     pub fn slots(&self) -> &[u64; N] {
         &self.slots

--- a/bindings/rust/standard/s2n-tls-metrics-subscriber/src/counter.rs
+++ b/bindings/rust/standard/s2n-tls-metrics-subscriber/src/counter.rs
@@ -73,7 +73,7 @@ impl<const N: usize, T: FiniteCounter<N>> std::fmt::Debug for Counter<N, T> {
 
 /// Exportable, immutable snapshot of a [`Counter<N, T>`].
 #[derive(Clone, PartialEq)]
-pub(crate) struct FrozenCounter<const N: usize, T: FiniteCounter<N>> {
+pub struct FrozenCounter<const N: usize, T: FiniteCounter<N>> {
     pub(super) slots: [u64; N],
     pub(super) element: PhantomData<T>,
 }
@@ -95,8 +95,13 @@ impl<const N: usize, T: FiniteCounter<N>> std::fmt::Debug for FrozenCounter<N, T
 }
 
 impl<const N: usize, T: FiniteCounter<N>> FrozenCounter<N, T> {
+    /// The underlying slot array in element order.
+    pub fn slots(&self) -> &[u64; N] {
+        &self.slots
+    }
+
     /// `(slot, element, count)` triples for non-zero slots, in slot order.
-    pub(crate) fn iter_non_zero(&self) -> impl Iterator<Item = (usize, T, u64)> + '_ {
+    pub fn iter_non_zero(&self) -> impl Iterator<Item = (usize, T, u64)> + '_ {
         self.slots
             .iter()
             .enumerate()

--- a/bindings/rust/standard/s2n-tls-metrics-subscriber/src/lib.rs
+++ b/bindings/rust/standard/s2n-tls-metrics-subscriber/src/lib.rs
@@ -20,8 +20,8 @@ pub use attribution::Attribution;
 pub use counter::FrozenCounter;
 pub use record::{FrozenHandshakeRecord, MetricRecord};
 pub use static_lists::{
-    Cipher, FiniteCounter, Group, Signature, Version, CIPHER_COUNT, GROUP_COUNT, PROTOCOL_COUNT,
-    SIGNATURE_COUNT,
+    CIPHER_COUNT, Cipher, FiniteCounter, GROUP_COUNT, Group, PROTOCOL_COUNT, SIGNATURE_COUNT,
+    Signature, Version,
 };
 pub use subscriber::AggregatedMetricsSubscriber;
 pub use telemetry_sink::TelemetrySink;

--- a/bindings/rust/standard/s2n-tls-metrics-subscriber/src/lib.rs
+++ b/bindings/rust/standard/s2n-tls-metrics-subscriber/src/lib.rs
@@ -3,20 +3,25 @@
 
 pub mod attribution;
 mod compatibility;
-pub(crate) mod counter;
+pub mod counter;
 mod label;
 #[cfg(feature = "fuzzing")]
 pub mod parsing;
 #[cfg(not(feature = "fuzzing"))]
 mod parsing;
 mod record;
-mod static_lists;
+pub mod static_lists;
 pub mod subscriber;
 pub mod telemetry_sink;
 #[cfg(test)]
 mod test_utils;
 
 pub use attribution::Attribution;
-pub use record::MetricRecord;
+pub use counter::FrozenCounter;
+pub use record::{FrozenHandshakeRecord, MetricRecord};
+pub use static_lists::{
+    Cipher, FiniteCounter, Group, Signature, Version, CIPHER_COUNT, GROUP_COUNT, PROTOCOL_COUNT,
+    SIGNATURE_COUNT,
+};
 pub use subscriber::AggregatedMetricsSubscriber;
 pub use telemetry_sink::TelemetrySink;

--- a/bindings/rust/standard/s2n-tls-metrics-subscriber/src/record.rs
+++ b/bindings/rust/standard/s2n-tls-metrics-subscriber/src/record.rs
@@ -28,8 +28,8 @@ use crate::{
 // likely rely on an enum to handle different record types, e.g. SessionResumptionFailure.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct MetricRecord {
-    pub(crate) attribution: Attribution,
-    pub(crate) handshake: FrozenHandshakeRecord,
+    pub attribution: Attribution,
+    pub handshake: FrozenHandshakeRecord,
 }
 
 impl MetricRecord {
@@ -256,46 +256,46 @@ fn system_time_epoch() -> SystemTime {
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-pub(crate) struct FrozenHandshakeRecord {
+pub struct FrozenHandshakeRecord {
     #[serde(default = "system_time_epoch")]
-    freeze_time: SystemTime,
+    pub freeze_time: SystemTime,
 
     #[serde(default)]
-    pub(crate) handshake_count: u64,
+    pub handshake_count: u64,
 
     #[serde(default)]
-    negotiated_protocols: FrozenCounter<PROTOCOL_COUNT, Version>,
+    pub negotiated_protocols: FrozenCounter<PROTOCOL_COUNT, Version>,
     #[serde(default)]
-    negotiated_ciphers: FrozenCounter<CIPHER_COUNT, Cipher>,
+    pub negotiated_ciphers: FrozenCounter<CIPHER_COUNT, Cipher>,
     #[serde(default)]
-    negotiated_groups: FrozenCounter<GROUP_COUNT, Group>,
+    pub negotiated_groups: FrozenCounter<GROUP_COUNT, Group>,
     #[serde(default)]
-    negotiated_signatures: FrozenCounter<SIGNATURE_COUNT, Signature>,
+    pub negotiated_signatures: FrozenCounter<SIGNATURE_COUNT, Signature>,
 
     #[serde(default)]
-    sslv2_client_hello: u64,
+    pub sslv2_client_hello: u64,
     #[serde(default)]
-    supported_protocols: FrozenCounter<PROTOCOL_COUNT, Version>,
+    pub supported_protocols: FrozenCounter<PROTOCOL_COUNT, Version>,
     #[serde(default)]
-    supported_ciphers: FrozenCounter<CIPHER_COUNT, Cipher>,
+    pub supported_ciphers: FrozenCounter<CIPHER_COUNT, Cipher>,
     #[serde(default)]
-    supported_groups: FrozenCounter<GROUP_COUNT, Group>,
+    pub supported_groups: FrozenCounter<GROUP_COUNT, Group>,
     #[serde(default)]
-    supported_signatures: FrozenCounter<SIGNATURE_COUNT, Signature>,
+    pub supported_signatures: FrozenCounter<SIGNATURE_COUNT, Signature>,
 
     #[serde(default)]
-    compatibility_general20251201: u64,
+    pub compatibility_general20251201: u64,
     #[serde(default)]
-    compatibility_fips20251201: u64,
+    pub compatibility_fips20251201: u64,
     #[serde(default)]
-    compatibility_cnsa1: u64,
+    pub compatibility_cnsa1: u64,
     #[serde(default)]
-    compatibility_cnsa2: u64,
+    pub compatibility_cnsa2: u64,
 
     #[serde(default)]
-    handshake_duration_us: u64,
+    pub handshake_duration_us: u64,
     #[serde(default)]
-    handshake_compute_us: u64,
+    pub handshake_compute_us: u64,
 }
 
 // This is just cfg(test) because we only use it in tests to assert on cases of

--- a/bindings/rust/standard/s2n-tls-metrics-subscriber/src/static_lists.rs
+++ b/bindings/rust/standard/s2n-tls-metrics-subscriber/src/static_lists.rs
@@ -21,10 +21,10 @@ pub enum TlsParam {
     SignatureScheme,
 }
 
-pub(crate) const GROUP_COUNT: usize = GROUPS_AVAILABLE_IN_S2N.len();
-pub(crate) const CIPHER_COUNT: usize = CIPHERS_AVAILABLE_IN_S2N.len();
-pub(crate) const SIGNATURE_COUNT: usize = SIGNATURE_SCHEMES_AVAILABLE_IN_S2N.len();
-pub(crate) const PROTOCOL_COUNT: usize = VERSIONS_AVAILABLE_IN_S2N.len();
+pub const GROUP_COUNT: usize = GROUPS_AVAILABLE_IN_S2N.len();
+pub const CIPHER_COUNT: usize = CIPHERS_AVAILABLE_IN_S2N.len();
+pub const SIGNATURE_COUNT: usize = SIGNATURE_SCHEMES_AVAILABLE_IN_S2N.len();
+pub const PROTOCOL_COUNT: usize = VERSIONS_AVAILABLE_IN_S2N.len();
 
 use s2n_codec::{DecoderValue, zerocopy::U16};
 #[cfg(test)]
@@ -84,7 +84,7 @@ impl<'de> DeserializeAs<'de, U16> for ZerocopyU16 {
 /// abstraction to use. The trait only constrains the slot bijection;
 /// separate concerns (`Display`, serde, `FromStr`) are required at the
 /// impl sites that use them.
-pub(crate) trait FiniteCounter<const N: usize>: Copy + PartialEq {
+pub trait FiniteCounter<const N: usize>: Copy + PartialEq {
     /// All values of `Self` that the counter recognizes. Every element is
     /// assigned a stable slot index equal to its position in this array.
     const ELEMENTS: [Self; N];
@@ -219,7 +219,7 @@ unsafe fn static_memory_to_str(value: *const c_char) -> &'static str {
     serde::Deserialize,
 )]
 #[repr(C)]
-pub(crate) struct Version(#[serde_as(as = "ZerocopyU16")] pub(crate) s2n_codec::zerocopy::U16);
+pub struct Version(#[serde_as(as = "ZerocopyU16")] pub s2n_codec::zerocopy::U16);
 
 impl Version {
     pub const SSL_V3: Version = Version(U16::new(0x0300));
@@ -270,7 +270,7 @@ impl<'a> DecoderValue<'a> for Version {
     serde::Deserialize,
 )]
 #[repr(C)]
-pub(crate) struct Cipher(pub(crate) [u8; 2]);
+pub struct Cipher(pub [u8; 2]);
 
 impl Cipher {
     #[allow(dead_code)] // kept as part of the typed cipher roster
@@ -332,7 +332,7 @@ impl Display for Cipher {
     serde::Deserialize,
 )]
 #[repr(C)]
-pub(crate) struct Signature(#[serde_as(as = "ZerocopyU16")] pub(crate) s2n_codec::zerocopy::U16);
+pub struct Signature(#[serde_as(as = "ZerocopyU16")] pub s2n_codec::zerocopy::U16);
 
 // we allow non-upper case globals to let the constants exactly match the IANA description
 #[allow(non_upper_case_globals)]
@@ -387,7 +387,7 @@ impl Display for Signature {
     serde::Deserialize,
 )]
 #[repr(C)]
-pub(crate) struct Group(#[serde_as(as = "ZerocopyU16")] pub(crate) s2n_codec::zerocopy::U16);
+pub struct Group(#[serde_as(as = "ZerocopyU16")] pub s2n_codec::zerocopy::U16);
 
 // we allow non-upper case globals to let the constants exactly match the IANA description
 #[allow(non_upper_case_globals)]

--- a/bindings/rust/standard/s2n-tls-metrics-subscriber/tests/public_api.rs
+++ b/bindings/rust/standard/s2n-tls-metrics-subscriber/tests/public_api.rs
@@ -1,0 +1,272 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Integration tests for the public API surface of s2n-tls-metrics-subscriber.
+//! Exercises deserialization from CBOR streams, public field access,
+//! `FrozenCounter::slots()`, `FiniteCounter::key_from_slot`, and
+//! `FrozenCounter::iter_non_zero`.
+
+use std::time::SystemTime;
+
+use s2n_tls_metrics_subscriber::{
+    Cipher, FiniteCounter, Group, MetricRecord, Signature, Version, CIPHER_COUNT, GROUP_COUNT,
+    PROTOCOL_COUNT, SIGNATURE_COUNT,
+};
+
+fn sample_record_json() -> serde_json::Value {
+    serde_json::json!({
+        "attribution": {
+            "service": "my-service",
+            "resource": "arn:aws:elasticloadbalancing:us-east-1:123:listener/abc"
+        },
+        "handshake": {
+            "freeze_time": {"secs_since_epoch": 1_700_000_000u64, "nanos_since_epoch": 0u32},
+            "handshake_count": 1000,
+            "negotiated_protocols": [[0x0303u16, 400], [0x0304u16, 600]],
+            "negotiated_ciphers": [[[0x13, 0x01], 600], [[0x13, 0x02], 400]],
+            "negotiated_groups": [[23u16, 500], [29u16, 500]],
+            "negotiated_signatures": [[2052u16, 1000]],
+            "sslv2_client_hello": 2,
+            "supported_protocols": [[0x0303u16, 1000], [0x0304u16, 1000]],
+            "supported_ciphers": [[[0x13, 0x01], 1000], [[0x13, 0x02], 1000]],
+            "supported_groups": [[23u16, 1000], [29u16, 1000]],
+            "supported_signatures": [[2052u16, 1000]],
+            "compatibility_general20251201": 950,
+            "compatibility_fips20251201": 800,
+            "compatibility_cnsa1": 100,
+            "compatibility_cnsa2": 0,
+            "handshake_duration_us": 50000,
+            "handshake_compute_us": 25000
+        }
+    })
+}
+
+#[test]
+fn cbor_stream_deserialization() {
+    let record: MetricRecord = serde_json::from_value(sample_record_json()).unwrap();
+
+    let mut stream = Vec::new();
+    for _ in 0..3 {
+        stream.extend_from_slice(&serde_cbor::to_vec(&record).unwrap());
+    }
+
+    let records: Vec<MetricRecord> = serde_cbor::StreamDeserializer::new(
+        serde_cbor::de::IoRead::new(std::io::Cursor::new(&stream)),
+    )
+    .collect::<Result<Vec<_>, _>>()
+    .unwrap();
+
+    assert_eq!(records.len(), 3);
+    for r in &records {
+        assert_eq!(r.attribution.service, "my-service");
+        assert_eq!(r.handshake.handshake_count, 1000);
+    }
+}
+
+#[test]
+fn public_field_access() {
+    let record: MetricRecord = serde_json::from_value(sample_record_json()).unwrap();
+
+    assert_eq!(record.attribution.service, "my-service");
+    assert_eq!(
+        record.attribution.resource,
+        "arn:aws:elasticloadbalancing:us-east-1:123:listener/abc"
+    );
+
+    assert_eq!(record.handshake.handshake_count, 1000);
+    assert_eq!(record.handshake.sslv2_client_hello, 2);
+    assert_eq!(record.handshake.compatibility_general20251201, 950);
+    assert_eq!(record.handshake.compatibility_fips20251201, 800);
+    assert_eq!(record.handshake.compatibility_cnsa1, 100);
+    assert_eq!(record.handshake.compatibility_cnsa2, 0);
+    assert_eq!(record.handshake.handshake_duration_us, 50000);
+    assert_eq!(record.handshake.handshake_compute_us, 25000);
+
+    let dur = record
+        .handshake
+        .freeze_time
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap();
+    assert_eq!(dur.as_secs(), 1_700_000_000);
+}
+
+#[test]
+fn frozen_counter_slots_dense_array() {
+    let record: MetricRecord = serde_json::from_value(sample_record_json()).unwrap();
+
+    let protocol_slots = record.handshake.negotiated_protocols.slots();
+    assert_eq!(protocol_slots.len(), PROTOCOL_COUNT);
+    let total: u64 = protocol_slots.iter().sum();
+    assert_eq!(total, 1000);
+
+    let cipher_slots = record.handshake.negotiated_ciphers.slots();
+    assert_eq!(cipher_slots.len(), CIPHER_COUNT);
+    let total: u64 = cipher_slots.iter().sum();
+    assert_eq!(total, 1000);
+
+    let group_slots = record.handshake.negotiated_groups.slots();
+    assert_eq!(group_slots.len(), GROUP_COUNT);
+    let total: u64 = group_slots.iter().sum();
+    assert_eq!(total, 1000);
+
+    let sig_slots = record.handshake.negotiated_signatures.slots();
+    assert_eq!(sig_slots.len(), SIGNATURE_COUNT);
+    let total: u64 = sig_slots.iter().sum();
+    assert_eq!(total, 1000);
+}
+
+#[test]
+fn key_from_slot_produces_display_names() {
+    for slot in 0..PROTOCOL_COUNT {
+        let name = Version::key_from_slot(slot).unwrap().to_string();
+        assert!(!name.is_empty());
+        assert!(!name.starts_with("unknown"));
+    }
+
+    for slot in 0..CIPHER_COUNT {
+        let name = Cipher::key_from_slot(slot).unwrap().to_string();
+        assert!(!name.is_empty());
+        assert!(!name.starts_with("unknown"));
+    }
+
+    for slot in 0..GROUP_COUNT {
+        let name = Group::key_from_slot(slot).unwrap().to_string();
+        assert!(!name.is_empty());
+        assert!(!name.starts_with("unknown"));
+    }
+
+    for slot in 0..SIGNATURE_COUNT {
+        let name = Signature::key_from_slot(slot).unwrap().to_string();
+        assert!(!name.is_empty());
+        assert!(!name.starts_with("unknown"));
+    }
+}
+
+#[test]
+fn iter_non_zero_yields_expected_triples() {
+    let record: MetricRecord = serde_json::from_value(sample_record_json()).unwrap();
+
+    let non_zero: Vec<(usize, Version, u64)> = record
+        .handshake
+        .negotiated_protocols
+        .iter_non_zero()
+        .collect();
+    assert_eq!(non_zero.len(), 2);
+
+    let total: u64 = non_zero.iter().map(|(_, _, c)| c).sum();
+    assert_eq!(total, 1000);
+
+    for (slot, element, count) in &non_zero {
+        assert!(count > &0);
+        let name = element.to_string();
+        assert!(
+            name == "TLSv1_2" || name == "TLSv1_3",
+            "unexpected protocol: {name}"
+        );
+        assert_eq!(Version::key_from_slot(*slot).unwrap(), *element);
+    }
+}
+
+#[test]
+fn slots_and_iter_non_zero_are_consistent() {
+    let record: MetricRecord = serde_json::from_value(sample_record_json()).unwrap();
+
+    let slots = record.handshake.negotiated_ciphers.slots();
+    let from_iter: Vec<(usize, u64)> = record
+        .handshake
+        .negotiated_ciphers
+        .iter_non_zero()
+        .map(|(slot, _, count)| (slot, count))
+        .collect();
+
+    for &(slot, count) in &from_iter {
+        assert_eq!(slots[slot], count);
+    }
+
+    let non_zero_from_slots: Vec<(usize, u64)> = slots
+        .iter()
+        .enumerate()
+        .filter(|&(_, c)| *c > 0)
+        .map(|(i, &c)| (i, c))
+        .collect();
+    assert_eq!(from_iter, non_zero_from_slots);
+}
+
+#[test]
+fn cbor_round_trip_preserves_all_fields() {
+    let original: MetricRecord = serde_json::from_value(sample_record_json()).unwrap();
+    let cbor_bytes = serde_cbor::to_vec(&original).unwrap();
+    let recovered: MetricRecord = serde_cbor::from_slice(&cbor_bytes).unwrap();
+
+    assert_eq!(original, recovered);
+}
+
+#[test]
+fn empty_record_has_zero_slots() {
+    let json = serde_json::json!({
+        "attribution": { "service": "s", "resource": "r" },
+        "handshake": {
+            "freeze_time": {"secs_since_epoch": 0u64, "nanos_since_epoch": 0u32},
+            "handshake_count": 0u64
+        }
+    });
+    let record: MetricRecord = serde_json::from_value(json).unwrap();
+
+    assert!(record
+        .handshake
+        .negotiated_protocols
+        .slots()
+        .iter()
+        .all(|&c| c == 0));
+    assert!(record
+        .handshake
+        .negotiated_ciphers
+        .slots()
+        .iter()
+        .all(|&c| c == 0));
+    assert!(record
+        .handshake
+        .negotiated_groups
+        .slots()
+        .iter()
+        .all(|&c| c == 0));
+    assert!(record
+        .handshake
+        .negotiated_signatures
+        .slots()
+        .iter()
+        .all(|&c| c == 0));
+    assert!(record
+        .handshake
+        .supported_protocols
+        .slots()
+        .iter()
+        .all(|&c| c == 0));
+    assert!(record
+        .handshake
+        .supported_ciphers
+        .slots()
+        .iter()
+        .all(|&c| c == 0));
+    assert!(record
+        .handshake
+        .supported_groups
+        .slots()
+        .iter()
+        .all(|&c| c == 0));
+    assert!(record
+        .handshake
+        .supported_signatures
+        .slots()
+        .iter()
+        .all(|&c| c == 0));
+
+    assert_eq!(
+        record
+            .handshake
+            .negotiated_protocols
+            .iter_non_zero()
+            .count(),
+        0
+    );
+}

--- a/bindings/rust/standard/s2n-tls-metrics-subscriber/tests/public_api.rs
+++ b/bindings/rust/standard/s2n-tls-metrics-subscriber/tests/public_api.rs
@@ -47,14 +47,20 @@ fn cbor_stream_deserialization() {
 
     let mut stream = Vec::new();
     for _ in 0..3 {
-        stream.extend_from_slice(&serde_cbor::to_vec(&record).unwrap());
+        ciborium::into_writer(&record, &mut stream).unwrap();
     }
 
-    let records: Vec<MetricRecord> = serde_cbor::StreamDeserializer::new(
-        serde_cbor::de::IoRead::new(std::io::Cursor::new(&stream)),
-    )
-    .collect::<Result<Vec<_>, _>>()
-    .unwrap();
+    let mut cursor = std::io::Cursor::new(&stream);
+    let mut records: Vec<MetricRecord> = Vec::new();
+    loop {
+        match ciborium::from_reader(&mut cursor) {
+            Ok(record) => records.push(record),
+            Err(ciborium::de::Error::Io(e)) if e.kind() == std::io::ErrorKind::UnexpectedEof => {
+                break;
+            }
+            Err(e) => panic!("deserialization error: {e}"),
+        }
+    }
 
     assert_eq!(records.len(), 3);
     for r in &records {
@@ -195,8 +201,9 @@ fn slots_and_iter_non_zero_are_consistent() {
 #[test]
 fn cbor_round_trip_preserves_all_fields() {
     let original: MetricRecord = serde_json::from_value(sample_record_json()).unwrap();
-    let cbor_bytes = serde_cbor::to_vec(&original).unwrap();
-    let recovered: MetricRecord = serde_cbor::from_slice(&cbor_bytes).unwrap();
+    let mut cbor_bytes = Vec::new();
+    ciborium::into_writer(&original, &mut cbor_bytes).unwrap();
+    let recovered: MetricRecord = ciborium::from_reader(cbor_bytes.as_slice()).unwrap();
 
     assert_eq!(original, recovered);
 }

--- a/bindings/rust/standard/s2n-tls-metrics-subscriber/tests/public_api.rs
+++ b/bindings/rust/standard/s2n-tls-metrics-subscriber/tests/public_api.rs
@@ -9,8 +9,8 @@
 use std::time::SystemTime;
 
 use s2n_tls_metrics_subscriber::{
-    Cipher, FiniteCounter, Group, MetricRecord, Signature, Version, CIPHER_COUNT, GROUP_COUNT,
-    PROTOCOL_COUNT, SIGNATURE_COUNT,
+    CIPHER_COUNT, Cipher, FiniteCounter, GROUP_COUNT, Group, MetricRecord, PROTOCOL_COUNT,
+    SIGNATURE_COUNT, Signature, Version,
 };
 
 fn sample_record_json() -> serde_json::Value {
@@ -212,54 +212,70 @@ fn empty_record_has_zero_slots() {
     });
     let record: MetricRecord = serde_json::from_value(json).unwrap();
 
-    assert!(record
-        .handshake
-        .negotiated_protocols
-        .slots()
-        .iter()
-        .all(|&c| c == 0));
-    assert!(record
-        .handshake
-        .negotiated_ciphers
-        .slots()
-        .iter()
-        .all(|&c| c == 0));
-    assert!(record
-        .handshake
-        .negotiated_groups
-        .slots()
-        .iter()
-        .all(|&c| c == 0));
-    assert!(record
-        .handshake
-        .negotiated_signatures
-        .slots()
-        .iter()
-        .all(|&c| c == 0));
-    assert!(record
-        .handshake
-        .supported_protocols
-        .slots()
-        .iter()
-        .all(|&c| c == 0));
-    assert!(record
-        .handshake
-        .supported_ciphers
-        .slots()
-        .iter()
-        .all(|&c| c == 0));
-    assert!(record
-        .handshake
-        .supported_groups
-        .slots()
-        .iter()
-        .all(|&c| c == 0));
-    assert!(record
-        .handshake
-        .supported_signatures
-        .slots()
-        .iter()
-        .all(|&c| c == 0));
+    assert!(
+        record
+            .handshake
+            .negotiated_protocols
+            .slots()
+            .iter()
+            .all(|&c| c == 0)
+    );
+    assert!(
+        record
+            .handshake
+            .negotiated_ciphers
+            .slots()
+            .iter()
+            .all(|&c| c == 0)
+    );
+    assert!(
+        record
+            .handshake
+            .negotiated_groups
+            .slots()
+            .iter()
+            .all(|&c| c == 0)
+    );
+    assert!(
+        record
+            .handshake
+            .negotiated_signatures
+            .slots()
+            .iter()
+            .all(|&c| c == 0)
+    );
+    assert!(
+        record
+            .handshake
+            .supported_protocols
+            .slots()
+            .iter()
+            .all(|&c| c == 0)
+    );
+    assert!(
+        record
+            .handshake
+            .supported_ciphers
+            .slots()
+            .iter()
+            .all(|&c| c == 0)
+    );
+    assert!(
+        record
+            .handshake
+            .supported_groups
+            .slots()
+            .iter()
+            .all(|&c| c == 0)
+    );
+    assert!(
+        record
+            .handshake
+            .supported_signatures
+            .slots()
+            .iter()
+            .all(|&c| c == 0)
+    );
 
     assert_eq!(
         record


### PR DESCRIPTION
# Goal

Expose the public API surface of `s2n-tls-metrics-subscriber` so downstream consumers can deserialize and inspect aggregated metric records.

## Why

Downstream services need to deserialize `MetricRecord` from CBOR streams and directly access handshake counters for analysis. Previously all fields and types were `pub(crate)`, forcing consumers to depend on duplicate type definitions.

## How

- Changed visibility of `MetricRecord`, `FrozenHandshakeRecord`, `FrozenCounter`, and wire types (`Version`, `Cipher`, `Group`, `Signature`) from `pub(crate)` to `pub`.
- Exposed the `FiniteCounter` trait and count constants (`PROTOCOL_COUNT`, `CIPHER_COUNT`, `GROUP_COUNT`, `SIGNATURE_COUNT`) publicly.
- Added `FrozenCounter::slots()` accessor for dense array access alongside the existing `iter_non_zero()`.
- Made the `counter` and `static_lists` modules public.
- Re-exported key types from the crate root for ergonomic access.

## Callouts

- All struct fields on `FrozenHandshakeRecord` are now `pub`. This is a deliberate choice to allow direct field access for deserialization consumers, but it means future field additions are technically breaking changes.
- Added `serde_cbor` as a dev-dependency for integration tests.

## Testing

- Added `tests/public_api.rs` integration tests covering:
  - CBOR stream deserialization of multiple concatenated records
  - Public field access on `MetricRecord` and `FrozenHandshakeRecord`
  - `FrozenCounter::slots()` dense array access
  - `FiniteCounter::key_from_slot` producing valid display names
  - `iter_non_zero()` yielding expected triples
  - Consistency between `slots()` and `iter_non_zero()`
  - CBOR round-trip fidelity
  - Empty/default records deserializing with zero-valued slots


### Related
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
