### PR TITLE
refactor: add iovec definition for Windows

### DIFF
--- a/api/s2n.h
+++ b/api/s2n.h
@@ -37,7 +37,15 @@ extern "C" {
 #include <stdint.h>
 #include <stdio.h>
 #include <sys/types.h>
-#include <sys/uio.h>
+#ifndef _WIN32
+    #include <sys/uio.h>
+#else
+/* struct iovec equivalent for Windows */
+struct iovec {
+    void *iov_base;
+    size_t iov_len;
+};
+#endif
 
 /**
  *  Function return code

--- a/api/s2n.h
+++ b/api/s2n.h
@@ -2281,6 +2281,7 @@ S2N_API extern int s2n_negotiate(struct s2n_connection *conn, s2n_blocked_status
  */
 S2N_API extern ssize_t s2n_send(struct s2n_connection *conn, const void *buf, ssize_t size, s2n_blocked_status *blocked);
 
+#ifndef _WIN32
 /**
  * Works in the same way as s2n_sendv_with_offset() but with the `offs` parameter implicitly assumed to be 0.
  * Therefore in the partial write case, the caller would have to make sure that the `bufs` and `count` fields are modified in a way that takes
@@ -2312,6 +2313,7 @@ S2N_API extern ssize_t s2n_sendv(struct s2n_connection *conn, const struct iovec
  * @returns The number of bytes written on success, which may indicate a partial write. S2N_FAILURE on failure.
  */
 S2N_API extern ssize_t s2n_sendv_with_offset(struct s2n_connection *conn, const struct iovec *bufs, ssize_t count, ssize_t offs, s2n_blocked_status *blocked);
+#endif
 
 /**
  * Decrypts and reads **size* to `buf` data from the associated

--- a/api/unstable/cert_authorities.h
+++ b/api/unstable/cert_authorities.h
@@ -31,7 +31,9 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <sys/types.h>
-#include <sys/uio.h>
+#ifndef _WIN32
+    #include <sys/uio.h>
+#endif
 
 struct s2n_certificate_request;
 struct s2n_certificate_authority_list;

--- a/stuffer/s2n_stuffer.h
+++ b/stuffer/s2n_stuffer.h
@@ -19,7 +19,9 @@
 #include <stdarg.h>
 #include <stdint.h>
 #include <stdlib.h>
-#include <sys/uio.h>
+#ifndef _WIN32
+    #include <sys/uio.h>
+#endif
 
 #include "utils/s2n_blob.h"
 #include "utils/s2n_result.h"


### PR DESCRIPTION
# Goal

s2n-tls send functions: s2n_send and s2n_sendv both depends on iovec in <sys/uio.h>. We need to support them on Windows.

## Why

s2n_sendv takes in a iovec array to record all data that needs to be sent. s2n_send at the moment uses s2n_sendv under the hood.
https://github.com/aws/s2n-tls/blob/6f87432ad66c341c51bc9910de7a88c853018e5b/tls/s2n_send.c#L269-L275

The cleanest way right now is to add the iovec definition for Windows which mirrors the uio.h implementation:
```
struct iovec
  {
    void *iov_base;	/* Pointer to data.  */
    size_t iov_len;	/* Length of data.  */
  };
```
## How

Add a gate for all <sys/uio.h> imports. If the platform is Linux, then we use the default uio.h, otherwise, the library would use the iovec definition that we provided. In this way, existing Linux customers who uses s2n_sendv and iovec won't be affected.

## Callouts

New Windows users shouldn't use s2n_sendv. We support iovec to avoid large refactor on the s2n_send side, but that doesn't mean we want to support s2n_sendv and s2n_sendv_with_offset APIs on Windows.

## Testing

Existing tests should pass. And I try to compile it on my Windows EC2 instance, and it doesn't error on <sys/uio.h> is not found anymore.

### Related

related to https://github.com/aws/s2n-tls/issues/4018

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
