### PR TITLE
refactor: disable MLock on Windows

### DIFF
--- a/utils/s2n_mem.c
+++ b/utils/s2n_mem.c
@@ -21,9 +21,12 @@
 #include <limits.h>
 #include <stdint.h>
 #include <stdlib.h>
-#include <sys/mman.h>
-#include <sys/param.h>
-#include <unistd.h>
+#ifndef _WIN32
+/* No Windows-specific headers needed; mlock is not supported. */
+    #include <sys/mman.h>
+    #include <sys/param.h>
+    #include <unistd.h>
+#endif
 
 #include "error/s2n_errno.h"
 #include "utils/s2n_blob.h"
@@ -47,6 +50,14 @@ static s2n_mem_free_callback s2n_mem_free_cb = s2n_mem_free_mlock_impl;
 
 static int s2n_mem_init_impl(void)
 {
+#ifdef _WIN32
+    /* On Windows, unconditionally use the no-mlock path.
+     * Reset page_size, s2n_mem_malloc_cb, and s2n_mem_free_cb to default values.
+     */
+    page_size = 4096;
+    s2n_mem_malloc_cb = s2n_mem_malloc_no_mlock_impl;
+    s2n_mem_free_cb = s2n_mem_free_no_mlock_impl;
+#else
     long sysconf_rc = sysconf(_SC_PAGESIZE);
 
     /* sysconf must not error, and page_size cannot be 0 */
@@ -61,6 +72,7 @@ static int s2n_mem_init_impl(void)
         s2n_mem_malloc_cb = s2n_mem_malloc_no_mlock_impl;
         s2n_mem_free_cb = s2n_mem_free_no_mlock_impl;
     }
+#endif
     return S2N_SUCCESS;
 }
 
@@ -74,9 +86,13 @@ static int s2n_mem_cleanup_impl(void)
 
 static int s2n_mem_free_mlock_impl(void *ptr, uint32_t size)
 {
+#ifdef _WIN32
+    free(ptr);
+#else
     /* Perform a best-effort `munlock`: ignore any errors during unlocking. */
     munlock(ptr, size);
     free(ptr);
+#endif
     return S2N_SUCCESS;
 }
 
@@ -89,6 +105,10 @@ static int s2n_mem_free_no_mlock_impl(void *ptr, uint32_t size)
 
 static int s2n_mem_malloc_mlock_impl(void **ptr, uint32_t requested, uint32_t *allocated)
 {
+#ifdef _WIN32
+    /* mlock is not supported on Windows; this should never be called. */
+    POSIX_BAIL(S2N_ERR_UNIMPLEMENTED);
+#else
     POSIX_ENSURE_REF(ptr);
 
     /* Page aligned allocation required for mlock */
@@ -100,16 +120,16 @@ static int s2n_mem_malloc_mlock_impl(void **ptr, uint32_t requested, uint32_t *a
     POSIX_ENSURE(posix_memalign(ptr, page_size, allocate) == 0, S2N_ERR_ALLOC);
     *allocated = allocate;
 
-/*
+    /*
 ** We disable MAD_DONTDUMP when fuzz-testing or using the address sanitizer because
 ** both need to be able to dump pages to function. It's how they map heap output.
 */
-#if defined(MADV_DONTDUMP) && !defined(S2N_ADDRESS_SANITIZER) && !defined(S2N_FUZZ_TESTING)
+    #if defined(MADV_DONTDUMP) && !defined(S2N_ADDRESS_SANITIZER) && !defined(S2N_FUZZ_TESTING)
     if (madvise(*ptr, *allocated, MADV_DONTDUMP) != 0) {
         POSIX_GUARD(s2n_mem_free_no_mlock_impl(*ptr, *allocated));
         POSIX_BAIL(S2N_ERR_MADVISE);
     }
-#endif
+    #endif
 
     if (mlock(*ptr, *allocated) != 0) {
         /* When mlock fails, no memory will be locked, so we don't use munlock on free */
@@ -120,6 +140,7 @@ static int s2n_mem_malloc_mlock_impl(void **ptr, uint32_t requested, uint32_t *a
     POSIX_ENSURE(*ptr != NULL, S2N_ERR_ALLOC);
 
     return S2N_SUCCESS;
+#endif /* _WIN32 */
 }
 
 static int s2n_mem_malloc_no_mlock_impl(void **ptr, uint32_t requested, uint32_t *allocated)

--- a/utils/s2n_mem.c
+++ b/utils/s2n_mem.c
@@ -22,7 +22,6 @@
 #include <stdint.h>
 #include <stdlib.h>
 #ifndef _WIN32
-/* No Windows-specific headers needed; mlock is not supported. */
     #include <sys/mman.h>
     #include <sys/param.h>
     #include <unistd.h>
@@ -38,26 +37,30 @@ static bool initialized = false;
 
 static int s2n_mem_init_impl(void);
 static int s2n_mem_cleanup_impl(void);
+
+#ifdef _WIN32
+static int s2n_windows_mem_free_impl(void *ptr, uint32_t size);
+static int s2n_windows_mem_malloc_impl(void **ptr, uint32_t requested, uint32_t *allocated);
+#else
 static int s2n_mem_free_no_mlock_impl(void *ptr, uint32_t size);
-static int s2n_mem_free_mlock_impl(void *ptr, uint32_t size);
 static int s2n_mem_malloc_no_mlock_impl(void **ptr, uint32_t requested, uint32_t *allocated);
+static int s2n_mem_free_mlock_impl(void *ptr, uint32_t size);
 static int s2n_mem_malloc_mlock_impl(void **ptr, uint32_t requested, uint32_t *allocated);
+#endif
 
 static s2n_mem_init_callback s2n_mem_init_cb = s2n_mem_init_impl;
 static s2n_mem_cleanup_callback s2n_mem_cleanup_cb = s2n_mem_cleanup_impl;
+#ifdef _WIN32
+static s2n_mem_malloc_callback s2n_mem_malloc_cb = s2n_windows_mem_malloc_impl;
+static s2n_mem_free_callback s2n_mem_free_cb = s2n_windows_mem_free_impl;
+#else
 static s2n_mem_malloc_callback s2n_mem_malloc_cb = s2n_mem_malloc_mlock_impl;
 static s2n_mem_free_callback s2n_mem_free_cb = s2n_mem_free_mlock_impl;
+#endif
 
 static int s2n_mem_init_impl(void)
 {
-#ifdef _WIN32
-    /* On Windows, unconditionally use the no-mlock path.
-     * Reset page_size, s2n_mem_malloc_cb, and s2n_mem_free_cb to default values.
-     */
-    page_size = 4096;
-    s2n_mem_malloc_cb = s2n_mem_malloc_no_mlock_impl;
-    s2n_mem_free_cb = s2n_mem_free_no_mlock_impl;
-#else
+#ifndef _WIN32
     long sysconf_rc = sysconf(_SC_PAGESIZE);
 
     /* sysconf must not error, and page_size cannot be 0 */
@@ -79,20 +82,41 @@ static int s2n_mem_init_impl(void)
 static int s2n_mem_cleanup_impl(void)
 {
     page_size = 4096;
+#ifdef _WIN32
+    s2n_mem_malloc_cb = s2n_windows_mem_malloc_impl;
+    s2n_mem_free_cb = s2n_windows_mem_free_impl;
+#else
     s2n_mem_malloc_cb = s2n_mem_malloc_no_mlock_impl;
     s2n_mem_free_cb = s2n_mem_free_no_mlock_impl;
+#endif
     return S2N_SUCCESS;
 }
 
+#ifdef _WIN32
+/* mlock is not supported on Windows, so these use plain malloc/free without memory locking. */
+
+static int s2n_windows_mem_malloc_impl(void **ptr, uint32_t requested, uint32_t *allocated)
+{
+    *ptr = malloc(requested);
+    POSIX_ENSURE(*ptr != NULL, S2N_ERR_ALLOC);
+    *allocated = requested;
+
+    return S2N_SUCCESS;
+}
+
+static int s2n_windows_mem_free_impl(void *ptr, uint32_t size)
+{
+    free(ptr);
+    return S2N_SUCCESS;
+}
+
+#else
+
 static int s2n_mem_free_mlock_impl(void *ptr, uint32_t size)
 {
-#ifdef _WIN32
-    free(ptr);
-#else
     /* Perform a best-effort `munlock`: ignore any errors during unlocking. */
     munlock(ptr, size);
     free(ptr);
-#endif
     return S2N_SUCCESS;
 }
 
@@ -105,10 +129,6 @@ static int s2n_mem_free_no_mlock_impl(void *ptr, uint32_t size)
 
 static int s2n_mem_malloc_mlock_impl(void **ptr, uint32_t requested, uint32_t *allocated)
 {
-#ifdef _WIN32
-    /* mlock is not supported on Windows; this should never be called. */
-    POSIX_BAIL(S2N_ERR_UNIMPLEMENTED);
-#else
     POSIX_ENSURE_REF(ptr);
 
     /* Page aligned allocation required for mlock */
@@ -121,9 +141,9 @@ static int s2n_mem_malloc_mlock_impl(void **ptr, uint32_t requested, uint32_t *a
     *allocated = allocate;
 
     /*
-** We disable MAD_DONTDUMP when fuzz-testing or using the address sanitizer because
-** both need to be able to dump pages to function. It's how they map heap output.
-*/
+    ** We disable MAD_DONTDUMP when fuzz-testing or using the address sanitizer because
+    ** both need to be able to dump pages to function. It's how they map heap output.
+    */
     #if defined(MADV_DONTDUMP) && !defined(S2N_ADDRESS_SANITIZER) && !defined(S2N_FUZZ_TESTING)
     if (madvise(*ptr, *allocated, MADV_DONTDUMP) != 0) {
         POSIX_GUARD(s2n_mem_free_no_mlock_impl(*ptr, *allocated));
@@ -140,7 +160,6 @@ static int s2n_mem_malloc_mlock_impl(void **ptr, uint32_t requested, uint32_t *a
     POSIX_ENSURE(*ptr != NULL, S2N_ERR_ALLOC);
 
     return S2N_SUCCESS;
-#endif /* _WIN32 */
 }
 
 static int s2n_mem_malloc_no_mlock_impl(void **ptr, uint32_t requested, uint32_t *allocated)
@@ -151,6 +170,8 @@ static int s2n_mem_malloc_no_mlock_impl(void **ptr, uint32_t requested, uint32_t
 
     return S2N_SUCCESS;
 }
+
+#endif
 
 int s2n_mem_set_callbacks(s2n_mem_init_callback mem_init_callback, s2n_mem_cleanup_callback mem_cleanup_callback,
         s2n_mem_malloc_callback mem_malloc_callback, s2n_mem_free_callback mem_free_callback)


### PR DESCRIPTION
# Goal

Disable MLock for s2n-tls on Windows.

## Why

We want s2n-tls on Windows to be simple. The decision that we take is to disable MLock on Windows altogether.

## How

We gate MLock support for Linux only. As long as s2n-tls is built on Windows, we don't build MLock in s2n_mem.c. `s2n_mem_init_impl()` will reset the `s2n_mem_malloc_cb` and `s2n_mem_free_cb` to no-op implementations.

## Callouts

## Testing

Existing CI should pass. I tried to build libs2n.a on EC2 Windows instance, and I no longer get the mman.h compilation error.

### Related

Related to https://github.com/aws/s2n-tls/issues/4018.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
