### PR TITLE
feat(metrics-subscriber): add operation field to Attribution

### DIFF
--- a/bindings/rust/standard/s2n-tls-metrics-subscriber/examples/metrics_export.rs
+++ b/bindings/rust/standard/s2n-tls-metrics-subscriber/examples/metrics_export.rs
@@ -48,7 +48,7 @@ fn main() {
     let attribution = Attribution {
         service: "my-service".to_owned(),
         resource: "test-resource".to_owned(),
-        operation: "TlsTelemetry".to_owned(),
+        component: "frontend".to_owned(),
     };
 
     // Passive periodic export: the subscriber will automatically export

--- a/bindings/rust/standard/s2n-tls-metrics-subscriber/examples/metrics_export.rs
+++ b/bindings/rust/standard/s2n-tls-metrics-subscriber/examples/metrics_export.rs
@@ -48,6 +48,7 @@ fn main() {
     let attribution = Attribution {
         service: "my-service".to_owned(),
         resource: "test-resource".to_owned(),
+        operation: "TlsTelemetry".to_owned(),
     };
 
     // Passive periodic export: the subscriber will automatically export

--- a/bindings/rust/standard/s2n-tls-metrics-subscriber/src/attribution.rs
+++ b/bindings/rust/standard/s2n-tls-metrics-subscriber/src/attribution.rs
@@ -3,11 +3,14 @@
 
 use serde::{Deserialize, Serialize};
 
-/// Identifies the source of a metric record by service and resource.
+/// Identifies the source of a metric record by service, resource, and operation.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub struct Attribution {
     /// The service or application name (e.g. "my-tls-service")
     pub service: String,
     /// The resource producing metrics (e.g. an ARN or listener name)
     pub resource: String,
+    /// Distinguishes telemetry from multiple subscribers in the same service
+    /// (e.g. "TlsTelemetry.external" vs "TlsTelemetry.internal")
+    pub operation: String,
 }

--- a/bindings/rust/standard/s2n-tls-metrics-subscriber/src/attribution.rs
+++ b/bindings/rust/standard/s2n-tls-metrics-subscriber/src/attribution.rs
@@ -3,14 +3,16 @@
 
 use serde::{Deserialize, Serialize};
 
-/// Identifies the source of a metric record by service, resource, and operation.
+/// Identifies the source of a metric record by service, resource, and component.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub struct Attribution {
     /// The service or application name (e.g. "my-tls-service")
     pub service: String,
     /// The resource producing metrics (e.g. an ARN or listener name)
     pub resource: String,
-    /// Distinguishes telemetry from multiple subscribers in the same service
-    /// (e.g. "TlsTelemetry.external" vs "TlsTelemetry.internal")
-    pub operation: String,
+    /// Distinguishes telemetry from multiple components within the same
+    /// application. For example, a load balancer application might want to
+    /// record both "frontend" and "backend" telemetry. Leave empty to emit
+    /// just "TlsTelemetry" without a component suffix.
+    pub component: String,
 }

--- a/bindings/rust/standard/s2n-tls-metrics-subscriber/src/record.rs
+++ b/bindings/rust/standard/s2n-tls-metrics-subscriber/src/record.rs
@@ -44,7 +44,14 @@ impl MetricRecord {
 
 impl metrique_writer::Entry for MetricRecord {
     fn write<'a>(&'a self, writer: &mut impl metrique_writer::EntryWriter<'a>) {
-        writer.value("Operation", &self.attribution.operation);
+        // "Operation" is a reserved label in some telemetry systems,
+        // so the key generally shouldn't be changed.
+        let operation = if self.attribution.component.is_empty() {
+            "TlsTelemetry".to_owned()
+        } else {
+            format!("TlsTelemetry.{}", self.attribution.component)
+        };
+        writer.value("Operation", &operation);
         writer.value("service", &self.attribution.service);
         writer.value("resource", &self.attribution.resource);
         self.handshake.write(writer)

--- a/bindings/rust/standard/s2n-tls-metrics-subscriber/src/record.rs
+++ b/bindings/rust/standard/s2n-tls-metrics-subscriber/src/record.rs
@@ -44,6 +44,7 @@ impl MetricRecord {
 
 impl metrique_writer::Entry for MetricRecord {
     fn write<'a>(&'a self, writer: &mut impl metrique_writer::EntryWriter<'a>) {
+        writer.value("Operation", &self.attribution.operation);
         writer.value("service", &self.attribution.service);
         writer.value("resource", &self.attribution.resource);
         self.handshake.write(writer)

--- a/bindings/rust/standard/s2n-tls-metrics-subscriber/src/subscriber.rs
+++ b/bindings/rust/standard/s2n-tls-metrics-subscriber/src/subscriber.rs
@@ -311,6 +311,7 @@ mod tests {
         let attribution = Attribution {
             service: "test_server".to_owned(),
             resource: "test_resource".to_owned(),
+            operation: "TlsTelemetry".to_owned(),
         };
         // Use a zero-duration interval so every handshake triggers an export
         let subscriber = AggregatedMetricsSubscriber::with_periodic_export(
@@ -369,6 +370,7 @@ mod tests {
         let attribution = Attribution {
             service: "test_server".to_owned(),
             resource: "test_resource".to_owned(),
+            operation: "TlsTelemetry".to_owned(),
         };
         let subscriber = AggregatedMetricsSubscriber::new(sink.clone(), attribution)
             .with_synthetic_traffic_detector(Box::new(ToggleDetector(toggle.clone())));

--- a/bindings/rust/standard/s2n-tls-metrics-subscriber/src/subscriber.rs
+++ b/bindings/rust/standard/s2n-tls-metrics-subscriber/src/subscriber.rs
@@ -311,7 +311,7 @@ mod tests {
         let attribution = Attribution {
             service: "test_server".to_owned(),
             resource: "test_resource".to_owned(),
-            operation: "TlsTelemetry".to_owned(),
+            component: "test_component".to_owned(),
         };
         // Use a zero-duration interval so every handshake triggers an export
         let subscriber = AggregatedMetricsSubscriber::with_periodic_export(
@@ -370,7 +370,7 @@ mod tests {
         let attribution = Attribution {
             service: "test_server".to_owned(),
             resource: "test_resource".to_owned(),
-            operation: "TlsTelemetry".to_owned(),
+            component: "test_component".to_owned(),
         };
         let subscriber = AggregatedMetricsSubscriber::new(sink.clone(), attribution)
             .with_synthetic_traffic_detector(Box::new(ToggleDetector(toggle.clone())));

--- a/bindings/rust/standard/s2n-tls-metrics-subscriber/src/test_utils.rs
+++ b/bindings/rust/standard/s2n-tls-metrics-subscriber/src/test_utils.rs
@@ -57,6 +57,7 @@ impl TestEndpoint<VecSink> {
         let attribution = Attribution {
             service: "test_server".to_owned(),
             resource: "test_resource".to_owned(),
+            operation: "TlsTelemetry".to_owned(),
         };
         let subscriber = AggregatedMetricsSubscriber::new(sink.clone(), attribution);
         let server_config = {

--- a/bindings/rust/standard/s2n-tls-metrics-subscriber/src/test_utils.rs
+++ b/bindings/rust/standard/s2n-tls-metrics-subscriber/src/test_utils.rs
@@ -57,7 +57,7 @@ impl TestEndpoint<VecSink> {
         let attribution = Attribution {
             service: "test_server".to_owned(),
             resource: "test_resource".to_owned(),
-            operation: "TlsTelemetry".to_owned(),
+            component: "test_component".to_owned(),
         };
         let subscriber = AggregatedMetricsSubscriber::new(sink.clone(), attribution);
         let server_config = {

--- a/bindings/rust/standard/s2n-tls-metrics-subscriber/tests/public_api.rs
+++ b/bindings/rust/standard/s2n-tls-metrics-subscriber/tests/public_api.rs
@@ -17,7 +17,8 @@ fn sample_record_json() -> serde_json::Value {
     serde_json::json!({
         "attribution": {
             "service": "my-service",
-            "resource": "arn:aws:elasticloadbalancing:us-east-1:123:listener/abc"
+            "resource": "arn:aws:elasticloadbalancing:us-east-1:123:listener/abc",
+            "operation": "TlsTelemetry"
         },
         "handshake": {
             "freeze_time": {"secs_since_epoch": 1_700_000_000u64, "nanos_since_epoch": 0u32},
@@ -211,7 +212,7 @@ fn cbor_round_trip_preserves_all_fields() {
 #[test]
 fn empty_record_has_zero_slots() {
     let json = serde_json::json!({
-        "attribution": { "service": "s", "resource": "r" },
+        "attribution": { "service": "s", "resource": "r", "operation": "TlsTelemetry" },
         "handshake": {
             "freeze_time": {"secs_since_epoch": 0u64, "nanos_since_epoch": 0u32},
             "handshake_count": 0u64

--- a/bindings/rust/standard/s2n-tls-metrics-subscriber/tests/public_api.rs
+++ b/bindings/rust/standard/s2n-tls-metrics-subscriber/tests/public_api.rs
@@ -18,7 +18,7 @@ fn sample_record_json() -> serde_json::Value {
         "attribution": {
             "service": "my-service",
             "resource": "arn:aws:elasticloadbalancing:us-east-1:123:listener/abc",
-            "operation": "TlsTelemetry"
+            "component": "frontend"
         },
         "handshake": {
             "freeze_time": {"secs_since_epoch": 1_700_000_000u64, "nanos_since_epoch": 0u32},
@@ -212,7 +212,7 @@ fn cbor_round_trip_preserves_all_fields() {
 #[test]
 fn empty_record_has_zero_slots() {
     let json = serde_json::json!({
-        "attribution": { "service": "s", "resource": "r", "operation": "TlsTelemetry" },
+        "attribution": { "service": "s", "resource": "r", "component": "frontend" },
         "handshake": {
             "freeze_time": {"secs_since_epoch": 0u64, "nanos_since_epoch": 0u32},
             "handshake_count": 0u64

--- a/bindings/rust/standard/s2n-tls-metrics-subscriber/tests/subscriber_memory.rs
+++ b/bindings/rust/standard/s2n-tls-metrics-subscriber/tests/subscriber_memory.rs
@@ -41,6 +41,7 @@ fn attribution() -> Attribution {
     Attribution {
         service: "memtest".to_owned(),
         resource: "memtest".to_owned(),
+        operation: "TlsTelemetry".to_owned(),
     }
 }
 
@@ -147,8 +148,8 @@ fn subscriber_allocation_budget() {
     // node), so adding fields to either type bumps this number by
     // roughly (field_size * 2) * N.
     const EXPORT: AllocDelta = AllocDelta {
-        blocks: N * 3 + (N + 31) / 32,
-        bytes: 511_528,
+        blocks: N * 4 + (N + 31) / 32,
+        bytes: 513_928,
     };
 
     // Subscriber state is fixed-size, so nothing should be retained across

--- a/bindings/rust/standard/s2n-tls-metrics-subscriber/tests/subscriber_memory.rs
+++ b/bindings/rust/standard/s2n-tls-metrics-subscriber/tests/subscriber_memory.rs
@@ -41,7 +41,7 @@ fn attribution() -> Attribution {
     Attribution {
         service: "memtest".to_owned(),
         resource: "memtest".to_owned(),
-        operation: "TlsTelemetry".to_owned(),
+        component: "memtest".to_owned(),
     }
 }
 
@@ -149,7 +149,7 @@ fn subscriber_allocation_budget() {
     // roughly (field_size * 2) * N.
     const EXPORT: AllocDelta = AllocDelta {
         blocks: N * 4 + (N + 31) / 32,
-        bytes: 513_928,
+        bytes: 512_928,
     };
 
     // Subscriber state is fixed-size, so nothing should be retained across


### PR DESCRIPTION
# Goal
Add a `component` field to `Attribution`.

## Why
Today `MetricRecord`'s `Entry` impl emits `service` and `resource` but no `Operation`. Consumers that need an operation identifier to distinguish different components which emit metrics do not have a convenient way to do so.

## How
Add `component: String` to `Attribution` and emit it as `"TlsTelemetry.{component}"` in the `Operation` field of `MetricRecord`'s `Entry` impl (or just `"TlsTelemetry"` when blank).

## Callouts
Export adds one extra String clone per record (the new field), so the memory budget grows by 1 block + ~7 bytes per export.

## Testing
Existing tests updated to set `component`.

### Related
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
