### PR TITLE
refactor: gate socket support for Linux only

### DIFF
--- a/tls/s2n_connection.c
+++ b/tls/s2n_connection.c
@@ -53,7 +53,9 @@
 #include "utils/s2n_mem.h"
 #include "utils/s2n_random.h"
 #include "utils/s2n_safety.h"
-#include "utils/s2n_socket.h"
+#ifndef _WIN32
+    #include "utils/s2n_socket.h"
+#endif
 #include "utils/s2n_timer.h"
 
 #define S2N_SET_KEY_SHARE_LIST_EMPTY(keyshares) (keyshares |= 1)
@@ -169,11 +171,13 @@ static int s2n_connection_free_managed_recv_io(struct s2n_connection *conn)
 {
     POSIX_ENSURE_REF(conn);
 
+#ifndef _WIN32
     if (conn->managed_recv_io) {
         POSIX_GUARD(s2n_free_object((uint8_t **) &conn->recv_io_context, sizeof(struct s2n_socket_read_io_context)));
         conn->managed_recv_io = false;
         conn->recv = NULL;
     }
+#endif
     return S2N_SUCCESS;
 }
 
@@ -181,11 +185,13 @@ static int s2n_connection_free_managed_send_io(struct s2n_connection *conn)
 {
     POSIX_ENSURE_REF(conn);
 
+#ifndef _WIN32
     if (conn->managed_send_io) {
         POSIX_GUARD(s2n_free_object((uint8_t **) &conn->send_io_context, sizeof(struct s2n_socket_write_io_context)));
         conn->managed_send_io = false;
         conn->send = NULL;
     }
+#endif
     return S2N_SUCCESS;
 }
 
@@ -198,12 +204,14 @@ static int s2n_connection_free_managed_io(struct s2n_connection *conn)
 
 static int s2n_connection_wipe_io(struct s2n_connection *conn)
 {
+#ifndef _WIN32
     if (s2n_connection_is_managed_corked(conn) && conn->recv) {
         POSIX_GUARD(s2n_socket_read_restore(conn));
     }
     if (s2n_connection_is_managed_corked(conn) && conn->send) {
         POSIX_GUARD(s2n_socket_write_restore(conn));
     }
+#endif
 
     /* Remove all I/O-related members */
     POSIX_GUARD(s2n_connection_free_managed_io(conn));
@@ -834,6 +842,7 @@ int s2n_connection_set_client_auth_type(struct s2n_connection *conn, s2n_cert_au
     return 0;
 }
 
+#ifndef _WIN32
 int s2n_connection_set_read_fd(struct s2n_connection *conn, int rfd)
 {
     struct s2n_blob ctx_mem = { 0 };
@@ -926,6 +935,7 @@ int s2n_connection_use_corked_io(struct s2n_connection *conn)
 
     return 0;
 }
+#endif
 
 uint64_t s2n_connection_get_wire_bytes_in(struct s2n_connection *conn)
 {

--- a/tls/s2n_handshake_io.c
+++ b/tls/s2n_handshake_io.c
@@ -35,7 +35,9 @@
 #include "utils/s2n_events.h"
 #include "utils/s2n_random.h"
 #include "utils/s2n_safety.h"
-#include "utils/s2n_socket.h"
+#ifndef _WIN32
+    #include "utils/s2n_socket.h"
+#endif
 
 /* clang-format off */
 struct s2n_handshake_action {
@@ -853,7 +855,9 @@ message_type_t s2n_conn_get_current_message_type(const struct s2n_connection *co
 static int s2n_advance_message(struct s2n_connection *conn)
 {
     /* Get the mode: 'C'lient or 'S'erver */
+#ifndef _WIN32
     char previous_writer = ACTIVE_STATE(conn).writer;
+#endif
     char this_mode = CONNECTION_WRITER(conn);
 
     /* Actually advance the message number */
@@ -864,6 +868,7 @@ static int s2n_advance_message(struct s2n_connection *conn)
         conn->handshake.message_number++;
     }
 
+#ifndef _WIN32
     /* Set TCP_QUICKACK to avoid artificial delay during the handshake */
     POSIX_GUARD(s2n_socket_quickack(conn));
 
@@ -894,6 +899,7 @@ static int s2n_advance_message(struct s2n_connection *conn)
     if (s2n_connection_is_managed_corked(conn)) {
         POSIX_GUARD(s2n_socket_write_uncork(conn));
     }
+#endif
 
     return S2N_SUCCESS;
 }

--- a/tls/s2n_ktls.h
+++ b/tls/s2n_ktls.h
@@ -76,4 +76,4 @@ void s2n_ktls_configure_connection(struct s2n_connection *conn, s2n_ktls_mode kt
 
 int s2n_sendfile(struct s2n_connection *conn, int in_fd, off_t offset, size_t count,
         size_t *bytes_written, s2n_blocked_status *blocked);
-#endif /* _WIN32 */
+#endif

--- a/tls/s2n_recv.c
+++ b/tls/s2n_recv.c
@@ -32,7 +32,6 @@
 #include "utils/s2n_blob.h"
 #include "utils/s2n_io.h"
 #include "utils/s2n_safety.h"
-#include "utils/s2n_socket.h"
 
 S2N_RESULT s2n_recv_in_init(struct s2n_connection *conn, uint32_t written, uint32_t total)
 {

--- a/tls/s2n_x509_validator.c
+++ b/tls/s2n_x509_validator.c
@@ -13,12 +13,24 @@
  * permissions and limitations under the License.
  */
 
-#include <arpa/inet.h>
-#include <netinet/in.h>
+/* <winsock2.h> internally includes core elements from <windows.h>. For historical
+ * reasons, <windows.h> defaults to including <winsock.h> (Winsock 1.1), whose
+ * declarations conflict with <winsock2.h> (Winsock 2). Defining WIN32_LEAN_AND_MEAN
+ * before including <winsock2.h> prevents this transitive <winsock.h> inclusion.
+ * https://learn.microsoft.com/en-us/windows/win32/winsock/include-files-2
+ */
+#ifdef _WIN32
+    #define WIN32_LEAN_AND_MEAN
+    #include <winsock2.h>
+    #include <ws2tcpip.h>
+#else
+    #include <arpa/inet.h>
+    #include <netinet/in.h>
+    #include <sys/socket.h>
+#endif
 #include <openssl/asn1.h>
 #include <openssl/err.h>
 #include <openssl/x509.h>
-#include <sys/socket.h>
 
 #include "crypto/s2n_libcrypto.h"
 #include "crypto/s2n_openssl_x509.h"

--- a/utils/s2n_rfc5952.c
+++ b/utils/s2n_rfc5952.c
@@ -16,7 +16,18 @@
 #include "utils/s2n_rfc5952.h"
 
 #include <stdio.h>
-#include <sys/socket.h>
+/* <winsock2.h> internally includes core elements from <windows.h>. For historical
+ * reasons, <windows.h> defaults to including <winsock.h> (Winsock 1.1), whose
+ * declarations conflict with <winsock2.h> (Winsock 2). Defining WIN32_LEAN_AND_MEAN
+ * before including <winsock2.h> prevents this transitive <winsock.h> inclusion.
+ * https://learn.microsoft.com/en-us/windows/win32/winsock/include-files-2
+ */
+#ifdef _WIN32
+    #define WIN32_LEAN_AND_MEAN
+    #include <winsock2.h>
+#else
+    #include <sys/socket.h>
+#endif
 #include <sys/types.h>
 
 #include "error/s2n_errno.h"

--- a/utils/s2n_socket.c
+++ b/utils/s2n_socket.c
@@ -13,33 +13,38 @@
  * permissions and limitations under the License.
  */
 
-#include "utils/s2n_socket.h"
+/* On Windows, s2n-tls does not provide built-in socket I/O.
+ * This file compiles to an empty translation unit on Windows.
+ */
+#ifndef _WIN32
 
-#include <netinet/in.h>
-#include <netinet/tcp.h>
-#include <sys/socket.h>
-#include <unistd.h>
+    #include "utils/s2n_socket.h"
 
-#include "tls/s2n_connection.h"
-#include "utils/s2n_safety.h"
+    #include <netinet/in.h>
+    #include <netinet/tcp.h>
+    #include <sys/socket.h>
+    #include <unistd.h>
 
-#if TCP_CORK
-    #define S2N_CORK     TCP_CORK
-    #define S2N_CORK_ON  1
-    #define S2N_CORK_OFF 0
-#elif TCP_NOPUSH
-    #define S2N_CORK     TCP_NOPUSH
-    #define S2N_CORK_ON  1
-    #define S2N_CORK_OFF 0
-#elif TCP_NODELAY
-    #define S2N_CORK     TCP_NODELAY
-    #define S2N_CORK_ON  0
-    #define S2N_CORK_OFF 1
-#endif
+    #include "tls/s2n_connection.h"
+    #include "utils/s2n_safety.h"
+
+    #if TCP_CORK
+        #define S2N_CORK     TCP_CORK
+        #define S2N_CORK_ON  1
+        #define S2N_CORK_OFF 0
+    #elif TCP_NOPUSH
+        #define S2N_CORK     TCP_NOPUSH
+        #define S2N_CORK_ON  1
+        #define S2N_CORK_OFF 0
+    #elif TCP_NODELAY
+        #define S2N_CORK     TCP_NODELAY
+        #define S2N_CORK_ON  0
+        #define S2N_CORK_OFF 1
+    #endif
 
 int s2n_socket_quickack(struct s2n_connection *conn)
 {
-#ifdef TCP_QUICKACK
+    #ifdef TCP_QUICKACK
     POSIX_ENSURE_REF(conn);
     if (!conn->managed_recv_io) {
         return 0;
@@ -56,14 +61,14 @@ int s2n_socket_quickack(struct s2n_connection *conn)
     if (setsockopt(r_io_ctx->fd, IPPROTO_TCP, TCP_QUICKACK, &optval, sizeof(optval)) == 0) {
         r_io_ctx->tcp_quickack_set = 1;
     }
-#endif
+    #endif
 
     return 0;
 }
 
 int s2n_socket_write_snapshot(struct s2n_connection *conn)
 {
-#ifdef S2N_CORK
+    #ifdef S2N_CORK
     socklen_t corklen = sizeof(int);
     POSIX_ENSURE_REF(conn);
     struct s2n_socket_write_io_context *w_io_ctx = (struct s2n_socket_write_io_context *) conn->send_io_context;
@@ -72,14 +77,14 @@ int s2n_socket_write_snapshot(struct s2n_connection *conn)
     getsockopt(w_io_ctx->fd, IPPROTO_TCP, S2N_CORK, &w_io_ctx->original_cork_val, &corklen);
     POSIX_ENSURE_EQ(corklen, sizeof(int));
     w_io_ctx->original_cork_is_set = 1;
-#endif
+    #endif
 
     return 0;
 }
 
 int s2n_socket_read_snapshot(struct s2n_connection *conn)
 {
-#ifdef SO_RCVLOWAT
+    #ifdef SO_RCVLOWAT
     socklen_t watlen = sizeof(int);
     POSIX_ENSURE_REF(conn);
     struct s2n_socket_read_io_context *r_io_ctx = (struct s2n_socket_read_io_context *) conn->recv_io_context;
@@ -88,14 +93,14 @@ int s2n_socket_read_snapshot(struct s2n_connection *conn)
     getsockopt(r_io_ctx->fd, SOL_SOCKET, SO_RCVLOWAT, &r_io_ctx->original_rcvlowat_val, &watlen);
     POSIX_ENSURE_EQ(watlen, sizeof(int));
     r_io_ctx->original_rcvlowat_is_set = 1;
-#endif
+    #endif
 
     return 0;
 }
 
 int s2n_socket_write_restore(struct s2n_connection *conn)
 {
-#ifdef S2N_CORK
+    #ifdef S2N_CORK
     POSIX_ENSURE_REF(conn);
     struct s2n_socket_write_io_context *w_io_ctx = (struct s2n_socket_write_io_context *) conn->send_io_context;
     POSIX_ENSURE_REF(w_io_ctx);
@@ -105,14 +110,14 @@ int s2n_socket_write_restore(struct s2n_connection *conn)
     }
     setsockopt(w_io_ctx->fd, IPPROTO_TCP, S2N_CORK, &w_io_ctx->original_cork_val, sizeof(w_io_ctx->original_cork_val));
     w_io_ctx->original_cork_is_set = 0;
-#endif
+    #endif
 
     return 0;
 }
 
 int s2n_socket_read_restore(struct s2n_connection *conn)
 {
-#ifdef SO_RCVLOWAT
+    #ifdef SO_RCVLOWAT
     POSIX_ENSURE_REF(conn);
     struct s2n_socket_read_io_context *r_io_ctx = (struct s2n_socket_read_io_context *) conn->recv_io_context;
     POSIX_ENSURE_REF(r_io_ctx);
@@ -122,7 +127,7 @@ int s2n_socket_read_restore(struct s2n_connection *conn)
     }
     setsockopt(r_io_ctx->fd, SOL_SOCKET, SO_RCVLOWAT, &r_io_ctx->original_rcvlowat_val, sizeof(r_io_ctx->original_rcvlowat_val));
     r_io_ctx->original_rcvlowat_is_set = 0;
-#endif
+    #endif
 
     return 0;
 }
@@ -143,7 +148,7 @@ int s2n_socket_was_corked(struct s2n_connection *conn)
 
 int s2n_socket_write_cork(struct s2n_connection *conn)
 {
-#ifdef S2N_CORK
+    #ifdef S2N_CORK
     POSIX_ENSURE_REF(conn);
     int optval = S2N_CORK_ON;
 
@@ -152,14 +157,14 @@ int s2n_socket_write_cork(struct s2n_connection *conn)
 
     /* Ignore the return value, if it fails it fails */
     setsockopt(w_io_ctx->fd, IPPROTO_TCP, S2N_CORK, &optval, sizeof(optval));
-#endif
+    #endif
 
     return 0;
 }
 
 int s2n_socket_write_uncork(struct s2n_connection *conn)
 {
-#ifdef S2N_CORK
+    #ifdef S2N_CORK
     POSIX_ENSURE_REF(conn);
     int optval = S2N_CORK_OFF;
 
@@ -168,7 +173,7 @@ int s2n_socket_write_uncork(struct s2n_connection *conn)
 
     /* Ignore the return value, if it fails it fails */
     setsockopt(w_io_ctx->fd, IPPROTO_TCP, S2N_CORK, &optval, sizeof(optval));
-#endif
+    #endif
 
     return 0;
 }
@@ -226,3 +231,8 @@ int s2n_socket_is_ipv6(int fd, uint8_t *ipv6)
 
     return 0;
 }
+
+#endif
+
+/* Suppress empty translation unit warning when compiled on Windows. */
+#pragma clang diagnostic ignored "-Wempty-translation-unit"

--- a/utils/s2n_socket.h
+++ b/utils/s2n_socket.h
@@ -15,7 +15,13 @@
 
 #pragma once
 
-#include "tls/s2n_connection.h"
+/* On Windows, s2n-tls does not provide built-in socket I/O.
+ * Windows users must supply custom I/O callbacks via
+ * s2n_connection_set_recv_cb() / s2n_connection_set_send_cb().
+ */
+#ifndef _WIN32
+
+    #include "tls/s2n_connection.h"
 
 /* The default read I/O context for communication over a socket */
 struct s2n_socket_read_io_context {
@@ -50,3 +56,5 @@ int s2n_socket_write_uncork(struct s2n_connection *conn);
 int s2n_socket_read(void *io_context, uint8_t *buf, uint32_t len);
 int s2n_socket_write(void *io_context, const uint8_t *buf, uint32_t len);
 int s2n_socket_is_ipv6(int fd, uint8_t *ipv6);
+
+#endif


### PR DESCRIPTION
# Goal

Drop socket support for Windows and keep the existing socket supports for Windows only.

## Why

s2n-tls customers would implement socket callback functions via `s2n_connection_set_recv/send_cb()`. However, the current code change also use the Linux <sys/socket.h> to implement a default socket support. We decide to not implement those default socket supports for Windows, since Windows depends on other socket libraries and might need to scatter ifdefs across the library.

## How

Gate existing code that deal with <sys/socket.h> to Linux only. s2n_socket.c/.h will not be compiled and functions associated with sockets will either be gated out or include only noop impls.

## Callouts

I did include windows socket header in tls/s2n_x509_validator.c and utils/s2n_rfc5952.c. These two files don't do socket IO operations. Instead, they just introduce network address types and functions for IP handling on Windows. Windows socket headers provide the same type and functions names as those on Linux. See the inline comments for the reason that we define the WIN32_LEAN_AND_MEAN macro. 

## Testing

It builds on a Windows EC2 instance. We should be able to produce libs2n.a at this point.

### Related

Related to https://github.com/aws/s2n-tls/issues/4018.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
