### PR TITLE
chore: release metrics subscriber v0.0.3

### DIFF
--- a/bindings/rust/standard/s2n-tls-metrics-subscriber/Cargo.toml
+++ b/bindings/rust/standard/s2n-tls-metrics-subscriber/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "s2n-tls-metrics-subscriber"
-version = "0.0.2"
+version = "0.0.3"
 edition = "2024"
 description = "Telemetry provider for s2n-tls"
 authors = ["AWS s2n"]


### PR DESCRIPTION
# Goal
Bump s2n-tls-metrics-subscriber version to 0.0.3

## Why
v0.0.3 adds an operation field to Attribution for richer per-call context, and makes the synthetic-traffic detector pluggable so consumers can supply their own classification logic.

## How
Bumps the metrics subscriber version from 0.0.2 to 0.0.3.

## Callouts
N/A

## Testing
`cargo publish -p s2n-tls-metrics-subscriber --dry-run` passes

### Related
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
