### PR TITLE
ci: set up Windows MSYS2 Github Actions

### DIFF
--- a/.github/workflows/ci_windows.yml
+++ b/.github/workflows/ci_windows.yml
@@ -1,0 +1,74 @@
+---
+name: Windows (MSYS2)
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  merge_group:
+    types: [checks_requested]
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  windows-msys2:
+    runs-on: windows-latest
+    name: CI Windows (${{matrix.sys}})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - sys: ucrt64
+            pkg-prefix: mingw-w64-ucrt-x86_64
+            env-path: /ucrt64
+          - sys: mingw64
+            pkg-prefix: mingw-w64-x86_64
+            env-path: /mingw64
+          - sys: clang64
+            pkg-prefix: mingw-w64-clang-x86_64
+            env-path: /clang64
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup MSYS2
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: ${{matrix.sys}}
+          update: true
+          install: >-
+            ${{matrix.pkg-prefix}}-clang
+            ${{matrix.pkg-prefix}}-cmake
+            ${{matrix.pkg-prefix}}-ninja
+            ${{matrix.pkg-prefix}}-go
+            ${{matrix.pkg-prefix}}-nasm
+            make
+            git
+            diffutils
+
+      - name: Build AWS-LC
+        shell: msys2 {0}
+        run: |
+          set -eu
+          git clone --depth 1 https://github.com/aws/aws-lc.git aws-lc-src
+          cmake -B aws-lc-build aws-lc-src -GNinja \
+            -DCMAKE_C_COMPILER=clang \
+            -DCMAKE_CXX_COMPILER=clang++ \
+            -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+            -DCMAKE_INSTALL_PREFIX=${{matrix.env-path}}/local \
+            -DBUILD_SHARED_LIBS=OFF \
+            -DBUILD_TESTING=OFF
+          cmake --build aws-lc-build -j $(nproc) --target install
+
+      - name: Build libs2n.a
+        shell: msys2 {0}
+        run: |
+          set -eu
+          cmake -B build . \
+            -DCMAKE_C_COMPILER=clang \
+            -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+            -DCMAKE_PREFIX_PATH=${{matrix.env-path}}/local \
+            -DBUILD_TESTING=OFF
+          cmake --build ./build -j $(nproc)


### PR DESCRIPTION
# Goal

Enable a Github Action CI to test s2n-tls on Windows. At this point, we will verify if the libs2n.a can be built on Windows.

## Why

We are trying to enabling windows support for s2n-tls. Hence, we need a CI to test its behavior.

## How

The new github action uses an existing workflow [`setup-msys2`](https://github.com/marketplace/actions/setup-msys2).  The new Github Action follows the following steps right now:
1. Set up the environment with clang, cmake, and other necessary dependencies.
2. Install AWS-LC.
3. Build libs2n.a.

Such workflow is adopted by multiple AWS teams, such as:
aws-lc: https://github.com/aws/aws-lc/blob/9426cbfbd5e4056d7fc1feab62b3c15a081d8f66/.github/workflows/windows-alt.yml#L258
aws-crt-kotlin: https://github.com/aws/aws-crt-kotlin/blob/d8344ae04e8d89d3cf099b1f3d65545b222938bf/.github/workflows/ci.yaml#L161
aws-lc-rs: https://github.com/aws/aws-lc-rs/blob/f09726be585021649e4917bacbe4ea33cba20cae/.github/workflows/cross.yml#L613

While running on Windows, we can test the code against three different environments (this approach is also used by [AWS-LC](https://github.com/aws/aws-lc-rs/blob/f09726be585021649e4917bacbe4ea33cba20cae/.github/workflows/cross.yml#L600-L603)):

The UCRT64 environment is linked against the Universal C Runtime (UCRT), this is a common environment used by Windows. CLANG64 environment also linked against UCRT, and it's useful for clang specific behavior. MINGW64 is the MinGW environment which is a older runtime environment.

Each environment is an isolated toolchain with its own package naming convention and filesystem prefix, which is why we need to define specific `pkg-prefix` and `env-path` for each env.

## Callouts

We might add GCC into the CI.

## Testing

I have already ran this workflows on my fork and it works with three different sys:
https://github.com/boquan-fang/s2n-tls/actions/workflows/ci_windows.yml.
It successfully build libs2n.a.

This workflow should also shows up in this PR, which should also pass:
https://github.com/aws/s2n-tls/actions/runs/26782749164/job/78951048074?pr=5898

```
[176/177] Building C object CMakeFiles/s2n.dir/utils/s2n_rfc5952.c.obj
[177/177] Linking C static library lib\libs2n.a
```

### Related

related to https://github.com/aws/s2n-tls/issues/4018.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
