### PR TITLE
feat: add per-message handshake timing instrumentation

### DIFF
--- a/api/unstable/events.h
+++ b/api/unstable/events.h
@@ -73,6 +73,55 @@ S2N_API extern int s2n_config_set_subscriber(struct s2n_config *config, void *su
  */
 S2N_API extern int s2n_config_set_handshake_event(struct s2n_config *config, s2n_event_on_handshake_cb callback);
 
+/**
+ * Per-message timing checkpoint emitted once when each handshake message
+ * handler finishes. Consumers reconstruct per-message durations by computing
+ * the delta between consecutive checkpoint timestamps.
+ *
+ * Checkpoints fire from the shared handshake dispatch loop, so they are emitted
+ * for every negotiated protocol version. The message names reflect whichever
+ * version was negotiated.
+ *
+ * The pointer passed to the callback is valid only for the duration of the
+ * callback invocation. Callers must copy any fields they want to retain.
+ */
+struct s2n_timing_checkpoint {
+    /* Static-lifetime string identifying which message just finished. Points
+     * into a `const char *[]` array, so the pointer itself is safe to read
+     * during the callback. Do not retain the pointer past the callback. */
+    const char *name;
+    /* 0 = S2N_SERVER, 1 = S2N_CLIENT — matches conn->mode */
+    uint8_t role;
+    /* Monotonic timestamp in nanoseconds, captured via the same clock used
+     * for handshake_start_ns / handshake_end_ns in struct s2n_event_handshake.
+     * Per-message checkpoints and total handshake time are therefore on the
+     * same timeline. */
+    uint64_t timestamp_ns;
+};
+
+typedef void (*s2n_event_on_timing_checkpoint_cb)(struct s2n_connection *conn, void *subscriber, struct s2n_timing_checkpoint *checkpoint);
+
+/**
+ * Register a per-message timing checkpoint callback on a config.
+ *
+ * The callback fires once after each TLS handshake message handler completes,
+ * with a single monotonic timestamp. The consumer reconstructs per-message
+ * durations by computing deltas between consecutive checkpoint timestamps.
+ *
+ * The same `subscriber` pointer set via s2n_config_set_subscriber is passed
+ * as the second argument to the callback. If no subscriber has been set,
+ * NULL is passed.
+ *
+ * Note: On a server using SNI-based config swap (s2n_connection_set_config
+ * called from the client hello callback), NEGOTIATE_START fires before the
+ * swap occurs. To receive NEGOTIATE_START, register this callback on the
+ * initial/default config, not only on the SNI-selected config.
+ *
+ * Returns S2N_SUCCESS on success.
+ * Returns S2N_FAILURE with S2N_ERR_NULL if config or callback is NULL.
+ */
+S2N_API extern int s2n_config_set_timing_checkpoint_cb(struct s2n_config *config, s2n_event_on_timing_checkpoint_cb callback);
+
 #ifdef __cplusplus
 }
 #endif

--- a/bindings/rust/extended/s2n-tls/src/config.rs
+++ b/bindings/rust/extended/s2n-tls/src/config.rs
@@ -726,7 +726,8 @@ impl Builder {
         Ok(self)
     }
 
-    /// Corresponds to [`s2n_config_set_subscriber`] and [`s2n_config_set_handshake_event`].
+    /// Corresponds to [`s2n_config_set_subscriber`], [`s2n_config_set_handshake_event`],
+    /// and [`s2n_config_set_timing_checkpoint_cb`].
     #[cfg(feature = "unstable-events")]
     pub fn set_event_subscriber<T: 'static + EventSubscriber>(
         &mut self,
@@ -741,6 +742,22 @@ impl Builder {
                 let callback = context.event_subscriber.as_ref();
                 if let Some(callback) = callback {
                     callback.on_handshake_event(conn, &HandshakeEvent::new(&*event));
+                }
+            });
+        }
+
+        unsafe extern "C" fn on_timing_checkpoint(
+            conn_ptr: *mut s2n_tls_sys::s2n_connection,
+            _subscriber: *mut c_void,
+            checkpoint: *mut s2n_tls_sys::s2n_timing_checkpoint,
+        ) {
+            with_context(conn_ptr, |conn, context| {
+                let callback = context.event_subscriber.as_ref();
+                if let Some(callback) = callback {
+                    callback.on_timing_checkpoint(
+                        conn,
+                        &crate::events::TimingCheckpoint::new(&*checkpoint),
+                    );
                 }
             });
         }
@@ -764,6 +781,16 @@ impl Builder {
             s2n_config_set_handshake_event(self.as_mut_ptr(), Some(on_handshake_event))
                 .into_result()
         }?;
+
+        // Register the per-message timing checkpoint callback.
+        unsafe {
+            s2n_tls_sys::s2n_config_set_timing_checkpoint_cb(
+                self.as_mut_ptr(),
+                Some(on_timing_checkpoint),
+            )
+            .into_result()
+        }?;
+
         Ok(self)
     }
 

--- a/bindings/rust/extended/s2n-tls/src/events.rs
+++ b/bindings/rust/extended/s2n-tls/src/events.rs
@@ -127,15 +127,81 @@ fn maybe_string(string: *const libc::c_char) -> Option<&'static str> {
     }
 }
 
+/// Per-message timing checkpoint emitted once when each TLS handler finishes.
+///
+/// Consumers reconstruct per-message durations by computing the delta between
+/// consecutive checkpoint timestamps within a single handshake. The first
+/// checkpoint emitted per handshake is `NEGOTIATE_START`, which serves as the
+/// anchor for the first message's duration.
+///
+/// The event is only valid for the duration of the callback invocation.
+pub struct TimingCheckpoint<'a>(&'a s2n_tls_sys::s2n_timing_checkpoint);
+
+impl<'a> TimingCheckpoint<'a> {
+    pub(crate) fn new(event: &'a s2n_tls_sys::s2n_timing_checkpoint) -> Self {
+        Self(event)
+    }
+
+    /// The name of the checkpoint, e.g. "NEGOTIATE_START", "CLIENT_HELLO",
+    /// "SERVER_CERT_VERIFY", "CLIENT_CHANGE_CIPHER_SPEC".
+    pub fn name(&self) -> &str {
+        maybe_string(self.0.name).unwrap_or("unknown")
+    }
+
+    /// The role: 0 = server, 1 = client.
+    pub fn role(&self) -> u8 {
+        self.0.role
+    }
+
+    /// Whether this event was recorded on the server side.
+    pub fn is_server(&self) -> bool {
+        self.0.role == 0
+    }
+
+    /// The timestamp at which the handler finished, in nanoseconds, on the
+    /// monotonic clock used by `s2n_default_monotonic_clock`. Same clock as
+    /// [`HandshakeEvent::duration`] uses, so callers can correlate per-message
+    /// checkpoints with total handshake time.
+    pub fn timestamp_ns(&self) -> u64 {
+        self.0.timestamp_ns
+    }
+}
+
+impl Debug for TimingCheckpoint<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TimingCheckpoint")
+            .field("name", &self.name())
+            .field("role", &if self.is_server() { "server" } else { "client" })
+            .field("timestamp_ns", &self.timestamp_ns())
+            .finish()
+    }
+}
+
 impl<A: EventSubscriber, B: EventSubscriber> EventSubscriber for (A, B) {
     fn on_handshake_event(&self, connection: &Connection, event: &HandshakeEvent) {
         self.0.on_handshake_event(connection, event);
         self.1.on_handshake_event(connection, event);
     }
+
+    fn on_timing_checkpoint(&self, connection: &Connection, checkpoint: &TimingCheckpoint) {
+        self.0.on_timing_checkpoint(connection, checkpoint);
+        self.1.on_timing_checkpoint(connection, checkpoint);
+    }
 }
 
 pub trait EventSubscriber: 'static + Send + Sync {
     fn on_handshake_event(&self, connection: &Connection, event: &HandshakeEvent);
+
+    /// Called once after each TLS handshake message handler completes, with a
+    /// single monotonic timestamp. The consumer reconstructs per-message
+    /// durations by computing deltas between consecutive checkpoints.
+    ///
+    /// The first checkpoint per handshake is `NEGOTIATE_START` (the anchor);
+    /// subsequent checkpoints are named after the message that just finished
+    /// (e.g. "CLIENT_HELLO", "SERVER_CERT", "CLIENT_CHANGE_CIPHER_SPEC").
+    ///
+    /// The default implementation is a no-op.
+    fn on_timing_checkpoint(&self, _connection: &Connection, _checkpoint: &TimingCheckpoint) {}
 }
 
 #[cfg(test)]
@@ -438,6 +504,67 @@ mod tests {
                 .unwrap()
         };
         assert_eq!(event_error_name, server_err.name());
+
+        Ok(())
+    }
+
+    /// Per-message timing checkpoints are delivered via on_timing_checkpoint.
+    /// Each handshake emits one checkpoint per dispatched message plus a
+    /// NEGOTIATE_START anchor.
+    #[test]
+    fn timing_checkpoint_event() -> Result<(), S2NError> {
+        #[derive(Debug, Default)]
+        struct TimingSubscriber {
+            handshake_invoked: Arc<AtomicU64>,
+            checkpoint_invoked: Arc<AtomicU64>,
+            checkpoint_names: Arc<Mutex<Vec<String>>>,
+        }
+
+        impl EventSubscriber for TimingSubscriber {
+            fn on_handshake_event(&self, _conn: &Connection, _event: &HandshakeEvent) {
+                self.handshake_invoked.fetch_add(1, Ordering::Relaxed);
+            }
+
+            fn on_timing_checkpoint(&self, _conn: &Connection, checkpoint: &TimingCheckpoint) {
+                self.checkpoint_invoked.fetch_add(1, Ordering::Relaxed);
+                self.checkpoint_names
+                    .lock()
+                    .unwrap()
+                    .push(checkpoint.name().to_string());
+                /* Timestamp is from a monotonic clock, so it should be > 0. */
+                assert!(checkpoint.timestamp_ns() > 0);
+            }
+        }
+
+        let subscriber = TimingSubscriber::default();
+        let handshake_invoked = subscriber.handshake_invoked.clone();
+        let checkpoint_invoked = subscriber.checkpoint_invoked.clone();
+        let checkpoint_names = subscriber.checkpoint_names.clone();
+
+        let config = {
+            let mut builder = config_builder(&security::DEFAULT).unwrap();
+            builder.set_event_subscriber(subscriber)?;
+            builder.build()?
+        };
+
+        let mut pair = TestPair::from_config(&config);
+        pair.handshake().unwrap();
+
+        // Handshake event always fires (both sides).
+        assert_eq!(handshake_invoked.load(Ordering::Relaxed), 2);
+
+        // Checkpoint events fire for both sides. The first checkpoint per
+        // side is the NEGOTIATE_START anchor.
+        let count = checkpoint_invoked.load(Ordering::Relaxed);
+        assert!(count > 0, "no checkpoints were emitted");
+        let names = checkpoint_names.lock().unwrap();
+        assert!(!names.is_empty());
+        // First two names are the NEGOTIATE_START anchors from each side.
+        assert!(names.iter().any(|n| n == "NEGOTIATE_START"));
+        // All names should be non-empty.
+        for name in names.iter() {
+            assert!(!name.is_empty(), "empty checkpoint name");
+        }
 
         Ok(())
     }

--- a/tests/unit/s2n_timing_test.c
+++ b/tests/unit/s2n_timing_test.c
@@ -1,0 +1,259 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#include "api/unstable/events.h"
+#include "error/s2n_errno.h"
+#include "s2n_test.h"
+#include "testlib/s2n_testlib.h"
+#include "tls/s2n_connection.h"
+#include "utils/s2n_events.h"
+#include "utils/s2n_safety.h"
+
+/* Generously sized so the subscriber never truncates, even on libcrypto
+ * implementations that fragment handshake records into many small records
+ * (each of which emits a RECORD_READ/RECORD_WRITE checkpoint). Truncation
+ * would otherwise drop the tail checkpoints, including NEGOTIATE_END. */
+#define MAX_CHECKPOINTS 256
+
+struct checkpoint_subscriber {
+    uint64_t invoked;
+    /* Count of checkpoints excluding RECORD_READ/RECORD_WRITE.*/
+    uint64_t message_invoked;
+    char names[MAX_CHECKPOINTS][64];
+    uint8_t roles[MAX_CHECKPOINTS];
+    uint64_t timestamps[MAX_CHECKPOINTS];
+};
+
+static void on_timing_checkpoint(
+        struct s2n_connection *conn,
+        void *ctx,
+        struct s2n_timing_checkpoint *checkpoint)
+{
+    struct checkpoint_subscriber *sub = (struct checkpoint_subscriber *) ctx;
+    if (sub->invoked < MAX_CHECKPOINTS) {
+        snprintf(sub->names[sub->invoked], sizeof(sub->names[0]),
+                "%s", checkpoint->name);
+        sub->roles[sub->invoked] = checkpoint->role;
+        sub->timestamps[sub->invoked] = checkpoint->timestamp_ns;
+    }
+    sub->invoked++;
+    if (strcmp(checkpoint->name, "RECORD_READ") != 0
+            && strcmp(checkpoint->name, "RECORD_WRITE") != 0) {
+        sub->message_invoked++;
+    }
+}
+
+/* Returns true if the subscriber recorded a checkpoint with the given name. */
+static bool checkpoint_seen(const struct checkpoint_subscriber *sub, const char *name)
+{
+    uint64_t seen = sub->invoked < MAX_CHECKPOINTS ? sub->invoked : MAX_CHECKPOINTS;
+    for (uint64_t i = 0; i < seen; i++) {
+        if (strcmp(sub->names[i], name) == 0) {
+            return true;
+        }
+    }
+    return false;
+}
+
+static int setup_tls13_config(struct s2n_config **server_config_out,
+        struct s2n_config **client_config_out,
+        struct s2n_cert_chain_and_key **chain_out)
+{
+    struct s2n_cert_chain_and_key *chain = NULL;
+    POSIX_GUARD(s2n_test_cert_chain_and_key_new(&chain,
+            S2N_DEFAULT_TEST_CERT_CHAIN, S2N_DEFAULT_TEST_PRIVATE_KEY));
+
+    struct s2n_config *server_config = s2n_config_new();
+    POSIX_ENSURE_REF(server_config);
+    POSIX_GUARD(s2n_config_set_cipher_preferences(server_config, "default_tls13"));
+    POSIX_GUARD(s2n_config_add_cert_chain_and_key_to_store(server_config, chain));
+    POSIX_GUARD(s2n_config_disable_x509_verification(server_config));
+
+    struct s2n_config *client_config = s2n_config_new();
+    POSIX_ENSURE_REF(client_config);
+    POSIX_GUARD(s2n_config_set_cipher_preferences(client_config, "default_tls13"));
+    POSIX_GUARD(s2n_config_disable_x509_verification(client_config));
+
+    *server_config_out = server_config;
+    *client_config_out = client_config;
+    *chain_out = chain;
+    return S2N_SUCCESS;
+}
+
+int main(int argc, char **argv)
+{
+    BEGIN_TEST();
+
+    /* Test: NULL config returns S2N_ERR_NULL */
+    {
+        EXPECT_FAILURE_WITH_ERRNO(
+                s2n_config_set_timing_checkpoint_cb(NULL, on_timing_checkpoint),
+                S2N_ERR_NULL);
+    }
+
+    /* Test: NULL callback returns S2N_ERR_NULL */
+    {
+        DEFER_CLEANUP(struct s2n_config *config = s2n_config_new_minimal(),
+                s2n_config_ptr_free);
+        EXPECT_FAILURE_WITH_ERRNO(
+                s2n_config_set_timing_checkpoint_cb(config, NULL),
+                S2N_ERR_NULL);
+    }
+
+    /* Test: registration succeeds */
+    {
+        DEFER_CLEANUP(struct s2n_config *config = s2n_config_new_minimal(),
+                s2n_config_ptr_free);
+        EXPECT_SUCCESS(s2n_config_set_timing_checkpoint_cb(config, on_timing_checkpoint));
+    }
+
+    /* Test: checkpoints fire with correct anchors and message names for a
+     * TLS 1.3 server-auth handshake. Skipped when the linked libcrypto cannot
+     * fully support TLS 1.3 (e.g. OpenSSL 1.0.2, LibreSSL), in which case the
+     * handshake negotiates TLS 1.2 and the TLS 1.3 message set does not apply. */
+    if (s2n_is_tls13_fully_supported()) {
+        struct s2n_config *server_config = NULL;
+        struct s2n_config *client_config = NULL;
+        DEFER_CLEANUP(struct s2n_cert_chain_and_key *chain = NULL,
+                s2n_cert_chain_and_key_ptr_free);
+        EXPECT_SUCCESS(setup_tls13_config(&server_config, &client_config, &chain));
+        DEFER_CLEANUP(struct s2n_config *sc = server_config, s2n_config_ptr_free);
+        DEFER_CLEANUP(struct s2n_config *cc = client_config, s2n_config_ptr_free);
+
+        struct checkpoint_subscriber server_sub = { 0 };
+        struct checkpoint_subscriber client_sub = { 0 };
+
+        EXPECT_SUCCESS(s2n_config_set_subscriber(sc, &server_sub));
+        EXPECT_SUCCESS(s2n_config_set_timing_checkpoint_cb(sc, on_timing_checkpoint));
+        EXPECT_SUCCESS(s2n_config_set_subscriber(cc, &client_sub));
+        EXPECT_SUCCESS(s2n_config_set_timing_checkpoint_cb(cc, on_timing_checkpoint));
+
+        DEFER_CLEANUP(struct s2n_connection *server = s2n_connection_new(S2N_SERVER),
+                s2n_connection_ptr_free);
+        DEFER_CLEANUP(struct s2n_connection *client = s2n_connection_new(S2N_CLIENT),
+                s2n_connection_ptr_free);
+        EXPECT_SUCCESS(s2n_connection_set_config(server, sc));
+        EXPECT_SUCCESS(s2n_connection_set_config(client, cc));
+        EXPECT_SUCCESS(s2n_connection_set_blinding(server, S2N_SELF_SERVICE_BLINDING));
+        EXPECT_SUCCESS(s2n_connection_set_blinding(client, S2N_SELF_SERVICE_BLINDING));
+
+        DEFER_CLEANUP(struct s2n_test_io_stuffer_pair io_pair = { 0 },
+                s2n_io_stuffer_pair_free);
+        EXPECT_OK(s2n_io_stuffer_pair_init(&io_pair));
+        EXPECT_OK(s2n_connections_set_io_stuffer_pair(client, server, &io_pair));
+
+        EXPECT_SUCCESS(s2n_negotiate_test_server_and_client(server, client));
+
+        /* Assert the exact number of message-handler checkpoints
+         *
+         * The 10 per side are, in order:
+         *   server: NEGOTIATE_START, CLIENT_HELLO, SERVER_HELLO,
+         *           SERVER_CHANGE_CIPHER_SPEC, ENCRYPTED_EXTENSIONS, SERVER_CERT,
+         *           SERVER_CERT_VERIFY, SERVER_FINISHED, CLIENT_FINISHED,
+         *           NEGOTIATE_END
+         *   client: NEGOTIATE_START, CLIENT_HELLO, SERVER_HELLO,
+         *           ENCRYPTED_EXTENSIONS, SERVER_CERT, SERVER_CERT_VERIFY,
+         *           SERVER_FINISHED, CLIENT_CHANGE_CIPHER_SPEC, CLIENT_FINISHED,
+         *           NEGOTIATE_END
+         */
+        EXPECT_EQUAL(server_sub.message_invoked, 10);
+        EXPECT_EQUAL(client_sub.message_invoked, 10);
+        /* Ensure we never truncated; otherwise the names[] tail (and the
+         * NEGOTIATE_END index below) would be invalid. */
+        EXPECT_TRUE(server_sub.invoked <= MAX_CHECKPOINTS);
+        EXPECT_TRUE(client_sub.invoked <= MAX_CHECKPOINTS);
+
+        /* The first checkpoint on each side must be NEGOTIATE_START. */
+        EXPECT_EQUAL(strcmp(server_sub.names[0], "NEGOTIATE_START"), 0);
+        EXPECT_EQUAL(strcmp(client_sub.names[0], "NEGOTIATE_START"), 0);
+
+        /* The last checkpoint on each side must be NEGOTIATE_END. */
+        EXPECT_EQUAL(strcmp(server_sub.names[server_sub.invoked - 1], "NEGOTIATE_END"), 0);
+        EXPECT_EQUAL(strcmp(client_sub.names[client_sub.invoked - 1], "NEGOTIATE_END"), 0);
+
+        /* Each message-handler checkpoint must fire on the side that dispatches it. */
+        EXPECT_TRUE(checkpoint_seen(&server_sub, "CLIENT_HELLO"));
+        EXPECT_TRUE(checkpoint_seen(&server_sub, "SERVER_HELLO"));
+        EXPECT_TRUE(checkpoint_seen(&server_sub, "ENCRYPTED_EXTENSIONS"));
+        EXPECT_TRUE(checkpoint_seen(&server_sub, "SERVER_CERT"));
+        EXPECT_TRUE(checkpoint_seen(&server_sub, "SERVER_CERT_VERIFY"));
+        EXPECT_TRUE(checkpoint_seen(&server_sub, "SERVER_FINISHED"));
+        EXPECT_TRUE(checkpoint_seen(&server_sub, "CLIENT_FINISHED"));
+
+        EXPECT_TRUE(checkpoint_seen(&client_sub, "CLIENT_HELLO"));
+        EXPECT_TRUE(checkpoint_seen(&client_sub, "SERVER_HELLO"));
+        EXPECT_TRUE(checkpoint_seen(&client_sub, "ENCRYPTED_EXTENSIONS"));
+        EXPECT_TRUE(checkpoint_seen(&client_sub, "SERVER_CERT"));
+        EXPECT_TRUE(checkpoint_seen(&client_sub, "SERVER_CERT_VERIFY"));
+        EXPECT_TRUE(checkpoint_seen(&client_sub, "SERVER_FINISHED"));
+        EXPECT_TRUE(checkpoint_seen(&client_sub, "CLIENT_FINISHED"));
+    }
+
+    /* Test: timestamps are monotonically non-decreasing within a connection.
+     *
+     * This verifies the consumer's "delta from previous checkpoint" computation
+     * never underflows, because s2n_default_monotonic_clock is monotonic. */
+    {
+        DEFER_CLEANUP(struct s2n_config *server_config = NULL, s2n_config_ptr_free);
+        DEFER_CLEANUP(struct s2n_config *client_config = NULL, s2n_config_ptr_free);
+        DEFER_CLEANUP(struct s2n_cert_chain_and_key *chain = NULL,
+                s2n_cert_chain_and_key_ptr_free);
+        EXPECT_SUCCESS(setup_tls13_config(&server_config, &client_config, &chain));
+
+        struct checkpoint_subscriber server_sub = { 0 };
+        struct checkpoint_subscriber client_sub = { 0 };
+
+        EXPECT_SUCCESS(s2n_config_set_subscriber(server_config, &server_sub));
+        EXPECT_SUCCESS(s2n_config_set_timing_checkpoint_cb(server_config, on_timing_checkpoint));
+        EXPECT_SUCCESS(s2n_config_set_subscriber(client_config, &client_sub));
+        EXPECT_SUCCESS(s2n_config_set_timing_checkpoint_cb(client_config, on_timing_checkpoint));
+
+        DEFER_CLEANUP(struct s2n_connection *server = s2n_connection_new(S2N_SERVER),
+                s2n_connection_ptr_free);
+        DEFER_CLEANUP(struct s2n_connection *client = s2n_connection_new(S2N_CLIENT),
+                s2n_connection_ptr_free);
+        EXPECT_SUCCESS(s2n_connection_set_config(server, server_config));
+        EXPECT_SUCCESS(s2n_connection_set_config(client, client_config));
+        EXPECT_SUCCESS(s2n_connection_set_blinding(server, S2N_SELF_SERVICE_BLINDING));
+        EXPECT_SUCCESS(s2n_connection_set_blinding(client, S2N_SELF_SERVICE_BLINDING));
+
+        DEFER_CLEANUP(struct s2n_test_io_stuffer_pair io_pair = { 0 },
+                s2n_io_stuffer_pair_free);
+        EXPECT_OK(s2n_io_stuffer_pair_init(&io_pair));
+        EXPECT_OK(s2n_connections_set_io_stuffer_pair(client, server, &io_pair));
+
+        EXPECT_SUCCESS(s2n_negotiate_test_server_and_client(server, client));
+
+        for (uint64_t i = 1; i < server_sub.invoked && i < MAX_CHECKPOINTS; i++) {
+            EXPECT_TRUE(server_sub.timestamps[i] >= server_sub.timestamps[i - 1]);
+        }
+        for (uint64_t i = 1; i < client_sub.invoked && i < MAX_CHECKPOINTS; i++) {
+            EXPECT_TRUE(client_sub.timestamps[i] >= client_sub.timestamps[i - 1]);
+        }
+    }
+
+    /* Test: s2n_event_checkpoint_send is a no-op when no callback registered */
+    {
+        DEFER_CLEANUP(struct s2n_config *config = s2n_config_new_minimal(),
+                s2n_config_ptr_free);
+        DEFER_CLEANUP(struct s2n_connection *conn = s2n_connection_new(S2N_SERVER),
+                s2n_connection_ptr_free);
+        EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
+
+        EXPECT_OK(s2n_event_checkpoint_send(conn, "TEST", 0));
+    }
+
+    END_TEST();
+}

--- a/tls/s2n_config.c
+++ b/tls/s2n_config.c
@@ -1366,3 +1366,11 @@ int s2n_config_set_handshake_event(struct s2n_config *config, s2n_event_on_hands
     config->on_handshake_event = callback;
     return S2N_SUCCESS;
 }
+
+int s2n_config_set_timing_checkpoint_cb(struct s2n_config *config, s2n_event_on_timing_checkpoint_cb callback)
+{
+    POSIX_ENSURE_REF(config);
+    POSIX_ENSURE_REF(callback);
+    config->on_timing_checkpoint_cb = callback;
+    return S2N_SUCCESS;
+}

--- a/tls/s2n_config.h
+++ b/tls/s2n_config.h
@@ -216,6 +216,7 @@ struct s2n_config {
 
     void *subscriber;
     s2n_event_on_handshake_cb on_handshake_event;
+    s2n_event_on_timing_checkpoint_cb on_timing_checkpoint_cb;
 
     /* The user defined context associated with config */
     void *context;

--- a/tls/s2n_handshake_io.c
+++ b/tls/s2n_handshake_io.c
@@ -1255,12 +1255,15 @@ static int s2n_handshake_write_io(struct s2n_connection *conn)
             POSIX_GUARD(s2n_handshake_write_header(&conn->handshake.io, ACTIVE_STATE(conn).message_type));
         }
         POSIX_GUARD(ACTIVE_STATE(conn).handler[conn->mode](conn));
+        POSIX_GUARD_RESULT(s2n_event_checkpoint_send(
+                conn, message_names[ACTIVE_MESSAGE(conn)], (uint8_t) conn->mode));
         if (record_type == TLS_HANDSHAKE) {
             POSIX_GUARD(s2n_handshake_finish_header(&conn->handshake.io));
         }
     }
 
     POSIX_GUARD_RESULT(s2n_handshake_message_send(conn, record_type, &blocked));
+    POSIX_GUARD_RESULT(s2n_event_checkpoint_send(conn, "RECORD_WRITE", (uint8_t) conn->mode));
     if (record_type == TLS_HANDSHAKE) {
         POSIX_GUARD_RESULT(s2n_handshake_transcript_update(conn));
     }
@@ -1461,6 +1464,8 @@ static int s2n_handshake_message_process(struct s2n_connection *conn, uint8_t re
 
         /* Call the relevant handler */
         WITH_ERROR_BLINDING(conn, POSIX_GUARD(ACTIVE_STATE(conn).handler[conn->mode](conn)));
+        POSIX_GUARD_RESULT(s2n_event_checkpoint_send(
+                conn, message_names[ACTIVE_MESSAGE(conn)], (uint8_t) conn->mode));
 
         /* Advance the state machine */
         POSIX_GUARD_RESULT(s2n_finish_read(conn));
@@ -1515,6 +1520,8 @@ static int s2n_handshake_read_io(struct s2n_connection *conn)
         }
         POSIX_GUARD(r);
     }
+
+    POSIX_GUARD_RESULT(s2n_event_checkpoint_send(conn, "RECORD_READ", (uint8_t) conn->mode));
 
     if (isSSLv2) {
         S2N_ERROR_IF(record_type != SSLv2_CLIENT_HELLO, S2N_ERR_BAD_MESSAGE);
@@ -1734,6 +1741,8 @@ int s2n_negotiate(struct s2n_connection *conn, s2n_blocked_status *blocked)
     POSIX_GUARD(s2n_default_monotonic_clock(NULL, &negotiate_start));
     if (conn->handshake_event.handshake_start_ns == 0) {
         conn->handshake_event.handshake_start_ns = negotiate_start;
+        POSIX_GUARD_RESULT(s2n_event_checkpoint_send(
+                conn, "NEGOTIATE_START", (uint8_t) conn->mode));
     }
 
     int result = s2n_negotiate_impl(conn, blocked);
@@ -1750,6 +1759,8 @@ int s2n_negotiate(struct s2n_connection *conn, s2n_blocked_status *blocked)
         conn->handshake_event.handshake_end_ns = negotiate_end;
         POSIX_GUARD_RESULT(s2n_event_handshake_populate(conn, &conn->handshake_event));
         POSIX_GUARD_RESULT(s2n_event_handshake_send(conn, &conn->handshake_event));
+        POSIX_GUARD_RESULT(s2n_event_checkpoint_send(
+                conn, "NEGOTIATE_END", (uint8_t) conn->mode));
     } else if (s2n_error_get_type(s2n_errno) != S2N_ERR_T_BLOCKED && conn->config) {
         /* S2N_ERR_T_BLOCKED is the only retryable error type -- it indicates
          * the handshake is still in progress but IO would block. All other

--- a/utils/s2n_events.c
+++ b/utils/s2n_events.c
@@ -15,6 +15,7 @@
 
 #include "utils/s2n_events.h"
 
+#include "tls/s2n_config.h"
 #include "tls/s2n_connection.h"
 #include "tls/s2n_security_policies.h"
 
@@ -64,5 +65,32 @@ S2N_RESULT s2n_event_handshake_send(struct s2n_connection *conn, struct s2n_even
 
     conn->config->on_handshake_event(conn, conn->config->subscriber, event);
     event->handshake_start_ns = HANDSHAKE_EVENT_SENT;
+    return S2N_RESULT_OK;
+}
+
+/**
+ * Emit a per-message timing checkpoint.
+ *
+ * No-op if no callback is registered or config is NULL.
+ */
+S2N_RESULT s2n_event_checkpoint_send(struct s2n_connection *conn, const char *name, uint8_t role)
+{
+    RESULT_ENSURE_REF(conn);
+    RESULT_ENSURE_REF(name);
+
+    if (conn->config == NULL || conn->config->on_timing_checkpoint_cb == NULL) {
+        return S2N_RESULT_OK;
+    }
+
+    uint64_t timestamp_ns = 0;
+    RESULT_GUARD_POSIX(s2n_default_monotonic_clock(NULL, &timestamp_ns));
+
+    struct s2n_timing_checkpoint checkpoint = {
+        .name = name,
+        .role = role,
+        .timestamp_ns = timestamp_ns,
+    };
+
+    conn->config->on_timing_checkpoint_cb(conn, conn->config->subscriber, &checkpoint);
     return S2N_RESULT_OK;
 }

--- a/utils/s2n_events.h
+++ b/utils/s2n_events.h
@@ -24,3 +24,5 @@
 
 S2N_RESULT s2n_event_handshake_populate(struct s2n_connection* conn, struct s2n_event_handshake* event);
 S2N_RESULT s2n_event_handshake_send(struct s2n_connection* conn, struct s2n_event_handshake* event);
+
+S2N_RESULT s2n_event_checkpoint_send(struct s2n_connection* conn, const char* name, uint8_t role);


### PR DESCRIPTION
# Goal
Add a checkpoint-based timing API to the s2n-tls handshake dispatch loop. A registered callback receives a monotonic timestamp after each handler completes, enabling consumers to reconstruct per-message durations by computing deltas between consecutive checkpoints.

## Why
Our existing benchmarks measure total handshake time but not where the time is spent. This PR adds the instrumentation needed to break down handshake cost per-message, so we can pinpoint which operations (like RSA signing in SERVER_CERT_VERIFY) slow down total handshake time.

## How
A single `s2n_event_checkpoint_send(conn, name, role)` call fires after each handler invocation in `s2n_handshake_io.c` (both write and read paths). It captures one monotonic timestamp via `s2n_default_monotonic_clock` and passes it to the registered callback. The consumer reconstructs per-message durations by computing deltas between consecutive checkpoints on the global timeline.

Additional checkpoints (`NEGOTIATE_START`, `NEGOTIATE_END`, `RECORD_READ`, `RECORD_WRITE`) provide record-layer and handshake-boundary visibility.

If no callback is registered, the only cost is one NULL check per message (~1ns). The clock is not read unless a callback is registered.

C changes:
- New `struct s2n_timing_checkpoint` (name + role + timestamp_ns) and `s2n_config_set_timing_checkpoint_cb` in `api/unstable/events.h`
- `s2n_event_checkpoint_send` helper in `utils/s2n_events.c` — no-op when no callback registered
- Checkpoints at both dispatch sites in `s2n_handshake_io.c` (write path + read path), plus `NEGOTIATE_START`/`NEGOTIATE_END` anchors and `RECORD_READ`/`RECORD_WRITE` for record-layer visibility
- Always compiled in; gated only by whether a callback is registered
- Uses `s2n_default_monotonic_clock` (same clock as the existing handshake event)

Rust bindings:
- `TimingCheckpoint` wrapper and `on_timing_checkpoint` trait method on `EventSubscriber`
- Updated `set_event_subscriber` in `config.rs` to register the checkpoint callback

## Callouts
- The timing code is always compiled in (no compile-time flag). Gating is purely at the API level.
- The benchmark harness has been moved to a separate repo (`tls-handshake-benchmarking`) for better integration with Rustls

## Testing
Usage:
  cd bindings/rust/standard 
  S2N_DONT_MLOCK=1 cargo run -p handshake-timing --release -- rsa2048
(or whatever cert type you want out of rsa2048, rsa3072, rsa4096, ecdsa256, ecdsa384)

### Related
Follow-up work: Rustls fork equivalent instrumentation, flamegraph integration, implementing improvements based on Rustls vs s2n-tls results.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
