### PR TITLE
test: configure non fork tests to run on Windows

### DIFF
--- a/.github/workflows/ci_windows.yml
+++ b/.github/workflows/ci_windows.yml
@@ -62,7 +62,7 @@ jobs:
             -DBUILD_TESTING=OFF
           cmake --build aws-lc-build -j $(nproc) --target install
 
-      - name: Build libs2n.a
+      - name: Build libs2n.a and unit tests
         shell: msys2 {0}
         run: |
           set -eu
@@ -70,6 +70,12 @@ jobs:
             -DCMAKE_C_COMPILER=clang \
             -DCMAKE_BUILD_TYPE=RelWithDebInfo \
             -DCMAKE_PREFIX_PATH=${{matrix.env-path}}/local \
-            -DBUILD_TESTING=OFF \
-            -DS2N_ENFORCE_PROPER_LIBCRYPTO_FEATURE_PROBE=ON
+            -DS2N_ENFORCE_PROPER_LIBCRYPTO_FEATURE_PROBE=ON \
+            -DBUILD_TESTING=ON
           cmake --build ./build -j $(nproc)
+
+      - name: Run unit tests
+        shell: msys2 {0}
+        run: |
+          set -eu
+          ctest --test-dir build --output-on-failure -j $(nproc)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -479,7 +479,11 @@ else()
     target_link_libraries(${PROJECT_NAME} PUBLIC ${LINK_LIB})
 endif()
 
-target_link_libraries(${PROJECT_NAME} PUBLIC ${OS_LIBS} m)
+target_link_libraries(${PROJECT_NAME} PUBLIC ${OS_LIBS})
+if (NOT WIN32)
+    # On Windows, math functions are part of the C runtime; no separate libm exists.
+    target_link_libraries(${PROJECT_NAME} PUBLIC m)
+endif()
 
 target_include_directories(${PROJECT_NAME} PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)
 target_include_directories(${PROJECT_NAME} PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/api> $<INSTALL_INTERFACE:include>)
@@ -500,6 +504,10 @@ if (BUILD_TESTING)
     # make sure all linked tests include the prelude
     target_compile_options(testss2n PUBLIC -include "${S2N_PRELUDE}" -fPIC)
     target_link_libraries(testss2n PUBLIC ${PROJECT_NAME})
+    if (WIN32)
+        # Test utilities use sockets for self-talk tests
+        target_link_libraries(testss2n PUBLIC ws2_32)
+    endif()
     if (SECCOMP)
         message(STATUS "Linking tests with seccomp")
         target_link_libraries(testss2n PRIVATE seccomp)
@@ -579,6 +587,64 @@ if (BUILD_TESTING)
     ############################################################################
 
     file(GLOB UNITTESTS_SRC "tests/unit/*.c")
+    if (WIN32)
+        # On Windows, exclude tests that require fork(), pipe(), kTLS, or other POSIX-only features not yet ported.
+        # This list will be significantly shortened after next refactors.
+        set(S2N_WINDOWS_EXCLUDE_TESTS
+            s2n_cleanup_test
+            s2n_client_auth_handshake_test
+            s2n_client_extensions_test
+            s2n_client_hello_recv_test
+            s2n_client_hello_test
+            s2n_client_record_version_test
+            s2n_client_secure_renegotiation_test
+            s2n_connection_test
+            s2n_drain_alert_test
+            s2n_examples_test
+            s2n_fragmentation_coalescing_test
+            s2n_handshake_invariant_test
+            s2n_handshake_test
+            s2n_init_test
+            s2n_io_test
+            s2n_key_update_threads_test
+            s2n_ktls_io_sendfile_test
+            s2n_ktls_io_test
+            s2n_ktls_test
+            s2n_ktls_test_utils_test
+            s2n_malformed_handshake_test
+            s2n_mem_allocator_test
+            s2n_mem_usage_test
+            s2n_policy_writer_test
+            s2n_post_handshake_recv_test
+            s2n_quic_support_test
+            s2n_random_test
+            s2n_recv_buffering_test
+            s2n_recv_test
+            s2n_release_non_empty_buffers_test
+            s2n_renegotiate_io_test
+            s2n_renegotiate_test
+            s2n_rfc5952_test
+            s2n_seccomp_failure_test
+            s2n_self_talk_alerts_test
+            s2n_self_talk_broken_pipe_test
+            s2n_self_talk_client_hello_cb_test
+            s2n_self_talk_custom_io_test
+            s2n_self_talk_io_mem_test
+            s2n_self_talk_ktls_test
+            s2n_self_talk_min_protocol_version_test
+            s2n_self_talk_nonblocking_test
+            s2n_self_talk_session_id_test
+            s2n_self_talk_tls12_test
+            s2n_self_talk_tls13_test
+            s2n_send_key_update_test
+            s2n_shutdown_test
+            s2n_tls13_zero_length_payload_test
+        )
+        foreach(excluded ${S2N_WINDOWS_EXCLUDE_TESTS})
+            list(REMOVE_ITEM UNITTESTS_SRC
+                "${CMAKE_CURRENT_SOURCE_DIR}/tests/unit/${excluded}.c")
+        endforeach()
+    endif()
     foreach(test_case ${UNITTESTS_SRC})
         # NAME_WE: name without extension
         get_filename_component(test_case_name ${test_case} NAME_WE)
@@ -593,16 +659,24 @@ if (BUILD_TESTING)
                   find . -name '${test_case_name}.c.o' -exec objcopy --redefine-syms libcrypto.symbols {} \\\;
             )
         endif()
-        target_compile_options(${test_case_name} PRIVATE 
-            -Wall -Wimplicit -Wunused -Wcomment -Wchar-subscripts -Wuninitialized 
-            -Wshadow  -Wcast-align -Wwrite-strings -Wformat-security
-            -Wno-deprecated-declarations -Wno-unknown-pragmas -Wno-deprecated -std=gnu99 -Wno-missing-braces
-        )
-        if (UNSAFE_TREAT_WARNINGS_AS_ERRORS)
-            target_compile_options(${test_case_name} PRIVATE -Werror)
-        endif()
-        if (S2N_LTO)
-            target_compile_options(${test_case_name} PRIVATE -flto)
+        # Windows uses different warning flags than GCC/Clang.
+        if (MSVC)
+            target_compile_options(${test_case_name} PRIVATE /W3 /wd4996)
+            if (UNSAFE_TREAT_WARNINGS_AS_ERRORS)
+                target_compile_options(${test_case_name} PRIVATE /WX)
+            endif()
+        else()
+            target_compile_options(${test_case_name} PRIVATE 
+                -Wall -Wimplicit -Wunused -Wcomment -Wchar-subscripts -Wuninitialized 
+                -Wshadow  -Wcast-align -Wwrite-strings -Wformat-security
+                -Wno-deprecated-declarations -Wno-unknown-pragmas -Wno-deprecated -std=gnu99 -Wno-missing-braces
+            )
+            if (UNSAFE_TREAT_WARNINGS_AS_ERRORS)
+                target_compile_options(${test_case_name} PRIVATE -Werror)
+            endif()
+            if (S2N_LTO)
+                target_compile_options(${test_case_name} PRIVATE -flto)
+            endif()
         endif()
 
         add_test(
@@ -619,21 +693,24 @@ if (BUILD_TESTING)
     ######################### build utility binaries ###########################
     ############################################################################
 
-    add_executable(s2nc "bin/s2nc.c" "bin/echo.c" "bin/https.c" "bin/common.c")
-    target_link_libraries(s2nc ${PROJECT_NAME})
-    target_compile_options(s2nc PRIVATE -std=gnu99)
+    # s2nc/s2nd can't be built on Windows yet
+    if (NOT WIN32)
+        add_executable(s2nc "bin/s2nc.c" "bin/echo.c" "bin/https.c" "bin/common.c")
+        target_link_libraries(s2nc ${PROJECT_NAME})
+        target_compile_options(s2nc PRIVATE -std=gnu99)
 
-    add_executable(s2nd "bin/s2nd.c" "bin/echo.c" "bin/https.c" "bin/common.c")
-    target_link_libraries(s2nd ${PROJECT_NAME})
-    target_compile_options(s2nd PRIVATE -std=gnu99)
+        add_executable(s2nd "bin/s2nd.c" "bin/echo.c" "bin/https.c" "bin/common.c")
+        target_link_libraries(s2nd ${PROJECT_NAME})
+        target_compile_options(s2nd PRIVATE -std=gnu99)
 
-    add_executable(policy "bin/policy.c")
-    target_link_libraries(policy ${PROJECT_NAME})
-    target_compile_options(policy PRIVATE -std=gnu99)
+        add_executable(policy "bin/policy.c")
+        target_link_libraries(policy ${PROJECT_NAME})
+        target_compile_options(policy PRIVATE -std=gnu99)
 
-    if(S2N_LTO)
-        target_compile_options(s2nc PRIVATE -flto)
-        target_compile_options(s2nd PRIVATE -flto)
+        if(S2N_LTO)
+            target_compile_options(s2nc PRIVATE -flto)
+            target_compile_options(s2nd PRIVATE -flto)
+        endif()
     endif()
 
     if (S2N_INTEG_TESTS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -588,57 +588,46 @@ if (BUILD_TESTING)
 
     file(GLOB UNITTESTS_SRC "tests/unit/*.c")
     if (WIN32)
-        # On Windows, exclude tests that require fork(), pipe(), kTLS, or other POSIX-only features not yet ported.
-        # This list will be significantly shortened after next refactors.
         set(S2N_WINDOWS_EXCLUDE_TESTS
-            s2n_cleanup_test
-            s2n_client_auth_handshake_test
-            s2n_client_extensions_test
-            s2n_client_hello_recv_test
-            s2n_client_hello_test
-            s2n_client_record_version_test
-            s2n_client_secure_renegotiation_test
-            s2n_connection_test
-            s2n_drain_alert_test
-            s2n_examples_test
-            s2n_fragmentation_coalescing_test
-            s2n_handshake_invariant_test
-            s2n_handshake_test
-            s2n_init_test
-            s2n_io_test
-            s2n_key_update_threads_test
+            # Tests that require kTLS
             s2n_ktls_io_sendfile_test
             s2n_ktls_io_test
             s2n_ktls_test
             s2n_ktls_test_utils_test
+            s2n_self_talk_ktls_test
+
+            # Tests that depend on POSIX socket close behavior: on Windows,
+            # closesocket() abruptly resets the connection and discards unread
+            # data, so the peer sees an I/O error instead of the buffered alert.
+            s2n_drain_alert_test
+
+            # Tests that require seccomp which is only available on Linux
+            s2n_seccomp_failure_test
+
+            # Tests that measure memory via /proc/self/statm and getrlimit() which are not
+            # available on Windows
+            s2n_mem_usage_test
+
+            # Tests that use fork()
+            s2n_examples_test
+            s2n_fragmentation_coalescing_test
+            s2n_handshake_test
+            s2n_init_test
+            s2n_io_test
+            s2n_key_update_threads_test
             s2n_malformed_handshake_test
             s2n_mem_allocator_test
-            s2n_mem_usage_test
-            s2n_policy_writer_test
-            s2n_post_handshake_recv_test
-            s2n_quic_support_test
             s2n_random_test
-            s2n_recv_buffering_test
-            s2n_recv_test
             s2n_release_non_empty_buffers_test
-            s2n_renegotiate_io_test
-            s2n_renegotiate_test
-            s2n_rfc5952_test
-            s2n_seccomp_failure_test
             s2n_self_talk_alerts_test
             s2n_self_talk_broken_pipe_test
             s2n_self_talk_client_hello_cb_test
             s2n_self_talk_custom_io_test
-            s2n_self_talk_io_mem_test
-            s2n_self_talk_ktls_test
             s2n_self_talk_min_protocol_version_test
             s2n_self_talk_nonblocking_test
             s2n_self_talk_session_id_test
             s2n_self_talk_tls12_test
             s2n_self_talk_tls13_test
-            s2n_send_key_update_test
-            s2n_shutdown_test
-            s2n_tls13_zero_length_payload_test
         )
         foreach(excluded ${S2N_WINDOWS_EXCLUDE_TESTS})
             list(REMOVE_ITEM UNITTESTS_SRC
@@ -659,24 +648,16 @@ if (BUILD_TESTING)
                   find . -name '${test_case_name}.c.o' -exec objcopy --redefine-syms libcrypto.symbols {} \\\;
             )
         endif()
-        # Windows uses different warning flags than GCC/Clang.
-        if (MSVC)
-            target_compile_options(${test_case_name} PRIVATE /W3 /wd4996)
-            if (UNSAFE_TREAT_WARNINGS_AS_ERRORS)
-                target_compile_options(${test_case_name} PRIVATE /WX)
-            endif()
-        else()
-            target_compile_options(${test_case_name} PRIVATE 
-                -Wall -Wimplicit -Wunused -Wcomment -Wchar-subscripts -Wuninitialized 
-                -Wshadow  -Wcast-align -Wwrite-strings -Wformat-security
-                -Wno-deprecated-declarations -Wno-unknown-pragmas -Wno-deprecated -std=gnu99 -Wno-missing-braces
-            )
-            if (UNSAFE_TREAT_WARNINGS_AS_ERRORS)
-                target_compile_options(${test_case_name} PRIVATE -Werror)
-            endif()
-            if (S2N_LTO)
-                target_compile_options(${test_case_name} PRIVATE -flto)
-            endif()
+        target_compile_options(${test_case_name} PRIVATE 
+            -Wall -Wimplicit -Wunused -Wcomment -Wchar-subscripts -Wuninitialized 
+            -Wshadow  -Wcast-align -Wwrite-strings -Wformat-security
+            -Wno-deprecated-declarations -Wno-unknown-pragmas -Wno-deprecated -std=gnu99 -Wno-missing-braces
+        )
+        if (UNSAFE_TREAT_WARNINGS_AS_ERRORS)
+            target_compile_options(${test_case_name} PRIVATE -Werror)
+        endif()
+        if (S2N_LTO)
+            target_compile_options(${test_case_name} PRIVATE -flto)
         endif()
 
         add_test(

--- a/docs/examples/s2n_send.c
+++ b/docs/examples/s2n_send.c
@@ -45,6 +45,8 @@ int s2n_example_send(struct s2n_connection *conn, uint8_t *data, size_t data_siz
     return 0;
 }
 
+/* s2n_sendv_with_offset is not part of the public API on Windows. */
+#ifndef _WIN32
 int s2n_example_sendv(struct s2n_connection *conn, uint8_t *data, size_t data_size)
 {
     struct iovec iov[1] = { 0 };
@@ -64,3 +66,4 @@ int s2n_example_sendv(struct s2n_connection *conn, uint8_t *data, size_t data_si
     }
     return 0;
 }
+#endif

--- a/error/s2n_errno.c
+++ b/error/s2n_errno.c
@@ -508,8 +508,9 @@ int s2n_get_stacktrace(struct s2n_stacktrace *trace)
     S2N_ERROR(S2N_ERR_UNIMPLEMENTED);
 }
 
+/* No-op on platforms without execinfo. Callers expect this to succeed without overwriting s2n_errno. */
 int s2n_print_stacktrace(FILE *fptr)
 {
-    S2N_ERROR(S2N_ERR_UNIMPLEMENTED);
+    return S2N_SUCCESS;
 }
 #endif /* S2N_STACKTRACE */

--- a/tests/s2n_test.h
+++ b/tests/s2n_test.h
@@ -117,12 +117,7 @@ bool s2n_use_color_in_output = true;
 #define FAIL_MSG_PRINT( msg ) do { \
                           /* isatty and s2n_print_stacktrace will overwrite errno on failure */ \
                           int real_errno = errno; \
-                          /* s2n_print_stacktrace overwrites s2n_errno with S2N_ERR_UNIMPLEMENTED \
-                           * on platforms where stacktraces are not supported (e.g. Windows). \
-                           * Save and restore so the error message reports the actual failure. */ \
-                          int real_s2n_errno = s2n_errno; \
                           s2n_print_stacktrace(stderr); \
-                          s2n_errno = real_s2n_errno; \
                           if (s2n_use_color_in_output && isatty(fileno(stderr))) { \
                             errno = real_errno; \
                             fprintf(stderr, "\033[31;1mFAILED test %d\033[0m\n%s (%s:%d)\nError Message: '%s'\n Debug String: '%s'\n System Error: %s (%d)\n", test_count, (msg), __FILE__, __LINE__, s2n_strerror(s2n_errno, "EN"), s2n_strerror_debug(s2n_errno, "EN"), strerror(errno), errno); \

--- a/tests/s2n_test.h
+++ b/tests/s2n_test.h
@@ -19,7 +19,18 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <unistd.h>
+#ifdef _WIN32
+    #include <io.h>
+    #define setenv(name, value, overwrite) _putenv_s(name, value)
+    #define unsetenv(name) _putenv_s(name, "")
+    #ifdef _MSC_VER
+        /* MSVC prefixes POSIX-like functions with underscores. */
+        #define isatty _isatty
+        #define fileno _fileno
+    #endif
+#else
+    #include <unistd.h>
+#endif
 
 #include "error/s2n_errno.h"
 #include "tls/s2n_alerts.h"
@@ -106,7 +117,12 @@ bool s2n_use_color_in_output = true;
 #define FAIL_MSG_PRINT( msg ) do { \
                           /* isatty and s2n_print_stacktrace will overwrite errno on failure */ \
                           int real_errno = errno; \
+                          /* s2n_print_stacktrace overwrites s2n_errno with S2N_ERR_UNIMPLEMENTED \
+                           * on platforms where stacktraces are not supported (e.g. Windows). \
+                           * Save and restore so the error message reports the actual failure. */ \
+                          int real_s2n_errno = s2n_errno; \
                           s2n_print_stacktrace(stderr); \
+                          s2n_errno = real_s2n_errno; \
                           if (s2n_use_color_in_output && isatty(fileno(stderr))) { \
                             errno = real_errno; \
                             fprintf(stderr, "\033[31;1mFAILED test %d\033[0m\n%s (%s:%d)\nError Message: '%s'\n Debug String: '%s'\n System Error: %s (%d)\n", test_count, (msg), __FILE__, __LINE__, s2n_strerror(s2n_errno, "EN"), s2n_strerror_debug(s2n_errno, "EN"), strerror(errno), errno); \

--- a/tests/testlib/s2n_connection_test_utils.c
+++ b/tests/testlib/s2n_connection_test_utils.c
@@ -15,23 +15,41 @@
 
 #include <fcntl.h>
 #include <stdio.h>
-#include <sys/socket.h>
+#ifdef _WIN32
+    #define WIN32_LEAN_AND_MEAN
+    #include <winsock2.h>
+    #include <ws2tcpip.h>
+#else
+    #include <sys/socket.h>
+    #include <unistd.h>
+#endif
 #include <sys/types.h>
-#include <unistd.h>
 
 #include "testlib/s2n_testlib.h"
 #include "tls/s2n_connection.h"
 #include "utils/s2n_safety.h"
-#include "utils/s2n_socket.h"
+#ifndef _WIN32
+    #include "utils/s2n_socket.h"
+#endif
 
 int s2n_fd_set_blocking(int fd)
 {
+#ifdef _WIN32
+    u_long mode = 0;
+    return ioctlsocket(fd, FIONBIO, &mode);
+#else
     return fcntl(fd, F_SETFL, fcntl(fd, F_GETFL) & ~O_NONBLOCK);
+#endif
 }
 
 int s2n_fd_set_non_blocking(int fd)
 {
+#ifdef _WIN32
+    u_long mode = 1;
+    return ioctlsocket(fd, FIONBIO, &mode);
+#else
     return fcntl(fd, F_SETFL, fcntl(fd, F_GETFL) | O_NONBLOCK);
+#endif
 }
 
 static int buffer_read(void *io_context, uint8_t *buf, uint32_t len)
@@ -137,6 +155,36 @@ S2N_RESULT s2n_connections_set_io_stuffer_pair(struct s2n_connection *client, st
 
 int s2n_io_pair_init(struct s2n_test_io_pair *io_pair)
 {
+#ifdef _WIN32
+    /* Winsock requires initialization before any socket call. */
+    WSADATA wsa_data = { 0 };
+    int wsa_rc = WSAStartup(MAKEWORD(2, 2), &wsa_data);
+    POSIX_ENSURE(wsa_rc == 0, S2N_ERR_IO);
+
+    /* Windows doesn't have socketpair. Emulate with TCP loopback. */
+    int listener = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
+    POSIX_ENSURE(listener >= 0, S2N_ERR_IO);
+
+    struct sockaddr_in addr = { 0 };
+    addr.sin_family = AF_INET;
+    addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    addr.sin_port = 0;
+
+    POSIX_ENSURE(bind(listener, (struct sockaddr *) &addr, sizeof(addr)) == 0, S2N_ERR_IO);
+    POSIX_ENSURE(listen(listener, 1) == 0, S2N_ERR_IO);
+
+    int addrlen = sizeof(addr);
+    POSIX_ENSURE(getsockname(listener, (struct sockaddr *) &addr, &addrlen) == 0, S2N_ERR_IO);
+
+    io_pair->client = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
+    POSIX_ENSURE(io_pair->client >= 0, S2N_ERR_IO);
+    POSIX_ENSURE(connect(io_pair->client, (struct sockaddr *) &addr, sizeof(addr)) == 0, S2N_ERR_IO);
+
+    io_pair->server = accept(listener, NULL, NULL);
+    POSIX_ENSURE(io_pair->server >= 0, S2N_ERR_IO);
+
+    closesocket(listener);
+#else
     signal(SIGPIPE, SIG_IGN);
 
     int socket_pair[2];
@@ -145,6 +193,7 @@ int s2n_io_pair_init(struct s2n_test_io_pair *io_pair)
 
     io_pair->client = socket_pair[0];
     io_pair->server = socket_pair[1];
+#endif
 
     return 0;
 }
@@ -159,13 +208,63 @@ int s2n_io_pair_init_non_blocking(struct s2n_test_io_pair *io_pair)
     return 0;
 }
 
+#ifdef _WIN32
+/* On Windows, the s2n library does not provide built-in socket I/O.
+ * Tests use these custom I/O callbacks that wrap Winsock recv/send.
+ * The socket fd is passed directly as the io_context pointer via uintptr_t cast.
+ */
+static int s2n_test_recv_cb(void *io_context, uint8_t *buf, uint32_t len)
+{
+    int fd = (int) (uintptr_t) io_context;
+
+    int result = recv(fd, (char *) buf, len, 0);
+    if (result < 0) {
+        int wsa_err = WSAGetLastError();
+        if (wsa_err == WSAEWOULDBLOCK) {
+            errno = EAGAIN;
+        } else {
+            errno = EIO;
+        }
+    }
+    return result;
+}
+
+static int s2n_test_send_cb(void *io_context, const uint8_t *buf, uint32_t len)
+{
+    int fd = (int) (uintptr_t) io_context;
+
+    int result = send(fd, (const char *) buf, len, 0);
+    if (result < 0) {
+        int wsa_err = WSAGetLastError();
+        if (wsa_err == WSAEWOULDBLOCK) {
+            errno = EAGAIN;
+        } else {
+            errno = EIO;
+        }
+    }
+    return result;
+}
+#endif
+
 int s2n_connection_set_io_pair(struct s2n_connection *conn, struct s2n_test_io_pair *io_pair)
 {
+    int fd = 0;
     if (conn->mode == S2N_CLIENT) {
-        POSIX_GUARD(s2n_connection_set_fd(conn, io_pair->client));
+        fd = io_pair->client;
     } else if (conn->mode == S2N_SERVER) {
-        POSIX_GUARD(s2n_connection_set_fd(conn, io_pair->server));
+        fd = io_pair->server;
+    } else {
+        POSIX_BAIL(S2N_ERR_INVALID_STATE);
     }
+
+#ifdef _WIN32
+    POSIX_GUARD(s2n_connection_set_recv_cb(conn, s2n_test_recv_cb));
+    POSIX_GUARD(s2n_connection_set_send_cb(conn, s2n_test_send_cb));
+    POSIX_GUARD(s2n_connection_set_recv_ctx(conn, (void *) (uintptr_t) fd));
+    POSIX_GUARD(s2n_connection_set_send_ctx(conn, (void *) (uintptr_t) fd));
+#else
+    POSIX_GUARD(s2n_connection_set_fd(conn, fd));
+#endif
 
     return 0;
 }
@@ -182,16 +281,27 @@ int s2n_io_pair_close(struct s2n_test_io_pair *io_pair)
 {
     POSIX_GUARD(s2n_io_pair_close_one_end(io_pair, S2N_CLIENT));
     POSIX_GUARD(s2n_io_pair_close_one_end(io_pair, S2N_SERVER));
+#ifdef _WIN32
+    WSACleanup();
+#endif
     return 0;
 }
 
 int s2n_io_pair_close_one_end(struct s2n_test_io_pair *io_pair, int mode_to_close)
 {
     if (mode_to_close == S2N_CLIENT && io_pair->client != S2N_CLOSED_FD) {
+#ifdef _WIN32
+        POSIX_GUARD(closesocket(io_pair->client));
+#else
         POSIX_GUARD(close(io_pair->client));
+#endif
         io_pair->client = S2N_CLOSED_FD;
     } else if (mode_to_close == S2N_SERVER && io_pair->server != S2N_CLOSED_FD) {
+#ifdef _WIN32
+        POSIX_GUARD(closesocket(io_pair->server));
+#else
         POSIX_GUARD(close(io_pair->server));
+#endif
         io_pair->server = S2N_CLOSED_FD;
     }
     return 0;

--- a/tests/testlib/s2n_ktls_test_utils.c
+++ b/tests/testlib/s2n_ktls_test_utils.c
@@ -13,7 +13,12 @@
  * permissions and limitations under the License.
  */
 
-#include "testlib/s2n_ktls_test_utils.h"
+/* kTLS is not supported on Windows. This file compiles to an empty
+ * translation unit on Windows.
+ */
+#ifndef _WIN32
+
+    #include "testlib/s2n_ktls_test_utils.h"
 
 S2N_RESULT s2n_ktls_set_control_data(struct msghdr *msg, char *buf, size_t buf_size,
         int cmsg_type, uint8_t record_type);
@@ -247,3 +252,5 @@ S2N_RESULT s2n_test_records_in_ancillary(struct s2n_test_ktls_io_stuffer *ktls_i
     RESULT_ENSURE_EQ(extra, 0);
     return S2N_RESULT_OK;
 }
+
+#endif

--- a/tests/testlib/s2n_testlib.h
+++ b/tests/testlib/s2n_testlib.h
@@ -64,6 +64,19 @@ int s2n_connections_set_io_pair(struct s2n_connection *client, struct s2n_connec
 int s2n_fd_set_blocking(int fd);
 int s2n_fd_set_non_blocking(int fd);
 
+/* On Windows, POSIX write()/read() don't work on sockets.
+ * Use these macros when writing/reading raw bytes to/from socket fds in tests.
+ */
+#ifdef _WIN32
+    #define WIN32_LEAN_AND_MEAN
+    #include <winsock2.h>
+    #define s2n_test_send(fd, buf, len) send(fd, (const char *) (buf), len, 0)
+    #define s2n_test_recv(fd, buf, len) recv(fd, (char *) (buf), len, 0)
+#else
+    #define s2n_test_send(fd, buf, len) write(fd, buf, len)
+    #define s2n_test_recv(fd, buf, len) read(fd, buf, len)
+#endif
+
 int s2n_set_connection_hello_retry_flags(struct s2n_connection *conn);
 int s2n_connection_mark_extension_received(struct s2n_connection *conn, uint16_t iana_value);
 int s2n_connection_allow_response_extension(struct s2n_connection *conn, uint16_t iana_value);

--- a/tests/unit/s2n_cleanup_test.c
+++ b/tests/unit/s2n_cleanup_test.c
@@ -14,7 +14,6 @@
  */
 
 #include <stdbool.h>
-#include <sys/wait.h>
 
 #include "api/s2n.h"
 #include "s2n_test.h"

--- a/tests/unit/s2n_client_extensions_test.c
+++ b/tests/unit/s2n_client_extensions_test.c
@@ -16,7 +16,6 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <stdint.h>
-#include <sys/wait.h>
 #include <unistd.h>
 
 #include "api/s2n.h"
@@ -283,10 +282,10 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_connection_set_config(server_conn, server_config));
 
         /* Send the client hello */
-        EXPECT_EQUAL(write(io_pair.client, record_header, sizeof(record_header)), sizeof(record_header));
-        EXPECT_EQUAL(write(io_pair.client, message_header, sizeof(message_header)), sizeof(message_header));
-        EXPECT_EQUAL(write(io_pair.client, client_hello_message, sizeof(client_hello_message)), sizeof(client_hello_message));
-        EXPECT_EQUAL(write(io_pair.client, client_extensions, sizeof(client_extensions)), sizeof(client_extensions));
+        EXPECT_EQUAL(s2n_test_send(io_pair.client, record_header, sizeof(record_header)), sizeof(record_header));
+        EXPECT_EQUAL(s2n_test_send(io_pair.client, message_header, sizeof(message_header)), sizeof(message_header));
+        EXPECT_EQUAL(s2n_test_send(io_pair.client, client_hello_message, sizeof(client_hello_message)), sizeof(client_hello_message));
+        EXPECT_EQUAL(s2n_test_send(io_pair.client, client_extensions, sizeof(client_extensions)), sizeof(client_extensions));
 
         /* Verify that the CLIENT HELLO is accepted */
         s2n_negotiate(server_conn, &server_blocked);
@@ -427,10 +426,10 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_connection_set_config(server_conn, server_config));
 
         /* Send the client hello */
-        EXPECT_EQUAL(write(io_pair.client, record_header, sizeof(record_header)), sizeof(record_header));
-        EXPECT_EQUAL(write(io_pair.client, message_header, sizeof(message_header)), sizeof(message_header));
-        EXPECT_EQUAL(write(io_pair.client, client_hello_message, sizeof(client_hello_message)), sizeof(client_hello_message));
-        EXPECT_EQUAL(write(io_pair.client, client_extensions, sizeof(client_extensions)), sizeof(client_extensions));
+        EXPECT_EQUAL(s2n_test_send(io_pair.client, record_header, sizeof(record_header)), sizeof(record_header));
+        EXPECT_EQUAL(s2n_test_send(io_pair.client, message_header, sizeof(message_header)), sizeof(message_header));
+        EXPECT_EQUAL(s2n_test_send(io_pair.client, client_hello_message, sizeof(client_hello_message)), sizeof(client_hello_message));
+        EXPECT_EQUAL(s2n_test_send(io_pair.client, client_extensions, sizeof(client_extensions)), sizeof(client_extensions));
 
         /* Verify that we fail for duplicated extension type Bad Message */
         EXPECT_SUCCESS(s2n_connection_set_blinding(server_conn, S2N_SELF_SERVICE_BLINDING));
@@ -521,10 +520,10 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_connection_set_config(server_conn, server_config));
 
         /* Send the client hello */
-        EXPECT_EQUAL(write(io_pair.client, record_header, sizeof(record_header)), sizeof(record_header));
-        EXPECT_EQUAL(write(io_pair.client, message_header, sizeof(message_header)), sizeof(message_header));
-        EXPECT_EQUAL(write(io_pair.client, client_hello_message, sizeof(client_hello_message)), sizeof(client_hello_message));
-        EXPECT_EQUAL(write(io_pair.client, client_extensions, sizeof(client_extensions)), sizeof(client_extensions));
+        EXPECT_EQUAL(s2n_test_send(io_pair.client, record_header, sizeof(record_header)), sizeof(record_header));
+        EXPECT_EQUAL(s2n_test_send(io_pair.client, message_header, sizeof(message_header)), sizeof(message_header));
+        EXPECT_EQUAL(s2n_test_send(io_pair.client, client_hello_message, sizeof(client_hello_message)), sizeof(client_hello_message));
+        EXPECT_EQUAL(s2n_test_send(io_pair.client, client_extensions, sizeof(client_extensions)), sizeof(client_extensions));
 
         /* Verify that the CLIENT HELLO is accepted */
         s2n_negotiate(server_conn, &server_blocked);
@@ -623,10 +622,10 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_connection_set_config(server_conn, server_config));
 
         /* Send the client hello */
-        EXPECT_EQUAL(write(io_pair.client, record_header, sizeof(record_header)), sizeof(record_header));
-        EXPECT_EQUAL(write(io_pair.client, message_header, sizeof(message_header)), sizeof(message_header));
-        EXPECT_EQUAL(write(io_pair.client, client_hello_message, sizeof(client_hello_message)), sizeof(client_hello_message));
-        EXPECT_EQUAL(write(io_pair.client, client_extensions, sizeof(client_extensions)), sizeof(client_extensions));
+        EXPECT_EQUAL(s2n_test_send(io_pair.client, record_header, sizeof(record_header)), sizeof(record_header));
+        EXPECT_EQUAL(s2n_test_send(io_pair.client, message_header, sizeof(message_header)), sizeof(message_header));
+        EXPECT_EQUAL(s2n_test_send(io_pair.client, client_hello_message, sizeof(client_hello_message)), sizeof(client_hello_message));
+        EXPECT_EQUAL(s2n_test_send(io_pair.client, client_extensions, sizeof(client_extensions)), sizeof(client_extensions));
 
         /* Verify that we fail for non-empty renegotiated_connection */
         EXPECT_SUCCESS(s2n_connection_set_blinding(server_conn, S2N_SELF_SERVICE_BLINDING));
@@ -638,7 +637,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_config_free(server_config));
 
         /* Clear pipe since negotiation failed mid-handshake */
-        EXPECT_SUCCESS(read(io_pair.client, buf, sizeof(buf)));
+        EXPECT_SUCCESS(s2n_test_recv(io_pair.client, buf, sizeof(buf)));
     };
 
     /* Client doesn't use the OCSP extension. */

--- a/tests/unit/s2n_client_hello_recv_test.c
+++ b/tests/unit/s2n_client_hello_recv_test.c
@@ -16,7 +16,6 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <stdint.h>
-#include <sys/wait.h>
 #include <unistd.h>
 
 #include "api/s2n.h"

--- a/tests/unit/s2n_client_hello_test.c
+++ b/tests/unit/s2n_client_hello_test.c
@@ -18,7 +18,6 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <stdint.h>
-#include <sys/wait.h>
 #include <unistd.h>
 
 #include "api/s2n.h"
@@ -869,8 +868,8 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_config_set_cipher_preferences(server_config, "20170210"));
 
         /* Send the client hello message */
-        EXPECT_EQUAL(write(io_pair.client, sslv2_client_hello_header, sslv2_client_hello_header_len), sslv2_client_hello_header_len);
-        EXPECT_EQUAL(write(io_pair.client, sslv2_client_hello, sslv2_client_hello_len), sslv2_client_hello_len);
+        EXPECT_EQUAL(s2n_test_send(io_pair.client, sslv2_client_hello_header, sslv2_client_hello_header_len), sslv2_client_hello_header_len);
+        EXPECT_EQUAL(s2n_test_send(io_pair.client, sslv2_client_hello, sslv2_client_hello_len), sslv2_client_hello_len);
 
         /* Verify that the sent client hello message is accepted */
         s2n_negotiate(server_conn, &server_blocked);
@@ -1073,9 +1072,9 @@ int main(int argc, char **argv)
         ext_data = NULL;
 
         /* Send the client hello message */
-        EXPECT_EQUAL(write(io_pair.client, record_header, sizeof(record_header)), sizeof(record_header));
-        EXPECT_EQUAL(write(io_pair.client, message_header, sizeof(message_header)), sizeof(message_header));
-        EXPECT_EQUAL(write(io_pair.client, sent_client_hello, sent_client_hello_len), sent_client_hello_len);
+        EXPECT_EQUAL(s2n_test_send(io_pair.client, record_header, sizeof(record_header)), sizeof(record_header));
+        EXPECT_EQUAL(s2n_test_send(io_pair.client, message_header, sizeof(message_header)), sizeof(message_header));
+        EXPECT_EQUAL(s2n_test_send(io_pair.client, sent_client_hello, sent_client_hello_len), sent_client_hello_len);
 
         /* Verify that the sent client hello message is accepted */
         s2n_negotiate(server_conn, &server_blocked);
@@ -1279,9 +1278,9 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_connection_set_config(server_conn, server_config));
 
         /* Re-send the client hello message */
-        EXPECT_EQUAL(write(io_pair.client, record_header, sizeof(record_header)), sizeof(record_header));
-        EXPECT_EQUAL(write(io_pair.client, message_header, sizeof(message_header)), sizeof(message_header));
-        EXPECT_EQUAL(write(io_pair.client, sent_client_hello, sent_client_hello_len), sent_client_hello_len);
+        EXPECT_EQUAL(s2n_test_send(io_pair.client, record_header, sizeof(record_header)), sizeof(record_header));
+        EXPECT_EQUAL(s2n_test_send(io_pair.client, message_header, sizeof(message_header)), sizeof(message_header));
+        EXPECT_EQUAL(s2n_test_send(io_pair.client, sent_client_hello, sent_client_hello_len), sent_client_hello_len);
 
         /* Verify that the sent client hello message is accepted */
         s2n_negotiate(server_conn, &server_blocked);
@@ -1418,9 +1417,9 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_connection_set_config(server_conn, server_config));
 
         /* Send the client hello message */
-        EXPECT_EQUAL(write(io_pair.client, record_header, sizeof(record_header)), sizeof(record_header));
-        EXPECT_EQUAL(write(io_pair.client, message_header, sizeof(message_header)), sizeof(message_header));
-        EXPECT_EQUAL(write(io_pair.client, sent_client_hello, sent_client_hello_len), sent_client_hello_len);
+        EXPECT_EQUAL(s2n_test_send(io_pair.client, record_header, sizeof(record_header)), sizeof(record_header));
+        EXPECT_EQUAL(s2n_test_send(io_pair.client, message_header, sizeof(message_header)), sizeof(message_header));
+        EXPECT_EQUAL(s2n_test_send(io_pair.client, sent_client_hello, sent_client_hello_len), sent_client_hello_len);
 
         /* Verify that the sent client hello message is accepted */
         s2n_negotiate(server_conn, &server_blocked);

--- a/tests/unit/s2n_client_record_version_test.c
+++ b/tests/unit/s2n_client_record_version_test.c
@@ -16,7 +16,6 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <stdint.h>
-#include <sys/wait.h>
 #include <unistd.h>
 
 #include "api/s2n.h"
@@ -106,7 +105,7 @@ int main(int argc, char **argv)
 
         /* we need only first 10 bytes to get to ClientHello protocol version */
         while (buf_occupied < 10) {
-            ssize_t n = read(io_pair.server, buf + buf_occupied, sizeof(buf) - buf_occupied);
+            ssize_t n = s2n_test_recv(io_pair.server, buf + buf_occupied, sizeof(buf) - buf_occupied);
 
             /* We should be able to read 10 bytes without blocking */
             EXPECT_TRUE(n > 0);
@@ -125,7 +124,7 @@ int main(int argc, char **argv)
 
         /* Read the rest of the pipe */
         while (1) {
-            ssize_t n = read(io_pair.server, buf, sizeof(buf));
+            ssize_t n = s2n_test_recv(io_pair.server, buf, sizeof(buf));
 
             if (n > 0) {
                 continue;
@@ -138,9 +137,9 @@ int main(int argc, char **argv)
         }
 
         /* Write the server hello */
-        EXPECT_EQUAL(write(io_pair.server, record_header, sizeof(record_header)), sizeof(record_header));
-        EXPECT_EQUAL(write(io_pair.server, message_header, sizeof(message_header)), sizeof(message_header));
-        EXPECT_EQUAL(write(io_pair.server, server_hello_message, sizeof(server_hello_message)), sizeof(server_hello_message));
+        EXPECT_EQUAL(s2n_test_send(io_pair.server, record_header, sizeof(record_header)), sizeof(record_header));
+        EXPECT_EQUAL(s2n_test_send(io_pair.server, message_header, sizeof(message_header)), sizeof(message_header));
+        EXPECT_EQUAL(s2n_test_send(io_pair.server, server_hello_message, sizeof(server_hello_message)), sizeof(server_hello_message));
 
         /* Verify that we proceed with handshake */
         EXPECT_EQUAL(s2n_negotiate(client_conn, &client_blocked), -1);
@@ -159,7 +158,7 @@ int main(int argc, char **argv)
         buf_occupied = 0;
         /* We need only first 5 bytes to get to record protocol version */
         while (buf_occupied < 5) {
-            ssize_t n = read(io_pair.server, buf + buf_occupied, sizeof(buf) - buf_occupied);
+            ssize_t n = s2n_test_recv(io_pair.server, buf + buf_occupied, sizeof(buf) - buf_occupied);
 
             /* We should be able to read 5 bytes without blocking */
             EXPECT_TRUE(n > 0);
@@ -240,7 +239,7 @@ int main(int argc, char **argv)
 
         /* we need only first 10 bytes to get to ClientHello protocol version */
         while (buf_occupied < 10) {
-            ssize_t n = read(io_pair.server, buf + buf_occupied, sizeof(buf) - buf_occupied);
+            ssize_t n = s2n_test_recv(io_pair.server, buf + buf_occupied, sizeof(buf) - buf_occupied);
 
             /* We should be able to read 10 bytes without blocking */
             EXPECT_TRUE(n > 0);
@@ -259,7 +258,7 @@ int main(int argc, char **argv)
 
         /* Read the rest of the pipe */
         while (1) {
-            ssize_t n = read(io_pair.server, buf, sizeof(buf));
+            ssize_t n = s2n_test_recv(io_pair.server, buf, sizeof(buf));
 
             if (n > 0) {
                 continue;
@@ -272,9 +271,9 @@ int main(int argc, char **argv)
         }
 
         /* Write the server hello */
-        EXPECT_EQUAL(write(io_pair.server, record_header, sizeof(record_header)), sizeof(record_header));
-        EXPECT_EQUAL(write(io_pair.server, message_header, sizeof(message_header)), sizeof(message_header));
-        EXPECT_EQUAL(write(io_pair.server, server_hello_message, sizeof(server_hello_message)), sizeof(server_hello_message));
+        EXPECT_EQUAL(s2n_test_send(io_pair.server, record_header, sizeof(record_header)), sizeof(record_header));
+        EXPECT_EQUAL(s2n_test_send(io_pair.server, message_header, sizeof(message_header)), sizeof(message_header));
+        EXPECT_EQUAL(s2n_test_send(io_pair.server, server_hello_message, sizeof(server_hello_message)), sizeof(server_hello_message));
 
         /* Verify that we proceed with handshake */
         EXPECT_EQUAL(s2n_negotiate(client_conn, &client_blocked), -1);
@@ -293,7 +292,7 @@ int main(int argc, char **argv)
         buf_occupied = 0;
         /* We need only first 5 bytes to get to record protocol version */
         while (buf_occupied < 5) {
-            ssize_t n = read(io_pair.server, buf + buf_occupied, sizeof(buf) - buf_occupied);
+            ssize_t n = s2n_test_recv(io_pair.server, buf + buf_occupied, sizeof(buf) - buf_occupied);
 
             /* We should be able to read 5 bytes without blocking */
             EXPECT_TRUE(n > 0);

--- a/tests/unit/s2n_client_secure_renegotiation_test.c
+++ b/tests/unit/s2n_client_secure_renegotiation_test.c
@@ -16,7 +16,6 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <stdint.h>
-#include <sys/wait.h>
 #include <unistd.h>
 
 #include "api/s2n.h"
@@ -116,10 +115,10 @@ int main(int argc, char **argv)
         EXPECT_EQUAL(client_blocked, S2N_BLOCKED_ON_READ);
 
         /* Write the server hello */
-        EXPECT_EQUAL(write(io_pair.server, record_header, sizeof(record_header)), sizeof(record_header));
-        EXPECT_EQUAL(write(io_pair.server, message_header, sizeof(message_header)), sizeof(message_header));
-        EXPECT_EQUAL(write(io_pair.server, server_hello_message, sizeof(server_hello_message)), sizeof(server_hello_message));
-        EXPECT_EQUAL(write(io_pair.server, server_extensions, sizeof(server_extensions)), sizeof(server_extensions));
+        EXPECT_EQUAL(s2n_test_send(io_pair.server, record_header, sizeof(record_header)), sizeof(record_header));
+        EXPECT_EQUAL(s2n_test_send(io_pair.server, message_header, sizeof(message_header)), sizeof(message_header));
+        EXPECT_EQUAL(s2n_test_send(io_pair.server, server_hello_message, sizeof(server_hello_message)), sizeof(server_hello_message));
+        EXPECT_EQUAL(s2n_test_send(io_pair.server, server_extensions, sizeof(server_extensions)), sizeof(server_extensions));
 
         /* Verify that we proceed with handshake */
         EXPECT_EQUAL(s2n_negotiate(client_conn, &client_blocked), -1);
@@ -195,9 +194,9 @@ int main(int argc, char **argv)
         EXPECT_EQUAL(client_blocked, S2N_BLOCKED_ON_READ);
 
         /* Write the server hello */
-        EXPECT_EQUAL(write(io_pair.server, record_header, sizeof(record_header)), sizeof(record_header));
-        EXPECT_EQUAL(write(io_pair.server, message_header, sizeof(message_header)), sizeof(message_header));
-        EXPECT_EQUAL(write(io_pair.server, server_hello_message, sizeof(server_hello_message)), sizeof(server_hello_message));
+        EXPECT_EQUAL(s2n_test_send(io_pair.server, record_header, sizeof(record_header)), sizeof(record_header));
+        EXPECT_EQUAL(s2n_test_send(io_pair.server, message_header, sizeof(message_header)), sizeof(message_header));
+        EXPECT_EQUAL(s2n_test_send(io_pair.server, server_hello_message, sizeof(server_hello_message)), sizeof(server_hello_message));
 
         /* Verify that we proceed with handshake */
         EXPECT_EQUAL(s2n_negotiate(client_conn, &client_blocked), -1);
@@ -288,10 +287,10 @@ int main(int argc, char **argv)
         EXPECT_EQUAL(client_blocked, S2N_BLOCKED_ON_READ);
 
         /* Write the server hello */
-        EXPECT_EQUAL(write(io_pair.server, record_header, sizeof(record_header)), sizeof(record_header));
-        EXPECT_EQUAL(write(io_pair.server, message_header, sizeof(message_header)), sizeof(message_header));
-        EXPECT_EQUAL(write(io_pair.server, server_hello_message, sizeof(server_hello_message)), sizeof(server_hello_message));
-        EXPECT_EQUAL(write(io_pair.server, server_extensions, sizeof(server_extensions)), sizeof(server_extensions));
+        EXPECT_EQUAL(s2n_test_send(io_pair.server, record_header, sizeof(record_header)), sizeof(record_header));
+        EXPECT_EQUAL(s2n_test_send(io_pair.server, message_header, sizeof(message_header)), sizeof(message_header));
+        EXPECT_EQUAL(s2n_test_send(io_pair.server, server_hello_message, sizeof(server_hello_message)), sizeof(server_hello_message));
+        EXPECT_EQUAL(s2n_test_send(io_pair.server, server_extensions, sizeof(server_extensions)), sizeof(server_extensions));
 
         /* Verify that we fail for non-empty renegotiated_connection */
         EXPECT_SUCCESS(s2n_connection_set_blinding(client_conn, S2N_SELF_SERVICE_BLINDING));

--- a/tests/unit/s2n_connection_test.c
+++ b/tests/unit/s2n_connection_test.c
@@ -15,7 +15,9 @@
 
 #include "tls/s2n_connection.h"
 
-#include "api/unstable/ktls.h"
+#ifndef _WIN32
+    #include "api/unstable/ktls.h"
+#endif
 #include "crypto/s2n_hash.h"
 #include "s2n_test.h"
 #include "testlib/s2n_testlib.h"
@@ -23,7 +25,6 @@
 #include "tls/extensions/s2n_extension_list.h"
 #include "tls/s2n_internal.h"
 #include "tls/s2n_tls.h"
-#include "utils/s2n_socket.h"
 
 const uint8_t actual_version = 1, client_version = 2, server_version = 3;
 static int s2n_set_test_protocol_versions(struct s2n_connection *conn)
@@ -479,6 +480,10 @@ int main(int argc, char **argv)
     };
 
     /* s2n_connection set fd functionality */
+    /* s2n_connection_set_fd, s2n_connection_set_read_fd, and s2n_connection_set_write_fd
+     * are not available on Windows (defined in utils/s2n_socket.c, gated behind #ifndef _WIN32).
+     */
+#ifndef _WIN32
     {
         static const int READFD = 1;
         static const int WRITEFD = 2;
@@ -614,6 +619,7 @@ int main(int argc, char **argv)
 
         EXPECT_SUCCESS(s2n_connection_free(conn));
     };
+#endif
 
     /* Test s2n_connection_get_config */
     {
@@ -933,6 +939,10 @@ int main(int argc, char **argv)
     };
 
     /* Test s2n_connection_get_key_update_counts */
+    /* s2n_connection_get_key_update_counts is declared in api/unstable/ktls.h,
+     * which is not available on Windows.
+     */
+#ifndef _WIN32
     {
         /* Safety */
         DEFER_CLEANUP(struct s2n_connection *conn = s2n_connection_new(S2N_CLIENT),
@@ -958,6 +968,7 @@ int main(int argc, char **argv)
         EXPECT_EQUAL(send_count, expected_send_count);
         EXPECT_EQUAL(recv_count, expected_recv_count);
     }
+#endif
 
     /* Test s2n_connection_get_client_auth_type */
     {

--- a/tests/unit/s2n_drain_alert_test.c
+++ b/tests/unit/s2n_drain_alert_test.c
@@ -113,12 +113,12 @@ int main(int argc, char **argv)
     EXPECT_SUCCESS(s2n_connection_set_config(server_conn, server_config));
 
     /* Send the client hello */
-    EXPECT_EQUAL(write(io_pair.client, record_header, sizeof(record_header)), sizeof(record_header));
-    EXPECT_EQUAL(write(io_pair.client, message_header, sizeof(message_header)), sizeof(message_header));
-    EXPECT_EQUAL(write(io_pair.client, client_hello_message, sizeof(client_hello_message)), sizeof(client_hello_message));
+    EXPECT_EQUAL(s2n_test_send(io_pair.client, record_header, sizeof(record_header)), sizeof(record_header));
+    EXPECT_EQUAL(s2n_test_send(io_pair.client, message_header, sizeof(message_header)), sizeof(message_header));
+    EXPECT_EQUAL(s2n_test_send(io_pair.client, client_hello_message, sizeof(client_hello_message)), sizeof(client_hello_message));
 
     /* Send an alert from client to server */
-    EXPECT_EQUAL(write(io_pair.client, alert_record, sizeof(alert_record)), sizeof(alert_record));
+    EXPECT_EQUAL(s2n_test_send(io_pair.client, alert_record, sizeof(alert_record)), sizeof(alert_record));
 
     /* Close the client read/write end */
     EXPECT_SUCCESS(s2n_io_pair_close_one_end(&io_pair, S2N_CLIENT));

--- a/tests/unit/s2n_key_update_test.c
+++ b/tests/unit/s2n_key_update_test.c
@@ -149,6 +149,7 @@ int main(int argc, char **argv)
         };
 
         /* Key update messages not allowed with ktls by default */
+#ifndef _WIN32
         {
             DEFER_CLEANUP(struct s2n_stuffer input, s2n_stuffer_free);
             EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&input, 0));
@@ -189,6 +190,7 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_key_update_recv(conn, &input));
             EXPECT_EQUAL(s2n_stuffer_data_available(&input), 0);
         };
+#endif
 
         /* Key update message received contains invalid key update request */
         {
@@ -510,6 +512,7 @@ int main(int argc, char **argv)
         };
 
         /* KeyUpdate fails if ktls */
+#ifndef _WIN32
         {
             DEFER_CLEANUP(struct s2n_connection *conn = s2n_connection_new(S2N_CLIENT),
                     s2n_connection_ptr_free);
@@ -532,6 +535,7 @@ int main(int argc, char **argv)
                     S2N_ERR_KTLS_KEYUPDATE);
             EXPECT_TRUE(s2n_atomic_flag_test(&conn->key_update_pending));
         };
+#endif
     };
 
     /* s2n_check_record_limit */

--- a/tests/unit/s2n_policy_writer_test.c
+++ b/tests/unit/s2n_policy_writer_test.c
@@ -227,7 +227,12 @@ int main(int argc, char **argv)
                     S2N_ERR_INVALID_ARGUMENT);
         };
 
-        /* Test: s2n_security_policy_write_fd - FORMAT_V1 structure verification */
+        /* Test: s2n_security_policy_write_fd - FORMAT_V1 structure verification.
+         * This test passes a socket fd to s2n_security_policy_write_fd, which
+         * uses POSIX write() internally. On Windows, write() does not work on
+         * sockets: only on regular files and pipes.
+         */
+#ifndef _WIN32
         {
             const struct s2n_security_policy *policy = NULL;
             EXPECT_SUCCESS(s2n_find_security_policy_from_version("default", &policy));
@@ -247,13 +252,14 @@ int main(int argc, char **argv)
             DEFER_CLEANUP(struct s2n_blob file_buffer = { 0 }, s2n_free);
             EXPECT_SUCCESS(s2n_alloc(&file_buffer, expected_length + 1));
 
-            ssize_t bytes_read = read(io_pair.server, file_buffer.data, expected_length);
+            ssize_t bytes_read = s2n_test_recv(io_pair.server, file_buffer.data, expected_length);
             EXPECT_TRUE(bytes_read >= 0);
             EXPECT_EQUAL((size_t) bytes_read, expected_length);
             file_buffer.data[expected_length] = '\0';
 
             EXPECT_OK(s2n_verify_format_v1_output((const char *) file_buffer.data));
         };
+#endif
     };
 
     END_TEST();

--- a/tests/unit/s2n_post_handshake_recv_test.c
+++ b/tests/unit/s2n_post_handshake_recv_test.c
@@ -13,8 +13,6 @@
  * permissions and limitations under the License.
  */
 
-#include <sys/socket.h>
-
 #include "api/unstable/renegotiate.h"
 #include "error/s2n_errno.h"
 #include "s2n_test.h"

--- a/tests/unit/s2n_quic_support_test.c
+++ b/tests/unit/s2n_quic_support_test.c
@@ -288,13 +288,16 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
 
         uint8_t buffer[10] = { 0 };
-        struct iovec iovec_buffer = { .iov_base = buffer, .iov_len = sizeof(buffer) };
         s2n_blocked_status blocked_status;
 
         EXPECT_FAILURE_WITH_ERRNO(s2n_recv(conn, buffer, sizeof(buffer), &blocked_status), S2N_ERR_UNSUPPORTED_WITH_QUIC);
         EXPECT_FAILURE_WITH_ERRNO(s2n_send(conn, buffer, sizeof(buffer), &blocked_status), S2N_ERR_UNSUPPORTED_WITH_QUIC);
+#ifndef _WIN32
+        /* s2n_sendv and s2n_sendv_with_offset are not available on Windows */
+        struct iovec iovec_buffer = { .iov_base = buffer, .iov_len = sizeof(buffer) };
         EXPECT_FAILURE_WITH_ERRNO(s2n_sendv(conn, &iovec_buffer, 1, &blocked_status), S2N_ERR_UNSUPPORTED_WITH_QUIC);
         EXPECT_FAILURE_WITH_ERRNO(s2n_sendv_with_offset(conn, &iovec_buffer, 1, 0, &blocked_status), S2N_ERR_UNSUPPORTED_WITH_QUIC);
+#endif
 
         EXPECT_SUCCESS(s2n_connection_free(conn));
         EXPECT_SUCCESS(s2n_config_free(config));

--- a/tests/unit/s2n_recv_buffering_test.c
+++ b/tests/unit/s2n_recv_buffering_test.c
@@ -16,7 +16,6 @@
 #include "api/s2n.h"
 #include "api/unstable/renegotiate.h"
 #include "s2n_test.h"
-#include "testlib/s2n_ktls_test_utils.h"
 #include "testlib/s2n_testlib.h"
 #include "utils/s2n_random.h"
 

--- a/tests/unit/s2n_recv_test.c
+++ b/tests/unit/s2n_recv_test.c
@@ -16,7 +16,9 @@
 #include "api/s2n.h"
 #include "api/unstable/renegotiate.h"
 #include "s2n_test.h"
-#include "testlib/s2n_ktls_test_utils.h"
+#ifndef _WIN32
+    #include "testlib/s2n_ktls_test_utils.h"
+#endif
 #include "testlib/s2n_testlib.h"
 #include "utils/s2n_random.h"
 
@@ -33,12 +35,15 @@ int s2n_expect_concurrent_error_recv_fn(void *io_context, uint8_t *buf, uint32_t
     return result;
 }
 
+#ifndef _WIN32
 static ssize_t s2n_test_ktls_recvmsg_cb(void *io_context, struct msghdr *msg)
 {
     POSIX_ENSURE_REF(io_context);
     return *(ssize_t *) io_context;
 }
+#endif
 
+#ifndef _WIN32
 static int s2n_test_reneg_req_cb(struct s2n_connection *conn, void *context,
         s2n_renegotiate_response *response)
 {
@@ -48,6 +53,7 @@ static int s2n_test_reneg_req_cb(struct s2n_connection *conn, void *context,
     *response = S2N_RENEGOTIATE_IGNORE;
     return S2N_SUCCESS;
 }
+#endif
 
 int main(int argc, char **argv)
 {
@@ -361,6 +367,7 @@ int main(int argc, char **argv)
         EXPECT_EQUAL(blocked, S2N_NOT_BLOCKED);
     };
 
+#ifndef _WIN32
     /* Test with ktls */
     {
         uint8_t test_data[100] = { 0 };
@@ -665,6 +672,7 @@ int main(int argc, char **argv)
             };
         };
     };
+#endif
 
     END_TEST();
 }

--- a/tests/unit/s2n_renegotiate_io_test.c
+++ b/tests/unit/s2n_renegotiate_io_test.c
@@ -15,10 +15,8 @@
 
 #include "s2n_test.h"
 #include "testlib/s2n_testlib.h"
-#include "tls/s2n_renegotiate.h"
 #include "tls/s2n_tls.h"
 #include "utils/s2n_safety.h"
-#include "utils/s2n_socket.h"
 
 /* We use bitflags to test every combination
  * of where application data could appear in renegotiation.

--- a/tests/unit/s2n_renegotiate_test.c
+++ b/tests/unit/s2n_renegotiate_test.c
@@ -20,7 +20,9 @@
 #include "tls/s2n_record.h"
 #include "tls/s2n_tls.h"
 #include "utils/s2n_safety.h"
-#include "utils/s2n_socket.h"
+#ifndef _WIN32
+    #include "utils/s2n_socket.h"
+#endif
 
 struct s2n_reneg_test_case {
     uint8_t protocol_version;
@@ -103,10 +105,12 @@ int main(int argc, char *argv[])
             EXPECT_SUCCESS(s2n_io_pair_init_non_blocking(&io_pair));
             EXPECT_SUCCESS(s2n_connection_set_io_pair(client_conn, &io_pair));
             EXPECT_SUCCESS(s2n_connection_set_io_pair(server_conn, &io_pair));
+#ifndef _WIN32
             EXPECT_EQUAL(client_conn->send, s2n_socket_write);
             EXPECT_TRUE(client_conn->managed_send_io);
             EXPECT_EQUAL(client_conn->recv, s2n_socket_read);
             EXPECT_TRUE(client_conn->managed_recv_io);
+#endif
 
             EXPECT_SUCCESS(s2n_negotiate_test_server_and_client(server_conn, client_conn));
             EXPECT_SUCCESS(s2n_renegotiate_wipe(client_conn));
@@ -134,9 +138,11 @@ int main(int argc, char *argv[])
             EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&out, 0));
             EXPECT_SUCCESS(s2n_connection_set_io_stuffers(&in, &out, client_conn));
             EXPECT_SUCCESS(s2n_connection_set_io_stuffers(&out, &in, server_conn));
+#ifndef _WIN32
             EXPECT_NOT_EQUAL(client_conn->send, s2n_socket_write);
-            EXPECT_FALSE(client_conn->managed_send_io);
             EXPECT_NOT_EQUAL(client_conn->recv, s2n_socket_read);
+#endif
+            EXPECT_FALSE(client_conn->managed_send_io);
             EXPECT_FALSE(client_conn->managed_recv_io);
 
             EXPECT_SUCCESS(s2n_negotiate_test_server_and_client(server_conn, client_conn));

--- a/tests/unit/s2n_rfc5952_test.c
+++ b/tests/unit/s2n_rfc5952_test.c
@@ -13,7 +13,12 @@
  * permissions and limitations under the License.
  */
 
-#include <arpa/inet.h>
+#ifdef _WIN32
+    #define WIN32_LEAN_AND_MEAN
+    #include <ws2tcpip.h>
+#else
+    #include <arpa/inet.h>
+#endif
 
 #include "s2n_test.h"
 

--- a/tests/unit/s2n_self_talk_io_mem_test.c
+++ b/tests/unit/s2n_self_talk_io_mem_test.c
@@ -14,7 +14,6 @@
  */
 
 #include <stdint.h>
-#include <sys/wait.h>
 #include <time.h>
 #include <unistd.h>
 

--- a/tests/unit/s2n_send_key_update_test.c
+++ b/tests/unit/s2n_send_key_update_test.c
@@ -14,7 +14,6 @@
  */
 
 #include <stdint.h>
-#include <sys/wait.h>
 #include <time.h>
 #include <unistd.h>
 

--- a/tests/unit/s2n_shutdown_test.c
+++ b/tests/unit/s2n_shutdown_test.c
@@ -16,10 +16,11 @@
 #include "tls/s2n_shutdown.c"
 
 #include "s2n_test.h"
-#include "testlib/s2n_ktls_test_utils.h"
+#ifndef _WIN32
+    #include "testlib/s2n_ktls_test_utils.h"
+#endif
 #include "testlib/s2n_testlib.h"
 #include "tls/s2n_alerts.h"
-#include "utils/s2n_socket.h"
 
 #define ALERT_LEN (sizeof(uint16_t))
 
@@ -833,91 +834,92 @@ int main(int argc, char **argv)
             EXPECT_TRUE(s2n_connection_check_io_status(conn, S2N_IO_CLOSED));
             EXPECT_FALSE(s2n_atomic_flag_test(&conn->close_notify_received));
         };
+    };
 
-        /* Test: kTLS enabled */
+#ifndef _WIN32
+    /* Test: s2n_shutdown_send: kTLS enabled */
+    {
+        /* Test: Successfully send alert */
         {
-            /* Test: Successfully send alert */
-            {
-                DEFER_CLEANUP(struct s2n_connection *conn = s2n_connection_new(S2N_SERVER),
-                        s2n_connection_ptr_free);
-                EXPECT_NOT_NULL(conn);
-                s2n_ktls_configure_connection(conn, S2N_KTLS_MODE_SEND);
+            DEFER_CLEANUP(struct s2n_connection *conn = s2n_connection_new(S2N_SERVER),
+                    s2n_connection_ptr_free);
+            EXPECT_NOT_NULL(conn);
+            s2n_ktls_configure_connection(conn, S2N_KTLS_MODE_SEND);
 
-                DEFER_CLEANUP(struct s2n_test_ktls_io_stuffer out = { 0 },
-                        s2n_ktls_io_stuffer_free);
-                EXPECT_OK(s2n_test_init_ktls_io_stuffer_send(conn, &out));
+            DEFER_CLEANUP(struct s2n_test_ktls_io_stuffer out = { 0 },
+                    s2n_ktls_io_stuffer_free);
+            EXPECT_OK(s2n_test_init_ktls_io_stuffer_send(conn, &out));
 
-                s2n_blocked_status blocked = S2N_NOT_BLOCKED;
+            s2n_blocked_status blocked = S2N_NOT_BLOCKED;
+            EXPECT_SUCCESS(s2n_shutdown_send(conn, &blocked));
+            EXPECT_EQUAL(blocked, S2N_NOT_BLOCKED);
+            EXPECT_TRUE(conn->alert_sent);
+            EXPECT_EQUAL(out.sendmsg_invoked_count, 1);
+            EXPECT_OK(s2n_test_validate_ancillary(&out, TLS_ALERT, S2N_ALERT_LENGTH));
+            EXPECT_OK(s2n_test_validate_data(&out,
+                    close_notify_alert, sizeof(close_notify_alert)));
+
+            /* Repeating the shutdown does not resend the alert */
+            for (size_t i = 0; i < 5; i++) {
                 EXPECT_SUCCESS(s2n_shutdown_send(conn, &blocked));
                 EXPECT_EQUAL(blocked, S2N_NOT_BLOCKED);
                 EXPECT_TRUE(conn->alert_sent);
                 EXPECT_EQUAL(out.sendmsg_invoked_count, 1);
-                EXPECT_OK(s2n_test_validate_ancillary(&out, TLS_ALERT, S2N_ALERT_LENGTH));
-                EXPECT_OK(s2n_test_validate_data(&out,
-                        close_notify_alert, sizeof(close_notify_alert)));
+            }
+        };
 
-                /* Repeating the shutdown does not resend the alert */
-                for (size_t i = 0; i < 5; i++) {
-                    EXPECT_SUCCESS(s2n_shutdown_send(conn, &blocked));
-                    EXPECT_EQUAL(blocked, S2N_NOT_BLOCKED);
-                    EXPECT_TRUE(conn->alert_sent);
-                    EXPECT_EQUAL(out.sendmsg_invoked_count, 1);
-                }
-            };
+        /* Test: Successfully send alert after blocking */
+        {
+            /* One call does the partial write, the second blocks */
+            const size_t partial_write = 1;
+            const size_t second_write = sizeof(close_notify_alert) - partial_write;
+            EXPECT_TRUE(second_write > 0);
 
-            /* Test: Successfully send alert after blocking */
-            {
-                /* One call does the partial write, the second blocks */
-                const size_t partial_write = 1;
-                const size_t second_write = sizeof(close_notify_alert) - partial_write;
-                EXPECT_TRUE(second_write > 0);
+            DEFER_CLEANUP(struct s2n_connection *conn = s2n_connection_new(S2N_SERVER),
+                    s2n_connection_ptr_free);
+            EXPECT_NOT_NULL(conn);
+            s2n_ktls_configure_connection(conn, S2N_KTLS_MODE_SEND);
 
-                DEFER_CLEANUP(struct s2n_connection *conn = s2n_connection_new(S2N_SERVER),
-                        s2n_connection_ptr_free);
-                EXPECT_NOT_NULL(conn);
-                s2n_ktls_configure_connection(conn, S2N_KTLS_MODE_SEND);
+            DEFER_CLEANUP(struct s2n_test_ktls_io_stuffer out = { 0 },
+                    s2n_ktls_io_stuffer_free);
+            EXPECT_OK(s2n_test_init_ktls_io_stuffer_send(conn, &out));
+            EXPECT_SUCCESS(s2n_stuffer_free(&out.data_buffer));
+            EXPECT_SUCCESS(s2n_stuffer_alloc(&out.data_buffer, partial_write));
 
-                DEFER_CLEANUP(struct s2n_test_ktls_io_stuffer out = { 0 },
-                        s2n_ktls_io_stuffer_free);
-                EXPECT_OK(s2n_test_init_ktls_io_stuffer_send(conn, &out));
-                EXPECT_SUCCESS(s2n_stuffer_free(&out.data_buffer));
-                EXPECT_SUCCESS(s2n_stuffer_alloc(&out.data_buffer, partial_write));
+            /* One call does the partial write, the second blocks */
+            size_t expected_calls = 2;
 
-                /* One call does the partial write, the second blocks */
-                size_t expected_calls = 2;
+            /* Initial shutdown blocks */
+            s2n_blocked_status blocked = S2N_NOT_BLOCKED;
+            EXPECT_FAILURE_WITH_ERRNO(s2n_shutdown_send(conn, &blocked),
+                    S2N_ERR_IO_BLOCKED);
+            EXPECT_EQUAL(blocked, S2N_BLOCKED_ON_WRITE);
+            EXPECT_TRUE(conn->alert_sent);
+            EXPECT_EQUAL(out.sendmsg_invoked_count, expected_calls);
+            EXPECT_OK(s2n_test_validate_ancillary(&out, TLS_ALERT, partial_write));
+            EXPECT_OK(s2n_test_validate_data(&out, close_notify_alert, partial_write));
 
-                /* Initial shutdown blocks */
-                s2n_blocked_status blocked = S2N_NOT_BLOCKED;
-                EXPECT_FAILURE_WITH_ERRNO(s2n_shutdown_send(conn, &blocked),
-                        S2N_ERR_IO_BLOCKED);
-                EXPECT_EQUAL(blocked, S2N_BLOCKED_ON_WRITE);
-                EXPECT_TRUE(conn->alert_sent);
-                EXPECT_EQUAL(out.sendmsg_invoked_count, expected_calls);
-                EXPECT_OK(s2n_test_validate_ancillary(&out, TLS_ALERT, partial_write));
-                EXPECT_OK(s2n_test_validate_data(&out, close_notify_alert, partial_write));
+            /* Unblock the output stuffer */
+            out.data_buffer.growable = true;
+            expected_calls++;
+            EXPECT_SUCCESS(s2n_stuffer_wipe(&out.ancillary_buffer));
 
-                /* Unblock the output stuffer */
-                out.data_buffer.growable = true;
-                expected_calls++;
-                EXPECT_SUCCESS(s2n_stuffer_wipe(&out.ancillary_buffer));
+            /* Second shutdown succeeds */
+            EXPECT_SUCCESS(s2n_shutdown_send(conn, &blocked));
+            EXPECT_EQUAL(blocked, S2N_NOT_BLOCKED);
+            EXPECT_TRUE(conn->alert_sent);
+            EXPECT_EQUAL(out.sendmsg_invoked_count, expected_calls);
+            EXPECT_OK(s2n_test_validate_ancillary(&out, TLS_ALERT, second_write));
+            EXPECT_OK(s2n_test_validate_data(&out, close_notify_alert,
+                    sizeof(close_notify_alert)));
 
-                /* Second shutdown succeeds */
+            /* Repeating the shutdown does not resend the alert */
+            for (size_t i = 0; i < 5; i++) {
                 EXPECT_SUCCESS(s2n_shutdown_send(conn, &blocked));
                 EXPECT_EQUAL(blocked, S2N_NOT_BLOCKED);
                 EXPECT_TRUE(conn->alert_sent);
                 EXPECT_EQUAL(out.sendmsg_invoked_count, expected_calls);
-                EXPECT_OK(s2n_test_validate_ancillary(&out, TLS_ALERT, second_write));
-                EXPECT_OK(s2n_test_validate_data(&out, close_notify_alert,
-                        sizeof(close_notify_alert)));
-
-                /* Repeating the shutdown does not resend the alert */
-                for (size_t i = 0; i < 5; i++) {
-                    EXPECT_SUCCESS(s2n_shutdown_send(conn, &blocked));
-                    EXPECT_EQUAL(blocked, S2N_NOT_BLOCKED);
-                    EXPECT_TRUE(conn->alert_sent);
-                    EXPECT_EQUAL(out.sendmsg_invoked_count, expected_calls);
-                }
-            };
+            }
         };
     };
 
@@ -1055,6 +1057,7 @@ int main(int argc, char **argv)
             EXPECT_OK(s2n_test_records_in_ancillary(&io_pair.server_in, 0));
         };
     };
+#endif
 
     END_TEST();
 }

--- a/tests/unit/s2n_tls13_zero_length_payload_test.c
+++ b/tests/unit/s2n_tls13_zero_length_payload_test.c
@@ -16,7 +16,6 @@
 #include <fcntl.h>
 #include <stdint.h>
 #include <stdlib.h>
-#include <sys/wait.h>
 
 #include "api/s2n.h"
 #include "s2n_test.h"


### PR DESCRIPTION
# Goal

Enable s2n-tls' non-fork based tests to pass on Windows.

## Why

The goal is to enable all unit tests on Windows. This is the first step for tests refactoring.

## How

### Determine tests that we can add with little effort

I tried to enable tests that doesn't involve forking for this PR. The next refactor will deal with tests that uses `fork()`.

### Include Windows socket setup to `s2n_connection_test_utils.c`

We need to implement windows specific socket set up for tests. I find windows equivalents for Linux function to implement them in the util file.

For set blocking/unblocking: https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-ioctlsocket
For Windows socket initialization: https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-wsastartup
For socket bind and listen: https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-socket

Since, Windows doesn't provide default socket setup, we need to implement recv and send cb functions for the IO to work.

### Fix other dependencies

Other dependencies like <unistd.h> in s2n_test.h can be replaced by io.h provided by Windows.

### CMakeLists.txt changes

I setup the CMakeLists.txt to build a blocklist for unit tests. For now, we block those tests specified in CMakeLists.txt. I expect the block list to be significantly shortened after the following refactors (since more tests will be enabled on Windows).

### Run those tests automatically in CI

I also add the tests run command into the CI Github Action, so that those tests will be executed in CI.

## Callouts

* Rebase immediately after https://github.com/aws/s2n-tls/pull/5907 is merged in.
* https://github.com/aws/s2n-tls/pull/5904#discussion_r3392301976


### Decisions to add those tests into CI

I used a blocked list to remove some unit tests that I can't support right now. The approach that I took was a little rigid, as it's a hardcoded block list.

Other approaches might be:
1. Use a regex to shorten the list.
2. Don't add them to the CMakelists.txt just yet and only add the list to CMakeLists.txt once I have every tests running.

I decided not to go with either of those alternatives, because: 1. regex is very fragile and it would looks not very understandable. 2. I do want those tests to run in CI right now, instead of waiting for the next PR.

### Define WIN32_LEAN_AND_MEAN

The reason is the same as the previous PR https://github.com/aws/s2n-tls/pull/5895. Refer to the callouts section of that PR's description.

## Testing

Our CI should verify that all those test that I have enabled will pass: https://github.com/aws/s2n-tls/actions/runs/26973477206?pr=5904.

This PR enables 253 tests to run on Windows. At this moment, there are 280 tests for s2n-tls. I will deal with the rest in another PR.

### Related

Related to https://github.com/aws/s2n-tls/issues/4018.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
