### PR TITLE
feat(metrics): add security policy information

### DIFF
--- a/bindings/rust/standard/s2n-tls-metrics-schema/src/bounded_set.rs
+++ b/bindings/rust/standard/s2n-tls-metrics-schema/src/bounded_set.rs
@@ -9,11 +9,11 @@ use serde::{Deserialize, Serialize};
 pub enum FrozenBoundedStringSet {
     /// more than 10 values were supplied
     TooMany,
-    Entires(BTreeSet<String>),
+    Entries(BTreeSet<String>),
 }
 
 impl Default for FrozenBoundedStringSet {
     fn default() -> Self {
-        FrozenBoundedStringSet::Entires(BTreeSet::new())
+        FrozenBoundedStringSet::Entries(BTreeSet::new())
     }
 }

--- a/bindings/rust/standard/s2n-tls-metrics-schema/src/bounded_set.rs
+++ b/bindings/rust/standard/s2n-tls-metrics-schema/src/bounded_set.rs
@@ -1,0 +1,19 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::BTreeSet;
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub enum FrozenBoundedStringSet {
+    /// more than 10 values were supplied
+    TooMany,
+    Entires(BTreeSet<String>),
+}
+
+impl Default for FrozenBoundedStringSet {
+    fn default() -> Self {
+        FrozenBoundedStringSet::Entires(BTreeSet::new())
+    }
+}

--- a/bindings/rust/standard/s2n-tls-metrics-schema/src/lib.rs
+++ b/bindings/rust/standard/s2n-tls-metrics-schema/src/lib.rs
@@ -8,6 +8,7 @@
 //! minor versions.
 
 pub mod attribution;
+pub mod bounded_set;
 pub mod counter;
 pub mod label;
 pub mod record;

--- a/bindings/rust/standard/s2n-tls-metrics-schema/src/record.rs
+++ b/bindings/rust/standard/s2n-tls-metrics-schema/src/record.rs
@@ -128,7 +128,7 @@ impl metrique_writer::Entry for FrozenHandshakeRecord {
     fn write<'a>(&'a self, writer: &mut impl metrique_writer::EntryWriter<'a>) {
         match &self.security_policies {
             FrozenBoundedStringSet::TooMany => writer.value("tls_policy.TOO_MANY", &1_u64),
-            FrozenBoundedStringSet::Entires(hash_set) => {
+            FrozenBoundedStringSet::Entries(hash_set) => {
                 for policy in hash_set {
                     writer.value(format!("tls_policy.{policy}"), &1_u64);
                 }

--- a/bindings/rust/standard/s2n-tls-metrics-schema/src/record.rs
+++ b/bindings/rust/standard/s2n-tls-metrics-schema/src/record.rs
@@ -7,6 +7,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     attribution::Attribution,
+    bounded_set::FrozenBoundedStringSet,
     counter::FrozenCounter,
     static_lists::{
         CIPHER_COUNT, Cipher, GROUP_COUNT, Group, PROTOCOL_COUNT, SIGNATURE_COUNT, Signature,
@@ -52,6 +53,9 @@ fn system_time_epoch() -> SystemTime {
 pub struct FrozenHandshakeRecord {
     #[serde(default = "system_time_epoch")]
     pub freeze_time: SystemTime,
+
+    #[serde(default)]
+    pub security_policies: FrozenBoundedStringSet,
 
     #[serde(default)]
     pub handshake_count: u64,
@@ -115,12 +119,21 @@ impl Default for FrozenHandshakeRecord {
             handshake_duration_us: 0,
             handshake_compute_us: 0,
             synthetic_traffic_count: 0,
+            security_policies: Default::default(),
         }
     }
 }
 
 impl metrique_writer::Entry for FrozenHandshakeRecord {
     fn write<'a>(&'a self, writer: &mut impl metrique_writer::EntryWriter<'a>) {
+        match &self.security_policies {
+            FrozenBoundedStringSet::TooMany => writer.value("tls_policy.TOO_MANY", &1_u64),
+            FrozenBoundedStringSet::Entires(hash_set) => {
+                for policy in hash_set {
+                    writer.value(format!("tls_policy.{policy}"), &1_u64);
+                }
+            }
+        }
         writer.timestamp(self.freeze_time);
 
         fn write_counter<'a, const N: usize, T, W>(

--- a/bindings/rust/standard/s2n-tls-metrics-subscriber/src/bounded_set.rs
+++ b/bindings/rust/standard/s2n-tls-metrics-subscriber/src/bounded_set.rs
@@ -1,13 +1,20 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{collections::HashSet, ops::Deref, sync::RwLock};
+use std::{
+    collections::HashSet,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        RwLock,
+    },
+};
 
 use s2n_tls_metrics_schema::bounded_set::FrozenBoundedStringSet;
 
 #[derive(Debug)]
 pub(crate) struct BoundedStringSet {
     storage: RwLock<HashSet<String>>,
+    overflow: AtomicBool,
 }
 
 impl Default for BoundedStringSet {
@@ -15,37 +22,44 @@ impl Default for BoundedStringSet {
         Self {
             // set capacity to 10 to minimize allocations
             storage: RwLock::new(HashSet::with_capacity(Self::MAX_STORAGE)),
+            overflow: AtomicBool::new(false),
         }
     }
 }
 
 impl BoundedStringSet {
-    const MAX_STORAGE: usize = 10;
+    pub(crate) const MAX_STORAGE: usize = 10;
     /// record the existence of a value.
     ///
     /// This will be a no-op if the item is already in the set
     pub fn record(&self, item: &str) {
-        let should_insert = { Self::should_insert(&self.storage.read().unwrap(), item) };
-
-        if should_insert {
-            // acquire write lock
-            let mut write_set = self.storage.write().unwrap();
-            // recheck, because things might have changed
-            if Self::should_insert(&write_set, item) {
-                write_set.insert(item.to_owned());
-            }
+        let storage = self.storage.read().unwrap();
+        if storage.contains(item) {
+            return;
         }
-    }
+        if storage.len() >= Self::MAX_STORAGE {
+            self.overflow.store(true, Ordering::Relaxed);
+            return;
+        }
+        drop(storage);
 
-    fn should_insert<T: Deref<Target = HashSet<String>>>(set: &T, element: &str) -> bool {
-        !set.contains(element) && set.len() < Self::MAX_STORAGE
+        // acquire write lock
+        let mut write_set = self.storage.write().unwrap();
+        if write_set.contains(item) {
+            return;
+        }
+        if write_set.len() >= Self::MAX_STORAGE {
+            self.overflow.store(true, Ordering::Relaxed);
+            return;
+        }
+        write_set.insert(item.to_owned());
     }
 
     pub fn freeze(&self) -> FrozenBoundedStringSet {
-        let storage = self.storage.read().unwrap();
-        if storage.len() >= Self::MAX_STORAGE {
+        if self.overflow.load(Ordering::Relaxed) {
             FrozenBoundedStringSet::TooMany
         } else {
+            let storage = self.storage.read().unwrap();
             FrozenBoundedStringSet::Entries(storage.iter().cloned().collect())
         }
     }

--- a/bindings/rust/standard/s2n-tls-metrics-subscriber/src/bounded_set.rs
+++ b/bindings/rust/standard/s2n-tls-metrics-subscriber/src/bounded_set.rs
@@ -4,8 +4,8 @@
 use std::{
     collections::HashSet,
     sync::{
-        atomic::{AtomicBool, Ordering},
         RwLock,
+        atomic::{AtomicBool, Ordering},
     },
 };
 

--- a/bindings/rust/standard/s2n-tls-metrics-subscriber/src/bounded_set.rs
+++ b/bindings/rust/standard/s2n-tls-metrics-subscriber/src/bounded_set.rs
@@ -1,0 +1,52 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{collections::HashSet, ops::Deref, sync::RwLock};
+
+use s2n_tls_metrics_schema::bounded_set::FrozenBoundedStringSet;
+
+#[derive(Debug)]
+pub(crate) struct BoundedStringSet {
+    storage: RwLock<HashSet<String>>,
+}
+
+impl Default for BoundedStringSet {
+    fn default() -> Self {
+        Self {
+            // set capacity to 10 to minimize allocations
+            storage: RwLock::new(HashSet::with_capacity(Self::MAX_STORAGE)),
+        }
+    }
+}
+
+impl BoundedStringSet {
+    const MAX_STORAGE: usize = 10;
+    /// record the existence of a value.
+    ///
+    /// This will be a no-op if the item is already in the set
+    pub fn record(&self, item: &str) {
+        let should_insert = { Self::should_insert(&self.storage.read().unwrap(), item) };
+
+        if should_insert {
+            // acquire write lock
+            let mut write_set = self.storage.write().unwrap();
+            // recheck, because things might have changed
+            if Self::should_insert(&write_set, item) {
+                write_set.insert(item.to_owned());
+            }
+        }
+    }
+
+    fn should_insert<T: Deref<Target = HashSet<String>>>(set: &T, element: &str) -> bool {
+        !set.contains(element) && set.len() < Self::MAX_STORAGE
+    }
+
+    pub fn freeze(&self) -> FrozenBoundedStringSet {
+        let storage = self.storage.read().unwrap();
+        if storage.len() >= Self::MAX_STORAGE {
+            FrozenBoundedStringSet::TooMany
+        } else {
+            FrozenBoundedStringSet::Entires(storage.iter().cloned().collect())
+        }
+    }
+}

--- a/bindings/rust/standard/s2n-tls-metrics-subscriber/src/bounded_set.rs
+++ b/bindings/rust/standard/s2n-tls-metrics-subscriber/src/bounded_set.rs
@@ -46,7 +46,7 @@ impl BoundedStringSet {
         if storage.len() >= Self::MAX_STORAGE {
             FrozenBoundedStringSet::TooMany
         } else {
-            FrozenBoundedStringSet::Entires(storage.iter().cloned().collect())
+            FrozenBoundedStringSet::Entries(storage.iter().cloned().collect())
         }
     }
 }

--- a/bindings/rust/standard/s2n-tls-metrics-subscriber/src/lib.rs
+++ b/bindings/rust/standard/s2n-tls-metrics-subscriber/src/lib.rs
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+mod bounded_set;
 mod compatibility;
 pub(crate) mod counter;
 pub mod detector;

--- a/bindings/rust/standard/s2n-tls-metrics-subscriber/src/record.rs
+++ b/bindings/rust/standard/s2n-tls-metrics-subscriber/src/record.rs
@@ -15,6 +15,7 @@ use s2n_tls_metrics_schema::{
 };
 
 use crate::{
+    bounded_set::BoundedStringSet,
     compatibility::{Cnsa1, Cnsa2, Fips20251201, General20251201, TlsProfile},
     counter::Counter,
     detector::SyntheticTrafficDetector,
@@ -40,6 +41,8 @@ pub(crate) struct HandshakeRecordInProgress {
     /// This is used to send a frozen version back to the Aggregator, after which
     /// point it can be exported. This is only used in the drop impl.
     exporter: std::sync::mpsc::Sender<FrozenHandshakeRecord>,
+
+    security_policies: BoundedStringSet,
 
     /// the total number of handshakes that this record represents.
     handshake_count: AtomicU64,
@@ -80,6 +83,7 @@ pub(crate) struct HandshakeRecordInProgress {
 impl HandshakeRecordInProgress {
     pub fn new(exporter: std::sync::mpsc::Sender<FrozenHandshakeRecord>) -> Self {
         Self {
+            security_policies: Default::default(),
             handshake_count: Default::default(),
 
             negotiated_groups: Counter::new(),
@@ -126,6 +130,8 @@ impl HandshakeRecordInProgress {
         }
 
         self.handshake_count.fetch_add(1, Ordering::Relaxed);
+
+        self.security_policies.record(event.security_policy_label());
 
         if let Some(sig) = conn.signature_scheme().and_then(|s| s.parse().ok()) {
             self.negotiated_signatures.increment(&sig);
@@ -234,6 +240,7 @@ impl HandshakeRecordInProgress {
             handshake_duration_us: self.handshake_duration_us.load(Ordering::Relaxed),
             handshake_compute_us: self.handshake_compute_us.load(Ordering::Relaxed),
             synthetic_traffic_count: self.synthetic_traffic_count.load(Ordering::Relaxed),
+            security_policies: self.security_policies.freeze(),
         }
     }
 }
@@ -475,6 +482,84 @@ mod tests {
         assert_eq!(record.compatibility_fips20251201, 1);
         assert_eq!(record.compatibility_cnsa1, 1);
         assert_eq!(record.compatibility_cnsa2, 0);
+    }
+
+    #[test]
+    fn record_contents_security_policies() {
+        use s2n_tls::security::Policy;
+        use s2n_tls_metrics_schema::bounded_set::FrozenBoundedStringSet;
+        use std::ffi::CStr;
+
+        // a single handshake -> a single security policy
+        {
+            let endpoint = TestEndpoint::new();
+            endpoint.client_handshake(&ARBITRARY_POLICY_1);
+            endpoint.subscriber.finish_record();
+            let records = endpoint.sink.records.lock().unwrap();
+            let policies = &records[0].as_schema().handshake.security_policies;
+            match policies {
+                FrozenBoundedStringSet::Entires(set) => {
+                    assert_eq!(set.len(), 1);
+                    assert!(set.contains("default_tls13"));
+                }
+                FrozenBoundedStringSet::TooMany => panic!("expected Entires"),
+            }
+        }
+
+        // multiple handshakes shifting between two policies -> two policies recorded
+        {
+            let endpoint = TestEndpoint::new();
+            endpoint.client_handshake(&ARBITRARY_POLICY_1);
+
+            let policy_b = Policy::from_version("20240501").unwrap();
+            let client_config = s2n_tls::testing::build_config(&ARBITRARY_POLICY_1).unwrap();
+            let mut pair =
+                s2n_tls::testing::TestPair::from_configs(&client_config, &endpoint.server_config);
+            pair.server.set_security_policy(&policy_b).unwrap();
+            pair.handshake().unwrap();
+
+            endpoint.subscriber.finish_record();
+            let records = endpoint.sink.records.lock().unwrap();
+            let policies = &records[0].as_schema().handshake.security_policies;
+            match policies {
+                FrozenBoundedStringSet::Entires(set) => {
+                    assert_eq!(set.len(), 2);
+                }
+                FrozenBoundedStringSet::TooMany => panic!("expected Entires"),
+            }
+        }
+
+        // more than 10 security policies -> TOO_MANY is recorded
+        {
+            let endpoint = TestEndpoint::new();
+            let client_config = s2n_tls::testing::build_config(&ARBITRARY_POLICY_1).unwrap();
+
+            let policies: Vec<Policy> = s2n_tls_sys_internal::security_policy_table()
+                .iter()
+                .filter_map(|entry| {
+                    let name = unsafe { CStr::from_ptr(entry.version) }.to_str().ok()?;
+                    Policy::from_version(name).ok()
+                })
+                .take(11)
+                .collect();
+            assert!(policies.len() > 10, "not enough compatible policies found");
+
+            for policy in &policies {
+                let mut pair = s2n_tls::testing::TestPair::from_configs(
+                    &client_config,
+                    &endpoint.server_config,
+                );
+                pair.server.set_security_policy(policy).unwrap();
+                pair.handshake().unwrap();
+            }
+
+            endpoint.subscriber.finish_record();
+            let records = endpoint.sink.records.lock().unwrap();
+            assert_eq!(
+                records[0].as_schema().handshake.security_policies,
+                FrozenBoundedStringSet::TooMany
+            );
+        }
     }
 
     /// Make sure that the compute time is less than the overall handshake time.

--- a/bindings/rust/standard/s2n-tls-metrics-subscriber/src/record.rs
+++ b/bindings/rust/standard/s2n-tls-metrics-subscriber/src/record.rs
@@ -498,7 +498,7 @@ mod tests {
             let records = endpoint.sink.records.lock().unwrap();
             let policies = &records[0].as_schema().handshake.security_policies;
             match policies {
-                FrozenBoundedStringSet::Entires(set) => {
+                FrozenBoundedStringSet::Entries(set) => {
                     assert_eq!(set.len(), 1);
                     assert!(set.contains("default_tls13"));
                 }
@@ -522,7 +522,7 @@ mod tests {
             let records = endpoint.sink.records.lock().unwrap();
             let policies = &records[0].as_schema().handshake.security_policies;
             match policies {
-                FrozenBoundedStringSet::Entires(set) => {
+                FrozenBoundedStringSet::Entries(set) => {
                     assert_eq!(set.len(), 2);
                 }
                 FrozenBoundedStringSet::TooMany => panic!("expected Entires"),

--- a/bindings/rust/standard/s2n-tls-metrics-subscriber/src/record.rs
+++ b/bindings/rust/standard/s2n-tls-metrics-subscriber/src/record.rs
@@ -502,7 +502,7 @@ mod tests {
                     assert_eq!(set.len(), 1);
                     assert!(set.contains("default_tls13"));
                 }
-                FrozenBoundedStringSet::TooMany => panic!("expected Entires"),
+                FrozenBoundedStringSet::TooMany => panic!("expected Entries"),
             }
         }
 
@@ -525,7 +525,7 @@ mod tests {
                 FrozenBoundedStringSet::Entries(set) => {
                     assert_eq!(set.len(), 2);
                 }
-                FrozenBoundedStringSet::TooMany => panic!("expected Entires"),
+                FrozenBoundedStringSet::TooMany => panic!("expected Entries"),
             }
         }
 
@@ -534,15 +534,24 @@ mod tests {
             let endpoint = TestEndpoint::new();
             let client_config = s2n_tls::testing::build_config(&ARBITRARY_POLICY_1).unwrap();
 
-            let policies: Vec<Policy> = s2n_tls_sys_internal::security_policy_table()
-                .iter()
-                .filter_map(|entry| {
-                    let name = unsafe { CStr::from_ptr(entry.version) }.to_str().ok()?;
-                    Policy::from_version(name).ok()
-                })
-                .take(11)
-                .collect();
-            assert!(policies.len() > 10, "not enough compatible policies found");
+            let policies: Vec<Policy> = {
+                let mut seen = std::collections::HashSet::new();
+                let mut result = Vec::new();
+                for entry in s2n_tls_sys_internal::security_policy_table() {
+                    // we need unique security policies (e.g. unique security policy
+                    // pointers)
+                    if !seen.insert(entry.security_policy as usize) {
+                        continue;
+                    }
+                    let name = unsafe { CStr::from_ptr(entry.version) }.to_str().unwrap();
+                    result.push(Policy::from_version(name).unwrap());
+                    if result.len() > BoundedStringSet::MAX_STORAGE {
+                        break;
+                    }
+                }
+                result
+            };
+            assert_eq!(policies.len(), BoundedStringSet::MAX_STORAGE + 1);
 
             for policy in &policies {
                 let mut pair = s2n_tls::testing::TestPair::from_configs(

--- a/bindings/rust/standard/s2n-tls-metrics-subscriber/tests/snapshots/entry_emf.json
+++ b/bindings/rust/standard/s2n-tls-metrics-subscriber/tests/snapshots/entry_emf.json
@@ -8,6 +8,9 @@
         ],
         "Metrics": [
           {
+            "Name": "tls_policy.default_tls13"
+          },
+          {
             "Name": "version.negotiated.TLSv1_3"
           },
           {
@@ -188,6 +191,7 @@
   "signature_scheme.supported.rsa_pss_rsae_sha512": 1,
   "sslv2_client_hello": 0,
   "synthetic_traffic_count": 0,
+  "tls_policy.default_tls13": 1,
   "version.negotiated.TLSv1_3": 1,
   "version.supported.TLSv1_2": 1,
   "version.supported.TLSv1_3": 1

--- a/bindings/rust/standard/s2n-tls-metrics-subscriber/tests/subscriber_memory.rs
+++ b/bindings/rust/standard/s2n-tls-metrics-subscriber/tests/subscriber_memory.rs
@@ -156,8 +156,8 @@ fn subscriber_allocation_budget() {
     // Note that blocks may not scale in a strictly linear manner because of how
     // the mpsc channel allocs in chunks.
     const EXPORT: AllocDelta = AllocDelta {
-        blocks: 4,
-        bytes: 2564,
+        blocks: 5,
+        bytes: 3073,
     };
 
     // Subscriber state is fixed-size, so nothing should be retained across


### PR DESCRIPTION
# Goal
And telemetry on the configured security policy

## Why
It's useful to have in the Telemetry Record

## How
We introduce a new "frozen-bounded-set" which is used to record the various security policies that might be seen.

Multiple security policies might be seen in the event of
- a single subscriber set on multiple configs
- a security policy override being set on a connection

## Testing
Added tests confirming that the security policy is correctly recorded.

### Call Outs
Although it's a bit odd to have the single "1" value for the Entry API, this is the easiest way to be able to surface this information within CloudWatch, because there isn't any other good way of exposing this information.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
