### PR TITLE
test(metrics): add EMF snapshot test

### DIFF
--- a/bindings/rust/standard/s2n-tls-metrics-subscriber/Cargo.toml
+++ b/bindings/rust/standard/s2n-tls-metrics-subscriber/Cargo.toml
@@ -36,6 +36,8 @@ serde_json = "1.0.141"
 ciborium = "0.2"
 dhat = "0.3"
 tabled = "0.21"
+metrique-writer = { version = "0.1.19", features = ["test-util"] }
+metrique-writer-format-emf = "0.1.21"
 
 [[test]]
 name = "subscriber_memory"

--- a/bindings/rust/standard/s2n-tls-metrics-subscriber/tests/entry_snapshot.rs
+++ b/bindings/rust/standard/s2n-tls-metrics-subscriber/tests/entry_snapshot.rs
@@ -1,0 +1,98 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Snapshot test that performs a real handshake and renders the resulting
+//! MetricRecord as an EMF entry. Any change to what fields the Entry impl
+//! emits will show up as a diff in the snapshot file.
+
+use metrique_writer::format::Format;
+use metrique_writer_format_emf::Emf;
+use s2n_tls::{
+    security::DEFAULT_TLS13,
+    testing::{build_config, config_builder},
+};
+use s2n_tls_metrics_subscriber::{
+    AggregatedMetricsSubscriber, Attribution, MetricRecord, TelemetrySink,
+};
+use std::sync::{Arc, Mutex};
+
+#[derive(Clone)]
+struct CaptureSink(Arc<Mutex<Vec<MetricRecord>>>);
+impl TelemetrySink for CaptureSink {
+    fn export_record(&self, record: &MetricRecord) {
+        self.0.lock().unwrap().push(record.clone());
+    }
+}
+
+/// Normalize non-deterministic values (timestamps, timings) so the snapshot
+/// is stable across runs.
+fn normalize(value: &mut serde_json::Value) {
+    if let Some(obj) = value.as_object_mut() {
+        // Zero out timing fields
+        for key in ["handshake_duration_us", "handshake_compute_us"] {
+            if obj.contains_key(key) {
+                obj.insert(key.to_owned(), serde_json::json!("<DURATION>"));
+            }
+        }
+        // Zero out the EMF timestamp
+        if let Some(aws) = obj.get_mut("_aws").and_then(|v| v.as_object_mut()) {
+            if aws.contains_key("Timestamp") {
+                aws.insert("Timestamp".to_owned(), serde_json::json!("<TIMESTAMP>"));
+            }
+        }
+        // Recurse
+        for (_, v) in obj.iter_mut() {
+            normalize(v);
+        }
+    } else if let Some(arr) = value.as_array_mut() {
+        for v in arr {
+            normalize(v);
+        }
+    }
+}
+
+/// Render a real handshake record to EMF and compare against the expected
+/// snapshot.
+///
+/// If you changed the Entry implementation, update
+/// `tests/snapshots/entry_emf.json` to match the new output.
+#[test]
+fn entry_emf_snapshot() {
+    let sink = CaptureSink(Arc::new(Mutex::new(Vec::new())));
+    let subscriber = AggregatedMetricsSubscriber::new(
+        sink.clone(),
+        Attribution {
+            service: "my-service".to_owned(),
+            resource: "arn:aws:elasticloadbalancing:us-east-1:123:listener/abc".to_owned(),
+            component: "test-frontend-whatever".to_owned(),
+        },
+    );
+
+    let server_config = {
+        let mut c = config_builder(&DEFAULT_TLS13).unwrap();
+        c.set_event_subscriber(subscriber.clone()).unwrap();
+        c.build().unwrap()
+    };
+    let client_config = build_config(&DEFAULT_TLS13).unwrap();
+    let mut pair = s2n_tls::testing::TestPair::from_configs(&client_config, &server_config);
+    pair.handshake().unwrap();
+    subscriber.finish_record();
+
+    let records = sink.0.lock().unwrap();
+    let record = &records[0];
+
+    let mut emf = Emf::no_validations("TlsMetrics".into(), vec![vec![]]);
+    let mut buf = Vec::new();
+    emf.format(record, &mut buf).unwrap();
+    let emf_output = String::from_utf8(buf).unwrap();
+
+    let mut actual: serde_json::Value = serde_json::from_str(&emf_output).unwrap();
+    normalize(&mut actual);
+    let actual_pretty = serde_json::to_string_pretty(&actual).unwrap();
+
+    // Uncomment to update the snapshot:
+    // std::fs::write(concat!(env!("CARGO_MANIFEST_DIR"), "/tests/snapshots/entry_emf.json"), &actual_pretty).unwrap();
+
+    let expected = include_str!("snapshots/entry_emf.json").trim_end();
+    assert_eq!(actual_pretty, expected);
+}

--- a/bindings/rust/standard/s2n-tls-metrics-subscriber/tests/snapshots/entry_emf.json
+++ b/bindings/rust/standard/s2n-tls-metrics-subscriber/tests/snapshots/entry_emf.json
@@ -1,0 +1,194 @@
+{
+  "Operation": "TlsTelemetry.test-frontend-whatever",
+  "_aws": {
+    "CloudWatchMetrics": [
+      {
+        "Dimensions": [
+          []
+        ],
+        "Metrics": [
+          {
+            "Name": "version.negotiated.TLSv1_3"
+          },
+          {
+            "Name": "cipher.negotiated.TLS_AES_128_GCM_SHA256"
+          },
+          {
+            "Name": "group.negotiated.secp256r1"
+          },
+          {
+            "Name": "signature_scheme.negotiated.rsa_pss_rsae_sha256"
+          },
+          {
+            "Name": "version.supported.TLSv1_2"
+          },
+          {
+            "Name": "version.supported.TLSv1_3"
+          },
+          {
+            "Name": "cipher.supported.TLS_AES_128_GCM_SHA256"
+          },
+          {
+            "Name": "cipher.supported.TLS_AES_256_GCM_SHA384"
+          },
+          {
+            "Name": "cipher.supported.TLS_CHACHA20_POLY1305_SHA256"
+          },
+          {
+            "Name": "cipher.supported.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256"
+          },
+          {
+            "Name": "cipher.supported.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256"
+          },
+          {
+            "Name": "cipher.supported.TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384"
+          },
+          {
+            "Name": "cipher.supported.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384"
+          },
+          {
+            "Name": "cipher.supported.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256"
+          },
+          {
+            "Name": "cipher.supported.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256"
+          },
+          {
+            "Name": "cipher.supported.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"
+          },
+          {
+            "Name": "cipher.supported.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384"
+          },
+          {
+            "Name": "cipher.supported.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384"
+          },
+          {
+            "Name": "cipher.supported.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256"
+          },
+          {
+            "Name": "group.supported.secp256r1"
+          },
+          {
+            "Name": "group.supported.secp384r1"
+          },
+          {
+            "Name": "group.supported.secp521r1"
+          },
+          {
+            "Name": "group.supported.x25519"
+          },
+          {
+            "Name": "signature_scheme.supported.ecdsa_sha256"
+          },
+          {
+            "Name": "signature_scheme.supported.ecdsa_sha384"
+          },
+          {
+            "Name": "signature_scheme.supported.ecdsa_sha512"
+          },
+          {
+            "Name": "signature_scheme.supported.rsa_pkcs1_sha256"
+          },
+          {
+            "Name": "signature_scheme.supported.rsa_pkcs1_sha384"
+          },
+          {
+            "Name": "signature_scheme.supported.rsa_pkcs1_sha512"
+          },
+          {
+            "Name": "signature_scheme.supported.rsa_pss_pss_sha256"
+          },
+          {
+            "Name": "signature_scheme.supported.rsa_pss_pss_sha384"
+          },
+          {
+            "Name": "signature_scheme.supported.rsa_pss_pss_sha512"
+          },
+          {
+            "Name": "signature_scheme.supported.rsa_pss_rsae_sha256"
+          },
+          {
+            "Name": "signature_scheme.supported.rsa_pss_rsae_sha384"
+          },
+          {
+            "Name": "signature_scheme.supported.rsa_pss_rsae_sha512"
+          },
+          {
+            "Name": "compatibility.general20251201"
+          },
+          {
+            "Name": "compatibility.fips20251201"
+          },
+          {
+            "Name": "compatibility.cnsa1"
+          },
+          {
+            "Name": "compatibility.cnsa2"
+          },
+          {
+            "Name": "sslv2_client_hello"
+          },
+          {
+            "Name": "handshake_count"
+          },
+          {
+            "Name": "handshake_duration_us"
+          },
+          {
+            "Name": "handshake_compute_us"
+          },
+          {
+            "Name": "synthetic_traffic_count"
+          }
+        ],
+        "Namespace": "TlsMetrics"
+      }
+    ],
+    "Timestamp": "<TIMESTAMP>"
+  },
+  "cipher.negotiated.TLS_AES_128_GCM_SHA256": 1,
+  "cipher.supported.TLS_AES_128_GCM_SHA256": 1,
+  "cipher.supported.TLS_AES_256_GCM_SHA384": 1,
+  "cipher.supported.TLS_CHACHA20_POLY1305_SHA256": 1,
+  "cipher.supported.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256": 1,
+  "cipher.supported.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256": 1,
+  "cipher.supported.TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384": 1,
+  "cipher.supported.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384": 1,
+  "cipher.supported.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256": 1,
+  "cipher.supported.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256": 1,
+  "cipher.supported.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256": 1,
+  "cipher.supported.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384": 1,
+  "cipher.supported.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384": 1,
+  "cipher.supported.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256": 1,
+  "compatibility.cnsa1": 1,
+  "compatibility.cnsa2": 0,
+  "compatibility.fips20251201": 1,
+  "compatibility.general20251201": 1,
+  "group.negotiated.secp256r1": 1,
+  "group.supported.secp256r1": 1,
+  "group.supported.secp384r1": 1,
+  "group.supported.secp521r1": 1,
+  "group.supported.x25519": 1,
+  "handshake_compute_us": "<DURATION>",
+  "handshake_count": 1,
+  "handshake_duration_us": "<DURATION>",
+  "resource": "arn:aws:elasticloadbalancing:us-east-1:123:listener/abc",
+  "service": "my-service",
+  "signature_scheme.negotiated.rsa_pss_rsae_sha256": 1,
+  "signature_scheme.supported.ecdsa_sha256": 1,
+  "signature_scheme.supported.ecdsa_sha384": 1,
+  "signature_scheme.supported.ecdsa_sha512": 1,
+  "signature_scheme.supported.rsa_pkcs1_sha256": 1,
+  "signature_scheme.supported.rsa_pkcs1_sha384": 1,
+  "signature_scheme.supported.rsa_pkcs1_sha512": 1,
+  "signature_scheme.supported.rsa_pss_pss_sha256": 1,
+  "signature_scheme.supported.rsa_pss_pss_sha384": 1,
+  "signature_scheme.supported.rsa_pss_pss_sha512": 1,
+  "signature_scheme.supported.rsa_pss_rsae_sha256": 1,
+  "signature_scheme.supported.rsa_pss_rsae_sha384": 1,
+  "signature_scheme.supported.rsa_pss_rsae_sha512": 1,
+  "sslv2_client_hello": 0,
+  "synthetic_traffic_count": 0,
+  "version.negotiated.TLSv1_3": 1,
+  "version.supported.TLSv1_2": 1,
+  "version.supported.TLSv1_3": 1
+}


### PR DESCRIPTION
# Goal
Make it easy to confirm that new Entry fields were correctly added

## Why
It's way easier to check these things visually. 

## How
Add a snapshot test which uses the Metrique EMF formatted to create the telemetry record.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
