### PR TITLE
refactor: make MetricLabel more generic

### DIFF
--- a/bindings/rust/standard/s2n-tls-metrics-schema/src/label.rs
+++ b/bindings/rust/standard/s2n-tls-metrics-schema/src/label.rs
@@ -25,13 +25,10 @@ impl Display for State {
 }
 
 /// Cache key keyed by slot index so the cache type stays non-generic.
-/// `(parameter, slot)` is unique across the four TLS parameter kinds because
-/// `TlsParam` already discriminates between them.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-struct MetricLabel {
-    parameter: TlsParam,
-    slot: usize,
-    state: State,
+struct TelemetryLabel {
+    prefix: &'static str,
+    counter_slot: usize,
 }
 
 /// We want all of our metrics counters to be prefixed, e.g. `group.negotiated.secp256r1`
@@ -42,40 +39,58 @@ struct MetricLabel {
 ///
 /// This is acceptable because it's just a finite set of values.
 #[derive(Debug, Default)]
-struct MetricLabeller(RwLock<HashMap<MetricLabel, &'static str>>);
+struct TelemetryLabeller(RwLock<HashMap<TelemetryLabel, &'static str>>);
 
-impl MetricLabeller {
-    fn get(&self, metric: &MetricLabel) -> Option<&'static str> {
-        self.0.read().unwrap().get(metric).map(|label| &**label)
+impl TelemetryLabeller {
+    fn get(&self, telemetry: &TelemetryLabel) -> Option<&'static str> {
+        self.0.read().unwrap().get(telemetry).map(|label| &**label)
     }
 
-    fn insert(&self, metric: MetricLabel, value: String) -> &'static str {
+    fn insert(&self, telemetry: &TelemetryLabel, value: String) -> &'static str {
         let mut write_lock = self.0.write().unwrap();
         // it's important that we only leak _after_ we have acquired the write lock.
         // otherwise we might end up leaking extra copies of the metric label
         let label = value.leak();
-        write_lock.insert(metric, label);
+        write_lock.insert(*telemetry, label);
         label
     }
 }
 
 /// lookup from metric to the prefixed string, e.g. "group.negotiated.secp256r1"
-pub fn metric_label<T>(slot: usize, item: T, parameter: TlsParam, state: State) -> &'static str
+pub fn telemetry_label<T>(counter_slot: usize, item: T, prefix: &'static str) -> &'static str
 where
     T: Display,
 {
-    static PREFIXER: LazyLock<MetricLabeller> = LazyLock::new(MetricLabeller::default);
+    static PREFIXER: LazyLock<TelemetryLabeller> = LazyLock::new(TelemetryLabeller::default);
 
-    let key = MetricLabel {
-        parameter,
-        slot,
-        state,
+    let key = TelemetryLabel {
+        prefix,
+        counter_slot,
     };
 
     match PREFIXER.get(&key) {
         Some(label) => label,
-        None => PREFIXER.insert(key, format!("{parameter}.{state}.{item}")),
+        None => PREFIXER.insert(&key, format!("{prefix}.{item}")),
     }
+}
+
+/// a helper function to create the prefix for (param, state) tuples
+pub fn telemetry_prefix(param: TlsParam, state: State) -> &'static str {
+    let prefix = match (param, state) {
+        (TlsParam::Version, State::Negotiated) => "version.negotiated",
+        (TlsParam::Version, State::Supported) => "version.supported",
+        (TlsParam::Cipher, State::Negotiated) => "cipher.negotiated",
+        (TlsParam::Cipher, State::Supported) => "cipher.supported",
+        (TlsParam::Group, State::Negotiated) => "group.negotiated",
+        (TlsParam::Group, State::Supported) => "group.supported",
+        (TlsParam::SignatureScheme, State::Negotiated) => "signature_scheme.negotiated",
+        (TlsParam::SignatureScheme, State::Supported) => "signature_scheme.supported",
+    };
+    // this debug assert makes sure that our labels match the Display implementation.
+    // We don't directly use Display because that requires an allocation. We could
+    // introduce a static display trait, but that feels like overkill :)
+    debug_assert_eq!(format!("{param}.{state}"), prefix);
+    prefix
 }
 
 #[cfg(test)]
@@ -86,11 +101,10 @@ mod tests {
     #[test]
     fn label_output() {
         assert_eq!(
-            metric_label(
+            telemetry_label(
                 0,
                 Cipher::TLS_AES_256_GCM_SHA384,
-                TlsParam::Cipher,
-                State::Negotiated,
+                telemetry_prefix(TlsParam::Cipher, State::Negotiated),
             ),
             "cipher.negotiated.TLS_AES_256_GCM_SHA384"
         );

--- a/bindings/rust/standard/s2n-tls-metrics-schema/src/record.rs
+++ b/bindings/rust/standard/s2n-tls-metrics-schema/src/record.rs
@@ -15,7 +15,7 @@ use crate::{
 };
 
 use crate::{
-    label::{State, metric_label},
+    label::{State, telemetry_label, telemetry_prefix},
     static_lists::{FiniteCounter, TlsParam},
 };
 
@@ -125,65 +125,56 @@ impl metrique_writer::Entry for FrozenHandshakeRecord {
 
         fn write_counter<'a, const N: usize, T, W>(
             counter: &'a FrozenCounter<N, T>,
-            parameter: TlsParam,
-            state: State,
+            prefix: &'static str,
             writer: &mut W,
         ) where
             T: FiniteCounter<N> + std::fmt::Display,
             W: metrique_writer::EntryWriter<'a>,
         {
             for (slot, element, count) in counter.iter_non_zero() {
-                let label = metric_label(slot, element, parameter, state);
+                let label = telemetry_label(slot, element, prefix);
                 writer.value(label, &count);
             }
         }
 
         write_counter(
             &self.negotiated_protocols,
-            TlsParam::Version,
-            State::Negotiated,
+            telemetry_prefix(TlsParam::Version, State::Negotiated),
             writer,
         );
         write_counter(
             &self.negotiated_ciphers,
-            TlsParam::Cipher,
-            State::Negotiated,
+            telemetry_prefix(TlsParam::Cipher, State::Negotiated),
             writer,
         );
         write_counter(
             &self.negotiated_groups,
-            TlsParam::Group,
-            State::Negotiated,
+            telemetry_prefix(TlsParam::Group, State::Negotiated),
             writer,
         );
         write_counter(
             &self.negotiated_signatures,
-            TlsParam::SignatureScheme,
-            State::Negotiated,
+            telemetry_prefix(TlsParam::SignatureScheme, State::Negotiated),
             writer,
         );
         write_counter(
             &self.supported_protocols,
-            TlsParam::Version,
-            State::Supported,
+            telemetry_prefix(TlsParam::Version, State::Supported),
             writer,
         );
         write_counter(
             &self.supported_ciphers,
-            TlsParam::Cipher,
-            State::Supported,
+            telemetry_prefix(TlsParam::Cipher, State::Supported),
             writer,
         );
         write_counter(
             &self.supported_groups,
-            TlsParam::Group,
-            State::Supported,
+            telemetry_prefix(TlsParam::Group, State::Supported),
             writer,
         );
         write_counter(
             &self.supported_signatures,
-            TlsParam::SignatureScheme,
-            State::Supported,
+            telemetry_prefix(TlsParam::SignatureScheme, State::Supported),
             writer,
         );
 


### PR DESCRIPTION
# Goal
Make the `MetricLabel` more generic

## Why
So that it can be used with other types of counters.

https://github.com/aws/s2n-tls/pull/5911 adds a number of counters, but they don't fit neatly into the "metric label" paradigm. Switching to TelemetryLabel with a `&'static str` prefix allows this to be used for our security policy and cert counters.

## How
API change.

## Testing
Everything should remain the same. Ideally this is merged after the snapshot test that I added.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
