### PR TITLE
feat(metrics): add visibility into failures

### DIFF
--- a/api/unstable/events.h
+++ b/api/unstable/events.h
@@ -47,6 +47,12 @@ struct s2n_event_handshake {
      */
     uint64_t handshake_start_ns;
     uint64_t handshake_end_ns;
+    /**
+     * If the handshake failed, this contains the error code.
+     * 0 indicates no error (successful handshake).
+     * The error name can be retrieved via s2n_strerror_name(error_code).
+     */
+    int error_code;
 };
 
 typedef void (*s2n_event_on_handshake_cb)(struct s2n_connection *conn, void *subscriber, struct s2n_event_handshake *event);
@@ -58,6 +64,7 @@ S2N_API extern int s2n_config_set_subscriber(struct s2n_config *config, void *su
  * The `struct s2n_event_handshake *event` is only valid over the lifetime of the 
  * callbacks, and must not be referenced after the callback returned.
  * 
- * An event is not emitted if the handshake fails.
+ * An event is emitted both on success and failure. On failure, the event's
+ * error_code field will be set with the relevant error information.
  */
 S2N_API extern int s2n_config_set_handshake_event(struct s2n_config *config, s2n_event_on_handshake_cb callback);

--- a/bindings/rust/extended/s2n-tls/src/events.rs
+++ b/bindings/rust/extended/s2n-tls/src/events.rs
@@ -7,12 +7,54 @@ use crate::connection::Connection;
 
 pub struct HandshakeEvent<'a>(&'a s2n_tls_sys::s2n_event_handshake);
 
+/// The outcome of a handshake: either success with negotiated parameters,
+/// or failure with error information.
+pub enum HandshakeResult<'a> {
+    Success(HandshakeSuccess<'a>),
+    Failure(HandshakeFailure<'a>),
+}
+
+/// Negotiated parameters available after a successful handshake.
+pub struct HandshakeSuccess<'a>(&'a s2n_tls_sys::s2n_event_handshake);
+
+/// Error information available after a failed handshake.
+pub struct HandshakeFailure<'a>(&'a s2n_tls_sys::s2n_event_handshake);
+
 impl<'a> HandshakeEvent<'a> {
     pub(crate) fn new(event: &'a s2n_tls_sys::s2n_event_handshake) -> Self {
         Self(event)
     }
 
-    /// Return the negotiated protocol version on the connection
+    /// The security policy label for the connection.
+    pub fn security_policy_label(&self) -> &'static str {
+        maybe_string(self.0.security_policy_label).unwrap_or("unknown")
+    }
+
+    /// Handshake duration, which includes network latency and waiting for the peer.
+    pub fn duration(&self) -> Duration {
+        Duration::from_nanos(self.0.handshake_end_ns - self.0.handshake_start_ns)
+    }
+
+    /// Handshake time, which is just the amount of time synchronously spent in s2n_negotiate.
+    ///
+    /// This is roughly the "cpu cost" of the handshake.
+    pub fn synchronous_time(&self) -> Duration {
+        Duration::from_nanos(self.0.handshake_time_ns)
+    }
+
+    /// Returns the outcome of the handshake, providing access to either the
+    /// negotiated parameters (on success) or error information (on failure).
+    pub fn result(&self) -> HandshakeResult<'a> {
+        if self.0.error_code == 0 {
+            HandshakeResult::Success(HandshakeSuccess(self.0))
+        } else {
+            HandshakeResult::Failure(HandshakeFailure(self.0))
+        }
+    }
+}
+
+impl HandshakeSuccess<'_> {
+    /// Return the negotiated protocol version on the connection.
     pub fn protocol_version(&self) -> crate::enums::Version {
         self.0.protocol_version.try_into().unwrap()
     }
@@ -33,35 +75,32 @@ impl<'a> HandshakeEvent<'a> {
             Some(group)
         }
     }
+}
 
-    /// The security policy label for the connection.
-    pub fn security_policy_label(&self) -> &'static str {
-        maybe_string(self.0.security_policy_label).unwrap_or("unknown")
-    }
-
-    /// Handshake duration, which includes network latency and waiting for the peer.
-    pub fn duration(&self) -> Duration {
-        Duration::from_nanos(self.0.handshake_end_ns - self.0.handshake_start_ns)
-    }
-
-    /// Handshake time, which is just the amount of time synchronously spent in s2n_negotiate.
-    ///
-    /// This is roughly the "cpu cost" of the handshake.
-    pub fn synchronous_time(&self) -> Duration {
-        Duration::from_nanos(self.0.handshake_time_ns)
+impl HandshakeFailure<'_> {
+    /// The s2n error code for the handshake failure.
+    pub fn error_code(&self) -> i32 {
+        self.0.error_code
     }
 }
 
 impl Debug for HandshakeEvent<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("s2n_event_handshake")
-            .field("protocol_version", &self.protocol_version())
-            .field("cipher", &self.cipher())
-            .field("group", &self.group())
-            .field("security_policy_label", &self.security_policy_label())
-            .field("handshake_duration", &self.duration())
-            .field("handshake_cpu_duration", &self.synchronous_time())
-            .finish()
+        let mut s = f.debug_struct("HandshakeEvent");
+        s.field("security_policy_label", &self.security_policy_label())
+            .field("duration", &self.duration())
+            .field("synchronous_time", &self.synchronous_time());
+        match self.result() {
+            HandshakeResult::Success(success) => {
+                s.field("protocol_version", &success.protocol_version())
+                    .field("cipher", &success.cipher())
+                    .field("group", &success.group());
+            }
+            HandshakeResult::Failure(failure) => {
+                s.field("error_code", &failure.error_code());
+            }
+        }
+        s.finish()
     }
 }
 
@@ -87,6 +126,7 @@ pub trait EventSubscriber: 'static + Send + Sync {
 #[cfg(test)]
 mod tests {
     use futures_test::task::noop_waker;
+    use std::ffi::CStr;
 
     use crate::{
         enums::Version, error::Error as S2NError, security::DEFAULT_TLS13,
@@ -97,6 +137,7 @@ mod tests {
             atomic::{AtomicU64, Ordering},
             Arc, Mutex,
         },
+        task::Poll,
         time::SystemTime,
     };
 
@@ -105,8 +146,9 @@ mod tests {
         security::{self, Policy},
         testing::{build_config, config_builder, TestPair},
     };
+
     #[derive(Debug)]
-    struct ExpectedEvent {
+    struct ExpectedSuccess {
         cipher: &'static str,
         group: Option<&'static str>,
         protocol: crate::enums::Version,
@@ -116,31 +158,34 @@ mod tests {
     #[derive(Debug, Default)]
     pub struct TestSubscriber {
         invoked: Arc<AtomicU64>,
-        expected_event: Arc<Mutex<Option<ExpectedEvent>>>,
+        expected: Arc<Mutex<Option<ExpectedSuccess>>>,
     }
 
-    impl ExpectedEvent {
-        fn assert_similar(&self, event: &HandshakeEvent) {
-            assert_eq!(self.cipher, event.cipher());
-            assert_eq!(self.group, event.group());
-            assert_eq!(self.protocol, event.protocol_version());
+    impl ExpectedSuccess {
+        fn assert_matches(&self, event: &HandshakeEvent) {
+            let success = match event.result() {
+                HandshakeResult::Success(s) => s,
+                HandshakeResult::Failure(_) => panic!("expected success, got failure"),
+            };
+            assert_eq!(self.cipher, success.cipher());
+            assert_eq!(self.group, success.group());
+            assert_eq!(self.protocol, success.protocol_version());
             assert_eq!(self.security_policy_label, event.security_policy_label());
         }
     }
 
     impl TestSubscriber {
-        fn set_expected_event(&self, event: ExpectedEvent) {
-            let mut expected_event = self.expected_event.lock().unwrap();
-            *expected_event = Some(event);
+        fn set_expected(&self, event: ExpectedSuccess) {
+            *self.expected.lock().unwrap() = Some(event);
         }
     }
 
     impl EventSubscriber for TestSubscriber {
         fn on_handshake_event(&self, _conn: &Connection, event: &HandshakeEvent) {
             assert!(event.synchronous_time() <= event.duration());
-            let expected_event = self.expected_event.lock().unwrap();
-            if let Some(expected) = expected_event.as_ref() {
-                expected.assert_similar(event);
+            let expected = self.expected.lock().unwrap();
+            if let Some(expected) = expected.as_ref() {
+                expected.assert_matches(event);
             }
             self.invoked
                 .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
@@ -149,7 +194,7 @@ mod tests {
 
     #[test]
     fn tls13_handshake() -> Result<(), S2NError> {
-        const EXPECTED_EVENT: ExpectedEvent = ExpectedEvent {
+        const EXPECTED: ExpectedSuccess = ExpectedSuccess {
             cipher: "TLS_AES_128_GCM_SHA256",
             group: Some("X25519MLKEM768"),
             protocol: Version::TLS13,
@@ -158,7 +203,7 @@ mod tests {
 
         let subscriber = TestSubscriber::default();
         let invoked = subscriber.invoked.clone();
-        subscriber.set_expected_event(EXPECTED_EVENT);
+        subscriber.set_expected(EXPECTED);
 
         let server_config = {
             let mut builder = config_builder(&security::DEFAULT).unwrap();
@@ -206,7 +251,7 @@ mod tests {
     /// When RSA key exchange is negotiated, the group is not recorded in the event
     #[test]
     fn rsa_key_exchange() -> Result<(), S2NError> {
-        const EXPECTED_EVENT: ExpectedEvent = ExpectedEvent {
+        const EXPECTED: ExpectedSuccess = ExpectedSuccess {
             cipher: "AES128-SHA256",
             group: None,
             protocol: Version::TLS12,
@@ -218,7 +263,7 @@ mod tests {
 
         let subscriber = TestSubscriber::default();
         let invoked = subscriber.invoked.clone();
-        subscriber.set_expected_event(EXPECTED_EVENT);
+        subscriber.set_expected(EXPECTED);
 
         let server_config = {
             let mut builder = config_builder(&rsa_kx_policy).unwrap();
@@ -238,13 +283,13 @@ mod tests {
 
     #[test]
     fn tls12_handshake() -> Result<(), S2NError> {
-        const FULL_HS_EVENT: ExpectedEvent = ExpectedEvent {
+        const FULL_HS: ExpectedSuccess = ExpectedSuccess {
             cipher: "ECDHE-RSA-AES128-GCM-SHA256",
             group: Some("secp256r1"),
             protocol: Version::TLS12,
             security_policy_label: "ELBSecurityPolicy-TLS-1-0-2015-04",
         };
-        const RESUMPTION_EVENT: ExpectedEvent = ExpectedEvent {
+        const RESUMPTION: ExpectedSuccess = ExpectedSuccess {
             cipher: "ECDHE-RSA-AES128-GCM-SHA256",
             group: None,
             protocol: Version::TLS12,
@@ -253,7 +298,7 @@ mod tests {
 
         let subscriber = TestSubscriber::default();
         let invoked = subscriber.invoked.clone();
-        let expected_event = subscriber.expected_event.clone();
+        let expected = subscriber.expected.clone();
         // arbitrary policy which only allows TLS 1.2 and supports ECDHE
         let tls12_ecdhe_policy = Policy::from_version("ELBSecurityPolicy-TLS-1-0-2015-04")?;
 
@@ -280,7 +325,7 @@ mod tests {
         };
 
         // full handshake: ECDHE negotiated, so group is recorded
-        *expected_event.lock().unwrap() = Some(FULL_HS_EVENT);
+        *expected.lock().unwrap() = Some(FULL_HS);
         {
             let mut test_pair = TestPair::from_configs(&client_config, &server_config);
             test_pair.client.set_waker(Some(&noop_waker()))?;
@@ -290,7 +335,7 @@ mod tests {
 
         // session resumption: there is no additional ECDHE in TLS 1.2 session
         // resumption, so no group is recorded.
-        *expected_event.lock().unwrap() = Some(RESUMPTION_EVENT);
+        *expected.lock().unwrap() = Some(RESUMPTION);
         {
             let mut test_pair = TestPair::from_configs(&client_config, &server_config);
             test_pair.client.set_waker(Some(&noop_waker()))?;
@@ -329,11 +374,24 @@ mod tests {
         Ok(())
     }
 
-    /// No handshake event is emitted in the case of failure.
+    /// A handshake event is emitted in the case of failure, with error information.
     #[test]
-    fn no_event_when_failure() -> Result<(), S2NError> {
-        let subscriber = TestSubscriber::default();
-        let invoked = subscriber.invoked.clone();
+    fn failure_event() -> Result<(), S2NError> {
+        #[derive(Debug, Default)]
+        struct TestErrorSubscriber {
+            error_code: Arc<Mutex<Option<i32>>>,
+        }
+
+        impl EventSubscriber for TestErrorSubscriber {
+            fn on_handshake_event(&self, _conn: &Connection, event: &HandshakeEvent) {
+                if let HandshakeResult::Failure(failure) = event.result() {
+                    *self.error_code.lock().unwrap() = Some(failure.error_code());
+                }
+            }
+        }
+
+        let subscriber = TestErrorSubscriber::default();
+        let error_code = subscriber.error_code.clone();
 
         let server_config = {
             // doesn't allow TLS 1.3
@@ -346,9 +404,26 @@ mod tests {
         let client_config = build_config(&DEFAULT_TLS13).unwrap();
 
         let mut pair = TestPair::from_configs(&client_config, &server_config);
-        pair.handshake().unwrap_err();
+        // Drive the client first to send the ClientHello, then the server
+        // to process it and fail.
+        pair.server.set_waker(Some(&noop_waker()))?;
+        let _ = pair.client.poll_negotiate();
+        let server_err = match pair.server.poll_negotiate() {
+            Poll::Ready(Err(e)) => e,
+            other => panic!("expected server failure, got {:?}", other),
+        };
 
-        assert_eq!(invoked.load(Ordering::Relaxed), 0);
+        let code = error_code
+            .lock()
+            .unwrap()
+            .expect("failure event was emitted");
+        let event_error_name = unsafe {
+            CStr::from_ptr(s2n_tls_sys::s2n_strerror_name(code))
+                .to_str()
+                .unwrap()
+        };
+        assert_eq!(event_error_name, server_err.name());
+
         Ok(())
     }
 }

--- a/bindings/rust/standard/s2n-tls-metrics-schema/src/record.rs
+++ b/bindings/rust/standard/s2n-tls-metrics-schema/src/record.rs
@@ -57,7 +57,7 @@ pub struct FrozenHandshakeRecord {
     pub handshake_success_count: u64,
 
     #[serde(default)]
-    pub handshake_failed_count: u64,
+    pub handshake_failure_count: u64,
 
     #[serde(default)]
     pub negotiated_protocols: FrozenCounter<PROTOCOL_COUNT, Version>,
@@ -102,7 +102,7 @@ impl Default for FrozenHandshakeRecord {
         Self {
             freeze_time: SystemTime::UNIX_EPOCH,
             handshake_success_count: 0,
-            handshake_failed_count: 0,
+            handshake_failure_count: 0,
             negotiated_protocols: FrozenCounter::default(),
             negotiated_ciphers: FrozenCounter::default(),
             negotiated_groups: FrozenCounter::default(),
@@ -195,7 +195,7 @@ impl metrique_writer::Entry for FrozenHandshakeRecord {
 
         writer.value("sslv2_client_hello", &self.sslv2_client_hello);
         writer.value("handshake_success_count", &self.handshake_success_count);
-        writer.value("handshake_failed_count", &self.handshake_failed_count);
+        writer.value("handshake_failure_count", &self.handshake_failure_count);
         writer.value("handshake_duration_us", &self.handshake_duration_us);
         writer.value("handshake_compute_us", &self.handshake_compute_us);
         writer.value("synthetic_traffic_count", &self.synthetic_traffic_count);

--- a/bindings/rust/standard/s2n-tls-metrics-schema/src/record.rs
+++ b/bindings/rust/standard/s2n-tls-metrics-schema/src/record.rs
@@ -54,7 +54,10 @@ pub struct FrozenHandshakeRecord {
     pub freeze_time: SystemTime,
 
     #[serde(default)]
-    pub handshake_count: u64,
+    pub handshake_success_count: u64,
+
+    #[serde(default)]
+    pub handshake_failed_count: u64,
 
     #[serde(default)]
     pub negotiated_protocols: FrozenCounter<PROTOCOL_COUNT, Version>,
@@ -98,7 +101,8 @@ impl Default for FrozenHandshakeRecord {
     fn default() -> Self {
         Self {
             freeze_time: SystemTime::UNIX_EPOCH,
-            handshake_count: 0,
+            handshake_success_count: 0,
+            handshake_failed_count: 0,
             negotiated_protocols: FrozenCounter::default(),
             negotiated_ciphers: FrozenCounter::default(),
             negotiated_groups: FrozenCounter::default(),
@@ -190,7 +194,8 @@ impl metrique_writer::Entry for FrozenHandshakeRecord {
         writer.value("compatibility.cnsa2", &self.compatibility_cnsa2);
 
         writer.value("sslv2_client_hello", &self.sslv2_client_hello);
-        writer.value("handshake_count", &self.handshake_count);
+        writer.value("handshake_success_count", &self.handshake_success_count);
+        writer.value("handshake_failed_count", &self.handshake_failed_count);
         writer.value("handshake_duration_us", &self.handshake_duration_us);
         writer.value("handshake_compute_us", &self.handshake_compute_us);
         writer.value("synthetic_traffic_count", &self.synthetic_traffic_count);
@@ -203,10 +208,10 @@ mod tests {
 
     #[test]
     fn deserialize_missing_fields_uses_defaults() {
-        let json = r#"{"handshake_count": 10}"#;
+        let json = r#"{"handshake_success_count": 10}"#;
         let record: FrozenHandshakeRecord = serde_json::from_str(json).unwrap();
 
-        assert_eq!(record.handshake_count, 10);
+        assert_eq!(record.handshake_success_count, 10);
         assert_eq!(record.freeze_time, SystemTime::UNIX_EPOCH);
 
         assert_eq!(record.negotiated_protocols, FrozenCounter::default());

--- a/bindings/rust/standard/s2n-tls-metrics-schema/tests/public_api.rs
+++ b/bindings/rust/standard/s2n-tls-metrics-schema/tests/public_api.rs
@@ -21,7 +21,7 @@ fn sample_schema_record() -> s2n_tls_metrics_schema::record::MetricRecord {
         },
         "handshake": {
             "freeze_time": {"secs_since_epoch": 1_700_000_000u64, "nanos_since_epoch": 0u32},
-            "handshake_count": 1000,
+            "handshake_success_count": 1000,
             "negotiated_protocols": [[0x0303u16, 400], [0x0304u16, 600]],
             "negotiated_ciphers": [[[0x13, 0x01], 600], [[0x13, 0x02], 400]],
             "negotiated_groups": [[23u16, 500], [29u16, 500]],
@@ -67,7 +67,7 @@ fn cbor_stream_round_trip() {
     assert_eq!(records.len(), 3);
     for r in &records {
         assert_eq!(r.attribution.service, "my-service");
-        assert_eq!(r.handshake.handshake_count, 1000);
+        assert_eq!(r.handshake.handshake_success_count, 1000);
     }
 }
 
@@ -82,7 +82,7 @@ fn schema_field_access() {
         "arn:aws:elasticloadbalancing:us-east-1:123:listener/abc"
     );
 
-    assert_eq!(record.handshake.handshake_count, 1000);
+    assert_eq!(record.handshake.handshake_success_count, 1000);
     assert_eq!(record.handshake.sslv2_client_hello, 2);
     assert_eq!(record.handshake.compatibility_general20251201, 950);
     assert_eq!(record.handshake.compatibility_fips20251201, 800);
@@ -214,7 +214,7 @@ fn empty_record_has_zero_slots() {
         "attribution": { "service": "s", "resource": "r" },
         "handshake": {
             "freeze_time": {"secs_since_epoch": 0u64, "nanos_since_epoch": 0u32},
-            "handshake_count": 0u64
+            "handshake_success_count": 0u64
         }
     });
     let record: s2n_tls_metrics_schema::record::MetricRecord =

--- a/bindings/rust/standard/s2n-tls-metrics-subscriber/src/detector.rs
+++ b/bindings/rust/standard/s2n-tls-metrics-subscriber/src/detector.rs
@@ -9,7 +9,7 @@
 //! handshake should be counted as synthetic. When a detector returns `true`,
 //! [`AggregatedMetricsSubscriber`] increments only the `synthetic_traffic_count`
 //! field on the in-progress record; every other counter (including
-//! `handshake_count`) is left untouched, so each metric can be read directly
+//! `handshake_success_count`) is left untouched, so each metric can be read directly
 //! as a real traffic figure.
 //!
 //! [`ClientHello`]: s2n_tls::client_hello::ClientHello

--- a/bindings/rust/standard/s2n-tls-metrics-subscriber/src/record.rs
+++ b/bindings/rust/standard/s2n-tls-metrics-subscriber/src/record.rs
@@ -42,7 +42,10 @@ pub(crate) struct HandshakeRecordInProgress {
     exporter: std::sync::mpsc::Sender<FrozenHandshakeRecord>,
 
     /// the total number of handshakes that this record represents.
-    handshake_count: AtomicU64,
+    handshake_success_count: AtomicU64,
+
+    /// the total number of failed handshakes
+    handshake_failed_count: AtomicU64,
 
     negotiated_protocols: Counter<PROTOCOL_COUNT, Version>,
     negotiated_ciphers: Counter<CIPHER_COUNT, Cipher>,
@@ -64,23 +67,24 @@ pub(crate) struct HandshakeRecordInProgress {
 
     /// sum of handshake duration, including network latency and waiting
     ///
-    /// To get the average, divide this by handshake_count.
+    /// To get the average, divide this by handshake_success_count.
     handshake_duration_us: AtomicU64,
     /// sum of handshake compute
     ///
-    /// To get the average, divide this by handshake_count.
+    /// To get the average, divide this by handshake_success_count.
     handshake_compute_us: AtomicU64,
 
     /// Number of handshakes flagged by the configured
     /// [`SyntheticTrafficDetector`]. Synthetic handshakes are excluded from
-    /// every other counter on this record (including `handshake_count`).
+    /// every other counter on this record (including `handshake_success_count`).
     synthetic_traffic_count: AtomicU64,
 }
 
 impl HandshakeRecordInProgress {
     pub fn new(exporter: std::sync::mpsc::Sender<FrozenHandshakeRecord>) -> Self {
         Self {
-            handshake_count: Default::default(),
+            handshake_success_count: Default::default(),
+            handshake_failed_count: Default::default(),
 
             negotiated_groups: Counter::new(),
             negotiated_ciphers: Counter::new(),
@@ -115,7 +119,7 @@ impl HandshakeRecordInProgress {
 
         // Run the detector first, on every handshake (including SSLv2).
         // Synthetic handshakes contribute ONLY to `synthetic_traffic_count`;
-        // every other counter (including `handshake_count`) reflects real
+        // every other counter (including `handshake_success_count`) reflects real
         // traffic only, so consumers can read each metric directly without
         // post-processing.
         if let Some(detector) = detector {
@@ -125,7 +129,16 @@ impl HandshakeRecordInProgress {
             }
         }
 
-        self.handshake_count.fetch_add(1, Ordering::Relaxed);
+        let success = match event.result() {
+            s2n_tls::events::HandshakeResult::Failure(_) => {
+                self.handshake_failed_count.fetch_add(1, Ordering::Relaxed);
+                return Ok(());
+            }
+            s2n_tls::events::HandshakeResult::Success(s) => {
+                self.handshake_success_count.fetch_add(1, Ordering::Relaxed);
+                s
+            }
+        };
 
         if let Some(sig) = conn.signature_scheme().and_then(|s| s.parse().ok()) {
             self.negotiated_signatures.increment(&sig);
@@ -174,15 +187,15 @@ impl HandshakeRecordInProgress {
             }
         }
 
-        if let Some(version) = protocol_version_to_iana(event.protocol_version()) {
+        if let Some(version) = protocol_version_to_iana(success.protocol_version()) {
             self.negotiated_protocols.increment(&version);
         }
 
-        if let Some(cipher) = Cipher::from_openssl_name(event.cipher()) {
+        if let Some(cipher) = Cipher::from_openssl_name(success.cipher()) {
             self.negotiated_ciphers.increment(&cipher);
         }
 
-        if let Some(group) = event.group().and_then(|g| g.parse().ok()) {
+        if let Some(group) = success.group().and_then(|g| g.parse().ok()) {
             self.negotiated_groups.increment(&group);
         }
 
@@ -212,7 +225,8 @@ impl HandshakeRecordInProgress {
     fn finish(&mut self) -> FrozenHandshakeRecord {
         FrozenHandshakeRecord {
             freeze_time: SystemTime::now(),
-            handshake_count: self.handshake_count.load(Ordering::Relaxed),
+            handshake_success_count: self.handshake_success_count.load(Ordering::Relaxed),
+            handshake_failed_count: self.handshake_failed_count.load(Ordering::Relaxed),
             negotiated_protocols: self.negotiated_protocols.freeze(),
             negotiated_ciphers: self.negotiated_ciphers.freeze(),
             negotiated_groups: self.negotiated_groups.freeze(),
@@ -265,7 +279,7 @@ mod tests {
         let records = endpoint.sink.records.lock().unwrap();
         let record = &records[0].as_schema().handshake;
 
-        assert_eq!(record.handshake_count, 1);
+        assert_eq!(record.handshake_success_count, 1);
         assert_eq!(
             record
                 .negotiated_ciphers
@@ -410,7 +424,7 @@ mod tests {
         let records = endpoint.sink.records.lock().unwrap();
         let record = &records[0].as_schema().handshake;
 
-        assert_eq!(record.handshake_count, 3);
+        assert_eq!(record.handshake_success_count, 3);
         assert_eq!(
             record
                 .negotiated_ciphers

--- a/bindings/rust/standard/s2n-tls-metrics-subscriber/src/record.rs
+++ b/bindings/rust/standard/s2n-tls-metrics-subscriber/src/record.rs
@@ -45,7 +45,7 @@ pub(crate) struct HandshakeRecordInProgress {
     handshake_success_count: AtomicU64,
 
     /// the total number of failed handshakes
-    handshake_failed_count: AtomicU64,
+    handshake_failure_count: AtomicU64,
 
     negotiated_protocols: Counter<PROTOCOL_COUNT, Version>,
     negotiated_ciphers: Counter<CIPHER_COUNT, Cipher>,
@@ -84,7 +84,7 @@ impl HandshakeRecordInProgress {
     pub fn new(exporter: std::sync::mpsc::Sender<FrozenHandshakeRecord>) -> Self {
         Self {
             handshake_success_count: Default::default(),
-            handshake_failed_count: Default::default(),
+            handshake_failure_count: Default::default(),
 
             negotiated_groups: Counter::new(),
             negotiated_ciphers: Counter::new(),
@@ -131,7 +131,7 @@ impl HandshakeRecordInProgress {
 
         let success = match event.result() {
             s2n_tls::events::HandshakeResult::Failure(_) => {
-                self.handshake_failed_count.fetch_add(1, Ordering::Relaxed);
+                self.handshake_failure_count.fetch_add(1, Ordering::Relaxed);
                 return Ok(());
             }
             s2n_tls::events::HandshakeResult::Success(s) => {
@@ -226,7 +226,7 @@ impl HandshakeRecordInProgress {
         FrozenHandshakeRecord {
             freeze_time: SystemTime::now(),
             handshake_success_count: self.handshake_success_count.load(Ordering::Relaxed),
-            handshake_failed_count: self.handshake_failed_count.load(Ordering::Relaxed),
+            handshake_failure_count: self.handshake_failure_count.load(Ordering::Relaxed),
             negotiated_protocols: self.negotiated_protocols.freeze(),
             negotiated_ciphers: self.negotiated_ciphers.freeze(),
             negotiated_groups: self.negotiated_groups.freeze(),

--- a/bindings/rust/standard/s2n-tls-metrics-subscriber/src/subscriber.rs
+++ b/bindings/rust/standard/s2n-tls-metrics-subscriber/src/subscriber.rs
@@ -294,9 +294,9 @@ mod tests {
         );
 
         // Verify handshake counts
-        assert_eq!(records[0].as_schema().handshake.handshake_count, 2);
-        assert_eq!(records[1].as_schema().handshake.handshake_count, 1);
-        assert_eq!(records[2].as_schema().handshake.handshake_count, 0);
+        assert_eq!(records[0].as_schema().handshake.handshake_success_count, 2);
+        assert_eq!(records[1].as_schema().handshake.handshake_success_count, 1);
+        assert_eq!(records[2].as_schema().handshake.handshake_success_count, 0);
     }
 
     /// Passive export: when the interval has elapsed, the next handshake
@@ -400,7 +400,7 @@ mod tests {
         assert_eq!(records.len(), 1);
         let record = &records[0].as_schema().handshake;
 
-        assert_eq!(record.handshake_count, 2);
+        assert_eq!(record.handshake_success_count, 2);
         assert_eq!(record.synthetic_traffic_count, 3);
         assert_eq!(record.negotiated_protocols.total(), 2);
         assert_eq!(record.negotiated_ciphers.total(), 2);
@@ -416,7 +416,7 @@ mod tests {
         endpoint.subscriber.finish_record();
 
         let records = endpoint.sink.records.lock().unwrap();
-        assert_eq!(records[0].as_schema().handshake.handshake_count, 2);
+        assert_eq!(records[0].as_schema().handshake.handshake_success_count, 2);
         assert_eq!(records[0].as_schema().handshake.synthetic_traffic_count, 0);
     }
 }

--- a/bindings/rust/standard/s2n-tls-metrics-subscriber/tests/public_api.rs
+++ b/bindings/rust/standard/s2n-tls-metrics-subscriber/tests/public_api.rs
@@ -55,7 +55,7 @@ fn opaque_serialize_then_schema_deserialize() {
 
     assert_eq!(schema_record.attribution.service, "test");
     assert_eq!(schema_record.attribution.component, "frontend");
-    assert_eq!(schema_record.handshake.handshake_count, 1);
+    assert_eq!(schema_record.handshake.handshake_success_count, 1);
     assert!(
         schema_record
             .handshake

--- a/bindings/rust/standard/s2n-tls-metrics-subscriber/tests/snapshots/entry_emf.json
+++ b/bindings/rust/standard/s2n-tls-metrics-subscriber/tests/snapshots/entry_emf.json
@@ -128,7 +128,10 @@
             "Name": "sslv2_client_hello"
           },
           {
-            "Name": "handshake_count"
+            "Name": "handshake_success_count"
+          },
+          {
+            "Name": "handshake_failed_count"
           },
           {
             "Name": "handshake_duration_us"
@@ -169,8 +172,9 @@
   "group.supported.secp521r1": 1,
   "group.supported.x25519": 1,
   "handshake_compute_us": "<DURATION>",
-  "handshake_count": 1,
   "handshake_duration_us": "<DURATION>",
+  "handshake_failed_count": 0,
+  "handshake_success_count": 1,
   "resource": "arn:aws:elasticloadbalancing:us-east-1:123:listener/abc",
   "service": "my-service",
   "signature_scheme.negotiated.rsa_pss_rsae_sha256": 1,

--- a/bindings/rust/standard/s2n-tls-metrics-subscriber/tests/snapshots/entry_emf.json
+++ b/bindings/rust/standard/s2n-tls-metrics-subscriber/tests/snapshots/entry_emf.json
@@ -131,7 +131,7 @@
             "Name": "handshake_success_count"
           },
           {
-            "Name": "handshake_failed_count"
+            "Name": "handshake_failure_count"
           },
           {
             "Name": "handshake_duration_us"
@@ -173,7 +173,7 @@
   "group.supported.x25519": 1,
   "handshake_compute_us": "<DURATION>",
   "handshake_duration_us": "<DURATION>",
-  "handshake_failed_count": 0,
+  "handshake_failure_count": 0,
   "handshake_success_count": 1,
   "resource": "arn:aws:elasticloadbalancing:us-east-1:123:listener/abc",
   "service": "my-service",

--- a/tests/unit/s2n_events_test.c
+++ b/tests/unit/s2n_events_test.c
@@ -68,6 +68,8 @@ int main(int argc, char **argv)
         EXPECT_EQUAL(event.handshake_end_ns, 0);
         EXPECT_EQUAL(event.handshake_start_ns, 0);
         EXPECT_EQUAL(event.handshake_time_ns, 0);
+        /* no error on success */
+        EXPECT_EQUAL(event.error_code, 0);
     };
 
     /* s2n_event_handshake_send: callback is invoked */

--- a/tls/s2n_handshake_io.c
+++ b/tls/s2n_handshake_io.c
@@ -1750,6 +1750,20 @@ int s2n_negotiate(struct s2n_connection *conn, s2n_blocked_status *blocked)
         conn->handshake_event.handshake_end_ns = negotiate_end;
         POSIX_GUARD_RESULT(s2n_event_handshake_populate(conn, &conn->handshake_event));
         POSIX_GUARD_RESULT(s2n_event_handshake_send(conn, &conn->handshake_event));
+    } else if (s2n_error_get_type(s2n_errno) != S2N_ERR_T_BLOCKED && conn->config) {
+        /* S2N_ERR_T_BLOCKED is the only retryable error type -- it indicates
+         * the handshake is still in progress but IO would block. All other
+         * error types are terminal failures, so we emit the failure event. */
+        conn->handshake_event.handshake_end_ns = negotiate_end;
+        conn->handshake_event.error_code = s2n_errno;
+        /* Save and restore error state because populate calls functions
+         * that may overwrite them (e.g. s2n_connection_get_key_exchange_group). */
+        int saved_errno = s2n_errno;
+        struct s2n_debug_info saved_debug_info = _s2n_debug_info;
+        POSIX_GUARD_RESULT(s2n_event_handshake_populate(conn, &conn->handshake_event));
+        POSIX_GUARD_RESULT(s2n_event_handshake_send(conn, &conn->handshake_event));
+        s2n_errno = saved_errno;
+        _s2n_debug_info = saved_debug_info;
     }
 
     conn->negotiate_in_use = false;


### PR DESCRIPTION
# Goal
Add failure information to the handshake event.

## Why
Failures are important telemetry for endpoint management.

## How
In the event of a terminal failure in s2n_negotiate, we store the errno on the handshake event.

I then add a split API to the event to distinguish between fields that are only useful during a failed/successful handshake. 

## Testing
Added new unit tests.

### Related
I will follow up with failure metrics for specific error codes, as well as alert counts.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
