### PR TITLE
ci: fix OpenBSD CI mirror and bump to 7.9

### DIFF
--- a/.github/workflows/ci_openbsd.yml
+++ b/.github/workflows/ci_openbsd.yml
@@ -28,6 +28,7 @@ jobs:
           cpu_count: 4
           shell: bash
           run: |
+            export PKG_PATH="https://cdn.openbsd.org/pub/OpenBSD/$(uname -r)/packages/$(uname -p)/"
             sudo pkg_add ninja cmake
             pkg_info
             sysctl -n kern.version

--- a/.github/workflows/ci_openbsd.yml
+++ b/.github/workflows/ci_openbsd.yml
@@ -28,7 +28,7 @@ jobs:
           cpu_count: 4
           shell: bash
           run: |
-            export PKG_PATH="https://cdn.openbsd.org/pub/OpenBSD/$(uname -r)/packages/$(uname -p)/"
+            sudo sh -c 'echo "https://cdn.openbsd.org/pub/OpenBSD" > /etc/installurl'
             sudo pkg_add ninja cmake
             pkg_info
             sysctl -n kern.version

--- a/.github/workflows/ci_openbsd.yml
+++ b/.github/workflows/ci_openbsd.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           operating_system: openbsd
           architecture: x86-64
-          version: '7.4'
+          version: '7.9'
           cpu_count: 4
           shell: bash
           run: |


### PR DESCRIPTION
# Goal
Fix the OpenBSD CI that is failing due to package mirror 403 errors

## Why
The OpenBSD VM image used by `cross-platform-actions` has a Leaseweb mirror (`mirror.fra10.de.leaseweb.net`) baked in that is [returning 403 Forbidden](https://github.com/aws/s2n-tls/actions/runs/27227470287/job/80406808534?pr=5913) for all package requests. This causes `pkg_add ninja cmake` to fail, breaking the entire CI job.

## How
- Override the package mirror by writing OpenBSD's official CDN (`cdn.openbsd.org`) to `/etc/installurl` before installing packages. This is the idiomatic way to configure package sources on OpenBSD.
- Bump the OpenBSD version from 7.4 to 7.9, since 7.4 is end-of-life and no longer receives security patches or guaranteed package availability.

## Callouts
The mirror issue affected all OpenBSD versions (confirmed with both 7.4 and 7.9), so the `/etc/installurl` fix is the actual unblock. The version bump is a separate improvement.

## Testing
CI passes with both changes applied

### Related
#5913

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
