### PR TITLE
ci: remove redundant download in buildspec

### DIFF
--- a/codebuild/spec/buildspec_unit_nix.yml
+++ b/codebuild/spec/buildspec_unit_nix.yml
@@ -162,7 +162,6 @@ phases:
       - |
         set -e
         if [[ ! $CODEBUILD_BATCH_BUILD_IDENTIFIER =~ .*"nixCache".* ]]; then
-          nix copy --from  $NIX_CACHE_BUCKET --all  --no-check-sigs
           nix develop $NIXDEV_ARGS $NIXDEV_LIBCRYPTO --command bash -c "source ./nix/shell.sh; configure";
         fi
   build:


### PR DESCRIPTION
# Goal
hopefully make the unit nix integration job faster.

## Why
it is slow

## How
remove a redundant download call.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
