### PR TITLE
ci: cache all dev shells

### DIFF
--- a/codebuild/spec/buildspec_integ_rust.yml
+++ b/codebuild/spec/buildspec_integ_rust.yml
@@ -136,19 +136,19 @@ phases:
       - |
         if [[ $CODEBUILD_BATCH_BUILD_IDENTIFIER =~ .*"nixCache".* ]]; then
           echo "Refreshing nix cache..."
-          nix copy --from $NIX_CACHE_BUCKET --all --no-check-sigs
+          nix copy --from $NIX_CACHE_BUCKET --all --no-check-sigs || true
           nix build .#devShell
           nix copy --to $NIX_CACHE_BUCKET .#devShell
         else
           echo "Downloading cache"
-          nix copy --from $NIX_CACHE_BUCKET --all --no-check-sigs
+          nix copy --from $NIX_CACHE_BUCKET --all --no-check-sigs || true
         fi
   pre_build:
     commands:
       - |
         set -e
         if [[ ! $CODEBUILD_BATCH_BUILD_IDENTIFIER =~ .*"nixCache".* ]]; then
-          nix copy --from $NIX_CACHE_BUCKET --all --no-check-sigs
+          nix copy --from $NIX_CACHE_BUCKET --all --no-check-sigs || true
           nix develop $NIXDEV_ARGS $NIXDEV_LIBCRYPTO --command bash -c "source ./nix/shell.sh; rust_configure"
         fi
   build:

--- a/codebuild/spec/buildspec_integv2_nix.yml
+++ b/codebuild/spec/buildspec_integv2_nix.yml
@@ -108,19 +108,19 @@ phases:
       - |
         if [[ $CODEBUILD_BATCH_BUILD_IDENTIFIER =~ .*"nixCache".* ]]; then
           echo "Refreshing nix cache..."
-          nix copy --from $NIX_CACHE_BUCKET --all --no-check-sigs
+          nix copy --from $NIX_CACHE_BUCKET --all --no-check-sigs || true
           nix build .#devShell
           nix copy --to $NIX_CACHE_BUCKET .#devShell
         else
           echo "Downloading cache"
-          nix copy --from $NIX_CACHE_BUCKET --all --no-check-sigs
+          nix copy --from $NIX_CACHE_BUCKET --all --no-check-sigs || true
         fi
   pre_build:
     commands:
       - |
         set -e
         if [[ ! $CODEBUILD_BATCH_BUILD_IDENTIFIER =~ .*"nixCache".* ]]; then
-          nix copy --from  $NIX_CACHE_BUCKET --all  --no-check-sigs
+          nix copy --from  $NIX_CACHE_BUCKET --all  --no-check-sigs || true
           nix develop $NIXDEV_ARGS $NIXDEV_LIBCRYPTO --command bash -c "source ./nix/shell.sh; configure"
         fi
   build:

--- a/codebuild/spec/buildspec_ktls.yml
+++ b/codebuild/spec/buildspec_ktls.yml
@@ -44,7 +44,7 @@ phases:
       - mkdir -p ~/.config/nix; echo "experimental-features = nix-command flakes" >> ~/.config/nix/nix.conf
       - if [[ $(date +%u) -eq 0 ]]; then nix store gc;fi
       # Populate the store from the nix cache
-      - nix copy --from $NIX_CACHE_BUCKET --all  --no-check-sigs
+      - nix copy --from $NIX_CACHE_BUCKET --all  --no-check-sigs || true
       # Load the TLS kernel module
       - sudo modprobe tls
       - echo "Checking that the TLS kernel mod loaded..."; test $(sudo lsmod|grep -c tls) = 1

--- a/codebuild/spec/buildspec_ktls_keyupdate.yml
+++ b/codebuild/spec/buildspec_ktls_keyupdate.yml
@@ -31,7 +31,7 @@ phases:
     commands:
       - if [[ $(date +%u) -eq 0 ]]; then nix store gc;fi
       # Populate the store from the nix cache
-      - nix copy --from $NIX_CACHE_BUCKET --all  --no-check-sigs
+      - nix copy --from $NIX_CACHE_BUCKET --all  --no-check-sigs || true
       # Load the TLS kernel module
       - sudo modprobe tls
       - echo "Checking that the TLS kernel mod loaded..."; test $(sudo lsmod|grep -c tls) = 1

--- a/codebuild/spec/buildspec_unit_nix.yml
+++ b/codebuild/spec/buildspec_unit_nix.yml
@@ -12,28 +12,8 @@ env:
 
 batch:
   build-graph:
-    # Cache job for x86
-    - identifier: nixCache_x86_64
-      comment: identifiers can not contain dashes
-      env:
-        compute-type: BUILD_GENERAL1_LARGE
-        image: public.ecr.aws/l1b2r3y5/nix-aws-codebuild:latest
-        variables:
-          NIX_CACHE_BUCKET: s3://s2n-tls-nixcachebucket-x86-64?region=us-west-2
-
-    # Cache job for aarch64
-    - identifier: nixCache_aarch64
-      env:
-        compute-type: BUILD_GENERAL1_LARGE
-        image: public.ecr.aws/l1b2r3y5/nix-aws-codebuild-aarch64:next
-        type: ARM_CONTAINER
-        variables:
-          NIX_CACHE_BUCKET: s3://s2n-tls-nixcachebucket-aarch64?region=us-west-2
-
     # Openssl30 x86
     - identifier: UnitOpenssl30_x86_64
-      depend-on:
-        - nixCache_x86_64
       env:
         compute-type: BUILD_GENERAL1_LARGE
         image: public.ecr.aws/l1b2r3y5/nix-aws-codebuild:latest
@@ -44,8 +24,6 @@ batch:
 
     # Openssl30 aarch64
     - identifier: UnitOpenssl30_aarch64
-      depend-on:
-        - nixCache_aarch64
       env:
         compute-type: BUILD_GENERAL1_LARGE
         image: public.ecr.aws/l1b2r3y5/nix-aws-codebuild-aarch64:next
@@ -57,8 +35,6 @@ batch:
 
     # Openssl111 aarch64
     - identifier: UnitOpenssl111_aarch64
-      depend-on:
-        - nixCache_aarch64
       env:
         compute-type: BUILD_GENERAL1_LARGE
         image: public.ecr.aws/l1b2r3y5/nix-aws-codebuild-aarch64:next
@@ -70,8 +46,6 @@ batch:
 
     # Openssl102 aarch64
     - identifier: UnitOpenssl102_aarch64
-      depend-on:
-        - nixCache_aarch64
       env:
         compute-type: BUILD_GENERAL1_LARGE
         image: public.ecr.aws/l1b2r3y5/nix-aws-codebuild-aarch64:next
@@ -83,8 +57,6 @@ batch:
 
     # libressl x86
     - identifier: UnitLibressl_x86_64
-      depend-on:
-        - nixCache_x86_64
       env:
         compute-type: BUILD_GENERAL1_LARGE
         image: public.ecr.aws/l1b2r3y5/nix-aws-codebuild:latest
@@ -95,8 +67,6 @@ batch:
 
     # awslc x86
     - identifier: UnitAwslc_x86_64
-      depend-on:
-        - nixCache_x86_64
       env:
         compute-type: BUILD_GENERAL1_LARGE
         image: public.ecr.aws/l1b2r3y5/nix-aws-codebuild:latest
@@ -107,8 +77,6 @@ batch:
 
     # awslc aarch64
     - identifier: UnitAwslc_aarch64
-      depend-on:
-        - nixCache_aarch64
       env:
         compute-type: BUILD_GENERAL1_LARGE
         image: public.ecr.aws/l1b2r3y5/nix-aws-codebuild-aarch64:next
@@ -120,8 +88,6 @@ batch:
 
     # awslcfips 2022 aarch64
     - identifier: UnitAwslcFips2022_aarch64
-      depend-on:
-        - nixCache_aarch64
       env:
         compute-type: BUILD_GENERAL1_LARGE
         image: public.ecr.aws/l1b2r3y5/nix-aws-codebuild-aarch64:next
@@ -133,8 +99,6 @@ batch:
 
     # awslcfips 2024 aarch64
     - identifier: UnitAwslcFips2024_aarch64
-      depend-on:
-        - nixCache_aarch64
       env:
         compute-type: BUILD_GENERAL1_LARGE
         image: public.ecr.aws/l1b2r3y5/nix-aws-codebuild-aarch64:next
@@ -148,33 +112,25 @@ phases:
   install:
     commands:
       - |
-        if [[ "$CODEBUILD_BATCH_BUILD_IDENTIFIER" =~ .*"nixCache".* ]]; then
-          echo "Refreshing nix cache..."
-          nix copy --from $NIX_CACHE_BUCKET --all --no-check-sigs
-          nix build $NIXDEV_ARGS .#devShell
-          nix copy --to $NIX_CACHE_BUCKET .#devShell;
-        else
-          echo "Downloading cache"
-          nix copy --from $NIX_CACHE_BUCKET --all --no-check-sigs
-        fi
+        echo "Downloading nix cache..."
+        # Tolerate missing/corrupt paths; nix develop will fetch anything missing from cache.nixos.org
+        # This is necessary because our S3 lifecycle rule might accidentally delete
+        # files.
+        nix copy --from $NIX_CACHE_BUCKET --all --no-check-sigs || true
   pre_build:
     commands:
       - |
         set -e
-        if [[ ! $CODEBUILD_BATCH_BUILD_IDENTIFIER =~ .*"nixCache".* ]]; then
-          nix develop $NIXDEV_ARGS $NIXDEV_LIBCRYPTO --command bash -c "source ./nix/shell.sh; configure";
-        fi
+        nix develop $NIXDEV_ARGS $NIXDEV_LIBCRYPTO --command bash -c "source ./nix/shell.sh; configure"
   build:
     commands:
       - |
         set -e
-        if [[ ! $CODEBUILD_BATCH_BUILD_IDENTIFIER =~ .*"nixCache".* ]]; then
-          nix develop $NIXDEV_ARGS $NIXDEV_LIBCRYPTO --command bash -c "source ./nix/shell.sh; build";
-        fi
+        nix develop $NIXDEV_ARGS $NIXDEV_LIBCRYPTO --command bash -c "source ./nix/shell.sh; build"
   post_build:
     commands:
       - |
         set -e
-        if [[ ! $CODEBUILD_BATCH_BUILD_IDENTIFIER =~ .*"nixCache".* ]]; then
-          nix develop $NIXDEV_ARGS $NIXDEV_LIBCRYPTO --command bash -c "source ./nix/shell.sh; unit"
-        fi
+        nix develop $NIXDEV_ARGS $NIXDEV_LIBCRYPTO --command bash -c "source ./nix/shell.sh; unit"
+        echo "Pushing to nix cache..."
+        nix copy --to $NIX_CACHE_BUCKET $NIXDEV_LIBCRYPTO

--- a/codebuild/spec/buildspec_unit_nix.yml
+++ b/codebuild/spec/buildspec_unit_nix.yml
@@ -133,4 +133,5 @@ phases:
         set -e
         nix develop $NIXDEV_ARGS $NIXDEV_LIBCRYPTO --command bash -c "source ./nix/shell.sh; unit"
         echo "Pushing to nix cache..."
-        nix copy --to $NIX_CACHE_BUCKET $NIXDEV_LIBCRYPTO
+        # Push everything this job needed to S3 for future runs.
+        nix copy --to $NIX_CACHE_BUCKET --all


### PR DESCRIPTION
# Goal
Make UniNix faster

## Why
It is slow

## How
The previous job was only caching _some_ of the build artifacts (the dev shell).
```
          nix copy --from $NIX_CACHE_BUCKET --all --no-check-sigs
          nix build $NIXDEV_ARGS .#devShell
          nix copy --to $NIX_CACHE_BUCKET .#devShell;
```

But other libcrypto shells were not getting cached.

## Testing
On the first run, this took ~ 45 minutes. When I reran the job, it only took 7 minutes.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
