### PR TITLE
ci(aws-kms-tls-auth): pin time crate version

### DIFF
--- a/bindings/rust/aws-kms-tls-auth/Cargo.toml
+++ b/bindings/rust/aws-kms-tls-auth/Cargo.toml
@@ -26,7 +26,7 @@ tracing = "0.1.41"
 tracing-subscriber = "0.3.20"
 
 # Pinned to avoid coherence conflict between time 0.3.48+ and aws-smithy-types.
-time = "0.3.47"
+time = ">=0.3, <0.3.48"
 
 [dev-dependencies]
 s2n-tls-tokio = { version = "0.3.16" }

--- a/bindings/rust/aws-kms-tls-auth/Cargo.toml
+++ b/bindings/rust/aws-kms-tls-auth/Cargo.toml
@@ -25,6 +25,9 @@ rand = "0.9.2"
 tracing = "0.1.41"
 tracing-subscriber = "0.3.20"
 
+# Pinned to avoid coherence conflict between time 0.3.48+ and aws-smithy-types.
+time = "0.3.47"
+
 [dev-dependencies]
 s2n-tls-tokio = { version = "0.3.16" }
 aws-sdk-kms = {version = "1.76.0", features = ["test-util"]}


### PR DESCRIPTION
# Goal
Fix `aws-kms-tls-auth` CI build failure caused by a coherence conflict between `time` 0.3.48 and `aws-smithy-types`.

## Why
The time crate v0.3.48 introduced a `From` impl that conflicts with `aws-smithy-types`'s blanket `impl<T> From<T> for CanDisable<T>`, causing a Rust coherence error (E0119) that [fails compilation](https://github.com/aws/s2n-tls/actions/runs/27430778238/job/81080241285?pr=5926).

## How
Pin the time dependency in Cargo.toml to `>=0.3, <0.3.48` to prevent Cargo from resolving to the incompatible version.

## Callouts
This could be removed if `aws-smithy-types` publishes a fix for the coherence conflict.

## Testing
CI passes with time 0.3.47. Confirmed 0.3.48 triggers the failure.

### Related
#5926 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
