### PR TITLE
fix: initialize *blocked on early-return paths

### DIFF
--- a/tls/s2n_send.c
+++ b/tls/s2n_send.c
@@ -249,6 +249,9 @@ ssize_t s2n_sendv_with_offset(struct s2n_connection *conn, const struct iovec *b
         ssize_t offs, s2n_blocked_status *blocked)
 {
     POSIX_ENSURE_REF(conn);
+    POSIX_ENSURE_REF(blocked);
+    *blocked = S2N_BLOCKED_ON_WRITE;
+
     POSIX_ENSURE(!conn->send_in_use, S2N_ERR_REENTRANCY);
     conn->send_in_use = true;
 


### PR DESCRIPTION
## Goal
<!-- What is the PR doing? -->
Ensure the `*blocked` output parameter of `s2n_send`, `s2n_sendv`, and `s2n_sendv_with_offset` is always written before any error return.

## Why
<!-- Why is this PR necessary? -->
Three early-return paths in `s2n_sendv_with_offset` (reentrancy guard) and `s2n_sendv_with_offset_impl` (IO-closed check, QUIC check) exit before `s2n_flush` is reached, which is where `*blocked` is first set. A caller that reads `*blocked` after a non-S2N_ERR_T_BLOCKED error would observe indeterminate stack data. s2n_recv_impl was already hardened against this; the send path was not.

## How
<!-- How is this PR accomplishing its goals? -->
Add POSIX_ENSURE_REF(blocked) and *blocked = S2N_BLOCKED_ON_WRITE at the top of s2n_sendv_with_offset, before the reentrancy guard. This covers all three early-return paths and matches the existing pattern in s2n_recv_impl: https://github.com/aws/s2n-tls/blob/3ac3cbbfd5424973fa807acd9dab9275e7928f97/tls/s2n_recv.c#L173

## Testing
<!-- How is it tested? -->
All tests pass

## Related
<!-- E.g. "resolves #3456" --> <!-- for significant features includes a release summary --> <!-- The release summary must be a single line that starts with "release summary" --> <!-- release summary: s2n-tls users can now dance the tango -->
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.