### PR TITLE
refactor(metrics-schema): centralize metric name definitions for cross-crate reuse

### DIFF
--- a/bindings/rust/standard/s2n-tls-metrics-schema/src/label.rs
+++ b/bindings/rust/standard/s2n-tls-metrics-schema/src/label.rs
@@ -1,28 +1,22 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+//! Canonical metric name definitions and caching for TLS telemetry.
+//!
+//! All metric names emitted via EMF and consumed by MWS queries or storage
+//! layers are defined here. Downstream crates should import from this module
+//! rather than duplicating string literals.
+
 use std::{
     collections::HashMap,
     fmt::Display,
     sync::{LazyLock, RwLock},
 };
 
-use crate::static_lists::TlsParam;
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum State {
-    Negotiated,
-    Supported,
-}
-
-impl Display for State {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            State::Negotiated => write!(f, "negotiated"),
-            State::Supported => write!(f, "supported"),
-        }
-    }
-}
+use crate::static_lists::{
+    Alert, Cipher, DEFINED_ALERTS_COUNT, FiniteCounter, Group, Signature, Version, CIPHER_COUNT,
+    GROUP_COUNT, PROTOCOL_COUNT, SIGNATURE_COUNT,
+};
 
 /// Cache key keyed by slot index so the cache type stays non-generic.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -74,38 +68,132 @@ where
     }
 }
 
-/// a helper function to create the prefix for (param, state) tuples
-pub fn telemetry_prefix(param: TlsParam, state: State) -> &'static str {
-    let prefix = match (param, state) {
-        (TlsParam::Version, State::Negotiated) => "version.negotiated",
-        (TlsParam::Version, State::Supported) => "version.supported",
-        (TlsParam::Cipher, State::Negotiated) => "cipher.negotiated",
-        (TlsParam::Cipher, State::Supported) => "cipher.supported",
-        (TlsParam::Group, State::Negotiated) => "group.negotiated",
-        (TlsParam::Group, State::Supported) => "group.supported",
-        (TlsParam::SignatureScheme, State::Negotiated) => "signature_scheme.negotiated",
-        (TlsParam::SignatureScheme, State::Supported) => "signature_scheme.supported",
-    };
-    // this debug assert makes sure that our labels match the Display implementation.
-    // We don't directly use Display because that requires an allocation. We could
-    // introduce a static display trait, but that feels like overkill :)
-    debug_assert_eq!(format!("{param}.{state}"), prefix);
-    prefix
+pub const HANDSHAKE_SUCCESS_COUNT: &str = "handshake_success_count";
+pub const HANDSHAKE_FAILURE_COUNT: &str = "handshake_failure_count";
+pub const COMPATIBILITY_GENERAL20251201: &str = "compatibility.general20251201";
+pub const COMPATIBILITY_FIPS20251201: &str = "compatibility.fips20251201";
+pub const COMPATIBILITY_CNSA1: &str = "compatibility.cnsa1";
+pub const COMPATIBILITY_CNSA2: &str = "compatibility.cnsa2";
+pub const SECURITY_POLICY_PREFIX: &str = "tls_policy";
+pub const SECURITY_POLICY_TOO_MANY: &str = "tls_policy.TOO_MANY";
+
+pub fn security_policy_name(policy: &str) -> String {
+    format!("{SECURITY_POLICY_PREFIX}.{policy}")
 }
+
+pub const SSLV2_CLIENT_HELLO: &str = "sslv2_client_hello";
+pub const HANDSHAKE_DURATION_US: &str = "handshake_duration_us";
+pub const HANDSHAKE_COMPUTE_US: &str = "handshake_compute_us";
+pub const SYNTHETIC_TRAFFIC_COUNT: &str = "synthetic_traffic_count";
+
+pub const ALL_SCALARS: &[&str] = &[
+    COMPATIBILITY_GENERAL20251201,
+    COMPATIBILITY_FIPS20251201,
+    COMPATIBILITY_CNSA1,
+    COMPATIBILITY_CNSA2,
+    SSLV2_CLIENT_HELLO,
+    HANDSHAKE_SUCCESS_COUNT,
+    HANDSHAKE_FAILURE_COUNT,
+    HANDSHAKE_DURATION_US,
+    HANDSHAKE_COMPUTE_US,
+    SYNTHETIC_TRAFFIC_COUNT,
+];
+
+/// A counter group descriptor: prefix string, element count, and cached name accessor.
+///
+/// Each group represents one (TlsParam, State) combination, e.g. "cipher.negotiated".
+/// Individual metric names are formed as `"{prefix}.{element}"` and cached via
+/// [`telemetry_label`] for zero-allocation access after the first call.
+pub struct CounterGroup {
+    pub prefix: &'static str,
+    pub count: usize,
+    name_from_slot: fn(usize, &'static str) -> &'static str,
+}
+
+impl CounterGroup {
+    /// Returns the cached metric name for a slot index.
+    pub fn metric_name(&self, slot: usize) -> &'static str {
+        debug_assert!(slot < self.count, "slot {slot} out of range for {}", self.prefix);
+        (self.name_from_slot)(slot, self.prefix)
+    }
+
+    /// Returns the cached metric name when the caller already has the element.
+    pub fn metric_name_for<T: Display>(&self, slot: usize, element: T) -> &'static str {
+        telemetry_label(slot, element, self.prefix)
+    }
+}
+
+fn version_metric_name(slot: usize, prefix: &'static str) -> &'static str {
+    telemetry_label(slot, Version::key_from_slot(slot).unwrap(), prefix)
+}
+
+fn cipher_metric_name(slot: usize, prefix: &'static str) -> &'static str {
+    telemetry_label(slot, Cipher::key_from_slot(slot).unwrap(), prefix)
+}
+
+fn group_metric_name(slot: usize, prefix: &'static str) -> &'static str {
+    telemetry_label(slot, Group::key_from_slot(slot).unwrap(), prefix)
+}
+
+fn signature_metric_name(slot: usize, prefix: &'static str) -> &'static str {
+    telemetry_label(slot, Signature::key_from_slot(slot).unwrap(), prefix)
+}
+
+fn alert_metric_name(slot: usize, prefix: &'static str) -> &'static str {
+    telemetry_label(slot, Alert::key_from_slot(slot).unwrap(), prefix)
+}
+
+pub const ALERTS: CounterGroup = CounterGroup {
+    prefix: "alert",
+    count: DEFINED_ALERTS_COUNT,
+    name_from_slot: alert_metric_name,
+};
+
+macro_rules! define_counter_groups {
+    ($mod_name:ident, $state:literal) => {
+        pub mod $mod_name {
+            use super::*;
+
+            pub const VERSIONS: CounterGroup = CounterGroup {
+                prefix: concat!("version.", $state),
+                count: PROTOCOL_COUNT,
+                name_from_slot: version_metric_name,
+            };
+
+            pub const CIPHERS: CounterGroup = CounterGroup {
+                prefix: concat!("cipher.", $state),
+                count: CIPHER_COUNT,
+                name_from_slot: cipher_metric_name,
+            };
+
+            pub const GROUPS: CounterGroup = CounterGroup {
+                prefix: concat!("group.", $state),
+                count: GROUP_COUNT,
+                name_from_slot: group_metric_name,
+            };
+
+            pub const SIGNATURES: CounterGroup = CounterGroup {
+                prefix: concat!("signature_scheme.", $state),
+                count: SIGNATURE_COUNT,
+                name_from_slot: signature_metric_name,
+            };
+
+            pub const ALL: &[&CounterGroup] = &[&VERSIONS, &CIPHERS, &GROUPS, &SIGNATURES];
+        }
+    };
+}
+
+define_counter_groups!(negotiated, "negotiated");
+define_counter_groups!(supported, "supported");
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::static_lists::Cipher;
 
     #[test]
     fn label_output() {
         assert_eq!(
-            telemetry_label(
-                0,
-                Cipher::TLS_AES_256_GCM_SHA384,
-                telemetry_prefix(TlsParam::Cipher, State::Negotiated),
-            ),
+            telemetry_label(0, Cipher::TLS_AES_256_GCM_SHA384, "cipher.negotiated"),
             "cipher.negotiated.TLS_AES_256_GCM_SHA384"
         );
     }

--- a/bindings/rust/standard/s2n-tls-metrics-schema/src/label.rs
+++ b/bindings/rust/standard/s2n-tls-metrics-schema/src/label.rs
@@ -14,8 +14,8 @@ use std::{
 };
 
 use crate::static_lists::{
-    Alert, Cipher, DEFINED_ALERTS_COUNT, FiniteCounter, Group, Signature, Version, CIPHER_COUNT,
-    GROUP_COUNT, PROTOCOL_COUNT, SIGNATURE_COUNT,
+    Alert, CIPHER_COUNT, Cipher, DEFINED_ALERTS_COUNT, FiniteCounter, GROUP_COUNT, Group,
+    PROTOCOL_COUNT, SIGNATURE_COUNT, Signature, Version,
 };
 
 /// Cache key keyed by slot index so the cache type stays non-generic.
@@ -113,7 +113,11 @@ pub struct CounterGroup {
 impl CounterGroup {
     /// Returns the cached metric name for a slot index.
     pub fn metric_name(&self, slot: usize) -> &'static str {
-        debug_assert!(slot < self.count, "slot {slot} out of range for {}", self.prefix);
+        debug_assert!(
+            slot < self.count,
+            "slot {slot} out of range for {}",
+            self.prefix
+        );
         (self.name_from_slot)(slot, self.prefix)
     }
 

--- a/bindings/rust/standard/s2n-tls-metrics-schema/src/lib.rs
+++ b/bindings/rust/standard/s2n-tls-metrics-schema/src/lib.rs
@@ -10,6 +10,6 @@
 pub mod attribution;
 pub mod bounded_set;
 pub mod counter;
-pub mod label;
+pub mod metric_names;
 pub mod record;
 pub mod static_lists;

--- a/bindings/rust/standard/s2n-tls-metrics-schema/src/metric_names.rs
+++ b/bindings/rust/standard/s2n-tls-metrics-schema/src/metric_names.rs
@@ -3,9 +3,9 @@
 
 //! Canonical metric name definitions and caching for TLS telemetry.
 //!
-//! All metric names emitted via EMF and consumed by MWS queries or storage
-//! layers are defined here. Downstream crates should import from this module
-//! rather than duplicating string literals.
+//! All serialized metric names representations are defined here.
+//! Downstream crates should import from this module rather than
+//! duplicating string literals.
 
 use std::{
     collections::HashMap,

--- a/bindings/rust/standard/s2n-tls-metrics-schema/src/record.rs
+++ b/bindings/rust/standard/s2n-tls-metrics-schema/src/record.rs
@@ -16,8 +16,8 @@ use crate::{
 };
 
 use crate::{
-    label::{State, telemetry_label, telemetry_prefix},
-    static_lists::{FiniteCounter, TlsParam},
+    label::{self as names, negotiated, supported, CounterGroup},
+    static_lists::FiniteCounter,
 };
 
 /// Metric Record is an type which implements `metrique_writer::Entry`
@@ -135,10 +135,12 @@ impl Default for FrozenHandshakeRecord {
 impl metrique_writer::Entry for FrozenHandshakeRecord {
     fn write<'a>(&'a self, writer: &mut impl metrique_writer::EntryWriter<'a>) {
         match &self.security_policies {
-            FrozenBoundedStringSet::TooMany => writer.value("tls_policy.TOO_MANY", &1_u64),
+            FrozenBoundedStringSet::TooMany => {
+                writer.value(names::SECURITY_POLICY_TOO_MANY, &1_u64)
+            }
             FrozenBoundedStringSet::Entries(hash_set) => {
                 for policy in hash_set {
-                    writer.value(format!("tls_policy.{policy}"), &1_u64);
+                    writer.value(names::security_policy_name(policy), &1_u64);
                 }
             }
         }
@@ -146,77 +148,38 @@ impl metrique_writer::Entry for FrozenHandshakeRecord {
 
         fn write_counter<'a, const N: usize, T, W>(
             counter: &'a FrozenCounter<N, T>,
-            prefix: &'static str,
+            group: &CounterGroup,
             writer: &mut W,
         ) where
             T: FiniteCounter<N> + std::fmt::Display,
             W: metrique_writer::EntryWriter<'a>,
         {
             for (slot, element, count) in counter.iter_non_zero() {
-                let label = telemetry_label(slot, element, prefix);
-                writer.value(label, &count);
+                writer.value(group.metric_name_for(slot, element), &count);
             }
         }
 
-        write_counter(
-            &self.negotiated_protocols,
-            telemetry_prefix(TlsParam::Version, State::Negotiated),
-            writer,
-        );
-        write_counter(
-            &self.negotiated_ciphers,
-            telemetry_prefix(TlsParam::Cipher, State::Negotiated),
-            writer,
-        );
-        write_counter(
-            &self.negotiated_groups,
-            telemetry_prefix(TlsParam::Group, State::Negotiated),
-            writer,
-        );
-        write_counter(
-            &self.negotiated_signatures,
-            telemetry_prefix(TlsParam::SignatureScheme, State::Negotiated),
-            writer,
-        );
-        write_counter(
-            &self.supported_protocols,
-            telemetry_prefix(TlsParam::Version, State::Supported),
-            writer,
-        );
-        write_counter(
-            &self.supported_ciphers,
-            telemetry_prefix(TlsParam::Cipher, State::Supported),
-            writer,
-        );
-        write_counter(
-            &self.supported_groups,
-            telemetry_prefix(TlsParam::Group, State::Supported),
-            writer,
-        );
-        write_counter(
-            &self.supported_signatures,
-            telemetry_prefix(TlsParam::SignatureScheme, State::Supported),
-            writer,
-        );
+        write_counter(&self.negotiated_protocols, &negotiated::VERSIONS, writer);
+        write_counter(&self.negotiated_ciphers, &negotiated::CIPHERS, writer);
+        write_counter(&self.negotiated_groups, &negotiated::GROUPS, writer);
+        write_counter(&self.negotiated_signatures, &negotiated::SIGNATURES, writer);
+        write_counter(&self.supported_protocols, &supported::VERSIONS, writer);
+        write_counter(&self.supported_ciphers, &supported::CIPHERS, writer);
+        write_counter(&self.supported_groups, &supported::GROUPS, writer);
+        write_counter(&self.supported_signatures, &supported::SIGNATURES, writer);
 
-        writer.value(
-            "compatibility.general20251201",
-            &self.compatibility_general20251201,
-        );
-        writer.value(
-            "compatibility.fips20251201",
-            &self.compatibility_fips20251201,
-        );
-        writer.value("compatibility.cnsa1", &self.compatibility_cnsa1);
-        writer.value("compatibility.cnsa2", &self.compatibility_cnsa2);
+        writer.value(names::COMPATIBILITY_GENERAL20251201, &self.compatibility_general20251201);
+        writer.value(names::COMPATIBILITY_FIPS20251201, &self.compatibility_fips20251201);
+        writer.value(names::COMPATIBILITY_CNSA1, &self.compatibility_cnsa1);
+        writer.value(names::COMPATIBILITY_CNSA2, &self.compatibility_cnsa2);
 
-        writer.value("sslv2_client_hello", &self.sslv2_client_hello);
-        writer.value("handshake_success_count", &self.handshake_success_count);
-        writer.value("handshake_failure_count", &self.handshake_failure_count);
-        write_counter(&self.alerts, "alert", writer);
-        writer.value("handshake_duration_us", &self.handshake_duration_us);
-        writer.value("handshake_compute_us", &self.handshake_compute_us);
-        writer.value("synthetic_traffic_count", &self.synthetic_traffic_count);
+        writer.value(names::SSLV2_CLIENT_HELLO, &self.sslv2_client_hello);
+        writer.value(names::HANDSHAKE_SUCCESS_COUNT, &self.handshake_success_count);
+        writer.value(names::HANDSHAKE_FAILURE_COUNT, &self.handshake_failure_count);
+        write_counter(&self.alerts, &names::ALERTS, writer);
+        writer.value(names::HANDSHAKE_DURATION_US, &self.handshake_duration_us);
+        writer.value(names::HANDSHAKE_COMPUTE_US, &self.handshake_compute_us);
+        writer.value(names::SYNTHETIC_TRAFFIC_COUNT, &self.synthetic_traffic_count);
     }
 }
 

--- a/bindings/rust/standard/s2n-tls-metrics-schema/src/record.rs
+++ b/bindings/rust/standard/s2n-tls-metrics-schema/src/record.rs
@@ -16,7 +16,7 @@ use crate::{
 };
 
 use crate::{
-    label::{self as names, negotiated, supported, CounterGroup},
+    label::{self as names, CounterGroup, negotiated, supported},
     static_lists::FiniteCounter,
 };
 
@@ -168,18 +168,33 @@ impl metrique_writer::Entry for FrozenHandshakeRecord {
         write_counter(&self.supported_groups, &supported::GROUPS, writer);
         write_counter(&self.supported_signatures, &supported::SIGNATURES, writer);
 
-        writer.value(names::COMPATIBILITY_GENERAL20251201, &self.compatibility_general20251201);
-        writer.value(names::COMPATIBILITY_FIPS20251201, &self.compatibility_fips20251201);
+        writer.value(
+            names::COMPATIBILITY_GENERAL20251201,
+            &self.compatibility_general20251201,
+        );
+        writer.value(
+            names::COMPATIBILITY_FIPS20251201,
+            &self.compatibility_fips20251201,
+        );
         writer.value(names::COMPATIBILITY_CNSA1, &self.compatibility_cnsa1);
         writer.value(names::COMPATIBILITY_CNSA2, &self.compatibility_cnsa2);
 
         writer.value(names::SSLV2_CLIENT_HELLO, &self.sslv2_client_hello);
-        writer.value(names::HANDSHAKE_SUCCESS_COUNT, &self.handshake_success_count);
-        writer.value(names::HANDSHAKE_FAILURE_COUNT, &self.handshake_failure_count);
+        writer.value(
+            names::HANDSHAKE_SUCCESS_COUNT,
+            &self.handshake_success_count,
+        );
+        writer.value(
+            names::HANDSHAKE_FAILURE_COUNT,
+            &self.handshake_failure_count,
+        );
         write_counter(&self.alerts, &names::ALERTS, writer);
         writer.value(names::HANDSHAKE_DURATION_US, &self.handshake_duration_us);
         writer.value(names::HANDSHAKE_COMPUTE_US, &self.handshake_compute_us);
-        writer.value(names::SYNTHETIC_TRAFFIC_COUNT, &self.synthetic_traffic_count);
+        writer.value(
+            names::SYNTHETIC_TRAFFIC_COUNT,
+            &self.synthetic_traffic_count,
+        );
     }
 }
 

--- a/bindings/rust/standard/s2n-tls-metrics-schema/src/record.rs
+++ b/bindings/rust/standard/s2n-tls-metrics-schema/src/record.rs
@@ -16,7 +16,7 @@ use crate::{
 };
 
 use crate::{
-    label::{self as names, CounterGroup, negotiated, supported},
+    metric_names::{self as names, CounterGroup, negotiated, supported},
     static_lists::FiniteCounter,
 };
 

--- a/bindings/rust/standard/s2n-tls-metrics-schema/src/static_lists.rs
+++ b/bindings/rust/standard/s2n-tls-metrics-schema/src/static_lists.rs
@@ -11,33 +11,10 @@ use s2n_codec::zerocopy::U16;
 use serde_with::{DeserializeAs, SerializeAs, serde_as};
 use zerocopy::{FromBytes, Immutable, Unaligned};
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum TlsParam {
-    /// E.g. TLS 1.2
-    Version,
-    /// E.g. TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
-    Cipher,
-    /// E.g. SecP256r1MLKEM768
-    Group,
-    /// E.g. ecdsa_secp384r1_sha384
-    SignatureScheme,
-}
-
 pub const GROUP_COUNT: usize = GROUPS_AVAILABLE_IN_S2N.len();
 pub const CIPHER_COUNT: usize = CIPHERS_AVAILABLE_IN_S2N.len();
 pub const SIGNATURE_COUNT: usize = SIGNATURE_SCHEMES_AVAILABLE_IN_S2N.len();
 pub const PROTOCOL_COUNT: usize = VERSIONS_AVAILABLE_IN_S2N.len();
-
-impl Display for TlsParam {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            TlsParam::Version => write!(f, "version"),
-            TlsParam::Cipher => write!(f, "cipher"),
-            TlsParam::Group => write!(f, "group"),
-            TlsParam::SignatureScheme => write!(f, "signature_scheme"),
-        }
-    }
-}
 
 /// `serde_as` helper: encode `zerocopy::U16` as a native-endian `u16`.
 /// Shared by `Version`, `Group`, and `Signature`, whose wire form is the

--- a/bindings/rust/standard/s2n-tls-metrics-schema/tests/public_api.rs
+++ b/bindings/rust/standard/s2n-tls-metrics-schema/tests/public_api.rs
@@ -6,9 +6,7 @@
 //! These tests exercise deserialization of `MetricRecord`, field access,
 //! counter slot layout, and round-trip serialization.
 
-use std::borrow::Cow;
-use std::collections::HashSet;
-use std::time::SystemTime;
+use std::{borrow::Cow, collections::HashSet, time::SystemTime};
 
 use s2n_tls_metrics_schema::{
     label::{self as names, negotiated, supported},
@@ -308,7 +306,11 @@ struct NameCollector {
 impl<'a> metrique_writer::EntryWriter<'a> for NameCollector {
     fn timestamp(&mut self, _: SystemTime) {}
 
-    fn value(&mut self, name: impl Into<Cow<'a, str>>, _value: &(impl metrique_writer::Value + ?Sized)) {
+    fn value(
+        &mut self,
+        name: impl Into<Cow<'a, str>>,
+        _value: &(impl metrique_writer::Value + ?Sized),
+    ) {
         self.names.push(name.into().into_owned());
     }
 
@@ -319,34 +321,37 @@ impl<'a> metrique_writer::EntryWriter<'a> for NameCollector {
 /// exactly match the catalog defined in `metric_names`.
 #[test]
 fn entry_writes_match_metric_names_catalog() {
-    use s2n_tls_metrics_schema::counter::FrozenCounter;
-    use s2n_tls_metrics_schema::record::FrozenHandshakeRecord;
     use metrique_writer::Entry;
+    use s2n_tls_metrics_schema::{
+        bounded_set::FrozenBoundedStringSet, counter::FrozenCounter, record::FrozenHandshakeRecord,
+    };
 
     // Build a record with every counter slot populated so all names are emitted.
-    let mut record = FrozenHandshakeRecord::default();
-    record.handshake_success_count = 1;
-    record.handshake_failure_count = 1;
-    record.negotiated_protocols = FrozenCounter::from_slots([1; PROTOCOL_COUNT]);
-    record.negotiated_ciphers = FrozenCounter::from_slots([1; CIPHER_COUNT]);
-    record.negotiated_groups = FrozenCounter::from_slots([1; GROUP_COUNT]);
-    record.negotiated_signatures = FrozenCounter::from_slots([1; SIGNATURE_COUNT]);
-    record.supported_protocols = FrozenCounter::from_slots([1; PROTOCOL_COUNT]);
-    record.supported_ciphers = FrozenCounter::from_slots([1; CIPHER_COUNT]);
-    record.supported_groups = FrozenCounter::from_slots([1; GROUP_COUNT]);
-    record.supported_signatures = FrozenCounter::from_slots([1; SIGNATURE_COUNT]);
-    record.alerts = FrozenCounter::from_slots([1; DEFINED_ALERTS_COUNT]);
-    record.security_policies = s2n_tls_metrics_schema::bounded_set::FrozenBoundedStringSet::Entries(
-        ["TestPolicy"].into_iter().map(String::from).collect(),
-    );
-    record.compatibility_general20251201 = 1;
-    record.compatibility_fips20251201 = 1;
-    record.compatibility_cnsa1 = 1;
-    record.compatibility_cnsa2 = 1;
-    record.sslv2_client_hello = 1;
-    record.handshake_duration_us = 1;
-    record.handshake_compute_us = 1;
-    record.synthetic_traffic_count = 1;
+    let record = FrozenHandshakeRecord {
+        handshake_success_count: 1,
+        handshake_failure_count: 1,
+        negotiated_protocols: FrozenCounter::from_slots([1; PROTOCOL_COUNT]),
+        negotiated_ciphers: FrozenCounter::from_slots([1; CIPHER_COUNT]),
+        negotiated_groups: FrozenCounter::from_slots([1; GROUP_COUNT]),
+        negotiated_signatures: FrozenCounter::from_slots([1; SIGNATURE_COUNT]),
+        supported_protocols: FrozenCounter::from_slots([1; PROTOCOL_COUNT]),
+        supported_ciphers: FrozenCounter::from_slots([1; CIPHER_COUNT]),
+        supported_groups: FrozenCounter::from_slots([1; GROUP_COUNT]),
+        supported_signatures: FrozenCounter::from_slots([1; SIGNATURE_COUNT]),
+        alerts: FrozenCounter::from_slots([1; DEFINED_ALERTS_COUNT]),
+        security_policies: FrozenBoundedStringSet::Entries(
+            ["TestPolicy"].into_iter().map(String::from).collect(),
+        ),
+        compatibility_general20251201: 1,
+        compatibility_fips20251201: 1,
+        compatibility_cnsa1: 1,
+        compatibility_cnsa2: 1,
+        sslv2_client_hello: 1,
+        handshake_duration_us: 1,
+        handshake_compute_us: 1,
+        synthetic_traffic_count: 1,
+        ..Default::default()
+    };
 
     let mut collector = NameCollector { names: Vec::new() };
     record.write(&mut collector);

--- a/bindings/rust/standard/s2n-tls-metrics-schema/tests/public_api.rs
+++ b/bindings/rust/standard/s2n-tls-metrics-schema/tests/public_api.rs
@@ -9,7 +9,7 @@
 use std::{borrow::Cow, collections::HashSet, time::SystemTime};
 
 use s2n_tls_metrics_schema::{
-    label::{self as names, negotiated, supported},
+    metric_names::{self as names, negotiated, supported},
     static_lists::{
         CIPHER_COUNT, Cipher, DEFINED_ALERTS_COUNT, FiniteCounter, GROUP_COUNT, Group,
         PROTOCOL_COUNT, SIGNATURE_COUNT, Signature, Version,

--- a/bindings/rust/standard/s2n-tls-metrics-schema/tests/public_api.rs
+++ b/bindings/rust/standard/s2n-tls-metrics-schema/tests/public_api.rs
@@ -6,11 +6,16 @@
 //! These tests exercise deserialization of `MetricRecord`, field access,
 //! counter slot layout, and round-trip serialization.
 
+use std::borrow::Cow;
+use std::collections::HashSet;
 use std::time::SystemTime;
 
-use s2n_tls_metrics_schema::static_lists::{
-    CIPHER_COUNT, Cipher, FiniteCounter, GROUP_COUNT, Group, PROTOCOL_COUNT, SIGNATURE_COUNT,
-    Signature, Version,
+use s2n_tls_metrics_schema::{
+    label::{self as names, negotiated, supported},
+    static_lists::{
+        CIPHER_COUNT, Cipher, DEFINED_ALERTS_COUNT, FiniteCounter, GROUP_COUNT, Group,
+        PROTOCOL_COUNT, SIGNATURE_COUNT, Signature, Version,
+    },
 };
 
 fn sample_schema_record() -> s2n_tls_metrics_schema::record::MetricRecord {
@@ -292,5 +297,98 @@ fn empty_record_has_zero_slots() {
             .iter_non_zero()
             .count(),
         0
+    );
+}
+
+/// Mock writer that captures all metric names written by the Entry impl.
+struct NameCollector {
+    names: Vec<String>,
+}
+
+impl<'a> metrique_writer::EntryWriter<'a> for NameCollector {
+    fn timestamp(&mut self, _: SystemTime) {}
+
+    fn value(&mut self, name: impl Into<Cow<'a, str>>, _value: &(impl metrique_writer::Value + ?Sized)) {
+        self.names.push(name.into().into_owned());
+    }
+
+    fn config(&mut self, _: &'a dyn metrique_writer::EntryConfig) {}
+}
+
+/// Verifies that the metric names emitted by `FrozenHandshakeRecord::write()`
+/// exactly match the catalog defined in `metric_names`.
+#[test]
+fn entry_writes_match_metric_names_catalog() {
+    use s2n_tls_metrics_schema::counter::FrozenCounter;
+    use s2n_tls_metrics_schema::record::FrozenHandshakeRecord;
+    use metrique_writer::Entry;
+
+    // Build a record with every counter slot populated so all names are emitted.
+    let mut record = FrozenHandshakeRecord::default();
+    record.handshake_success_count = 1;
+    record.handshake_failure_count = 1;
+    record.negotiated_protocols = FrozenCounter::from_slots([1; PROTOCOL_COUNT]);
+    record.negotiated_ciphers = FrozenCounter::from_slots([1; CIPHER_COUNT]);
+    record.negotiated_groups = FrozenCounter::from_slots([1; GROUP_COUNT]);
+    record.negotiated_signatures = FrozenCounter::from_slots([1; SIGNATURE_COUNT]);
+    record.supported_protocols = FrozenCounter::from_slots([1; PROTOCOL_COUNT]);
+    record.supported_ciphers = FrozenCounter::from_slots([1; CIPHER_COUNT]);
+    record.supported_groups = FrozenCounter::from_slots([1; GROUP_COUNT]);
+    record.supported_signatures = FrozenCounter::from_slots([1; SIGNATURE_COUNT]);
+    record.alerts = FrozenCounter::from_slots([1; DEFINED_ALERTS_COUNT]);
+    record.security_policies = s2n_tls_metrics_schema::bounded_set::FrozenBoundedStringSet::Entries(
+        ["TestPolicy"].into_iter().map(String::from).collect(),
+    );
+    record.compatibility_general20251201 = 1;
+    record.compatibility_fips20251201 = 1;
+    record.compatibility_cnsa1 = 1;
+    record.compatibility_cnsa2 = 1;
+    record.sslv2_client_hello = 1;
+    record.handshake_duration_us = 1;
+    record.handshake_compute_us = 1;
+    record.synthetic_traffic_count = 1;
+
+    let mut collector = NameCollector { names: Vec::new() };
+    record.write(&mut collector);
+
+    let emitted: HashSet<String> = collector.names.into_iter().collect();
+
+    // Build expected set from the metric_names catalog.
+    let mut expected: HashSet<String> = HashSet::new();
+    for group in negotiated::ALL.iter().chain(supported::ALL.iter()) {
+        for slot in 0..group.count {
+            expected.insert(group.metric_name(slot).to_string());
+        }
+    }
+    for slot in 0..names::ALERTS.count {
+        expected.insert(names::ALERTS.metric_name(slot).to_string());
+    }
+    for &name in names::ALL_SCALARS {
+        expected.insert(name.to_string());
+    }
+    expected.insert(names::security_policy_name("TestPolicy"));
+
+    // Guard against a new counter group being added to `write()` without
+    // updating this test and the catalog. If both sides silently omit the new
+    // group the diff checks below pass vacuously — this count check does not.
+    let expected_count = PROTOCOL_COUNT * 2
+        + CIPHER_COUNT * 2
+        + GROUP_COUNT * 2
+        + SIGNATURE_COUNT * 2
+        + DEFINED_ALERTS_COUNT
+        + names::ALL_SCALARS.len()
+        + 1; // security_policies: 1 test policy entry
+    assert_eq!(
+        expected.len(),
+        expected_count,
+        "expected set size drifted — did you add a counter group to the catalog without updating this assertion?"
+    );
+
+    let missing: Vec<_> = expected.difference(&emitted).collect();
+    let extra: Vec<_> = emitted.difference(&expected).collect();
+
+    assert!(
+        missing.is_empty() && extra.is_empty(),
+        "metric_names catalog vs Entry impl mismatch.\n  Missing from Entry: {missing:?}\n  Extra in Entry: {extra:?}"
     );
 }


### PR DESCRIPTION
## Goal

Provide a single source of truth for all TLS telemetry metric names so downstream crates (e.g. `s2n-tls-metrics-subscriber`, EMF readers, aggregators etc) can reference the exact same names without duplicating string literals.

## Why

Previously, metric names were constructed ad-hoc from `TlsParam`/`State` enums and inline string literals in `record.rs`. This made it easy for name drift to occur between the schema crate, the subscriber crate, aggregator, and EMF query layer. Centralizing names into exported constants and `CounterGroup` descriptors eliminates that class of bug.

## How

- Replaced the `TlsParam` and `State` enums with a `CounterGroup` struct that pairs a prefix, element count, and cached-name accessor function.
- Introduced `negotiated` and `supported` modules (via `define_counter_groups!` macro) exposing `VERSIONS`, `CIPHERS`, `GROUPS`, and `SIGNATURES` as `CounterGroup` constants.
- Defined all scalar metric names as public `&str` constants (`HANDSHAKE_SUCCESS_COUNT`, `COMPATIBILITY_GENERAL`, etc.) with an `ALL_SCALARS` slice for enumeration.
- Simplified `FrozenHandshakeRecord::write()` to reference the new constants and counter groups directly.
- Removed the now-unused `TlsParam` enum and `State` enum.

## Callouts

- The `CounterGroup::metric_name()` method has a `debug_assert` for out-of-bounds slots — this will panic in debug builds but is a no-op in release.
- The `ALL_SCALARS` and `negotiated::ALL`/`supported::ALL` slices form the complete metric catalog; any new metric added to `write()` must also appear in these lists (enforced by the new test).

## Testing

- Added `entry_writes_match_metric_names_catalog` integration test that populates every counter slot, calls `write()`, and asserts the emitted names exactly match the union of `ALL_SCALARS` and all `CounterGroup` entries — catching any drift between the catalog and the `Entry` implementation.
- Existing `public_api.rs` tests continue to pass (deserialization, round-trip, slot layout).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
