### PR TITLE
refactor: fork based handshake tests to use in memory io pair

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -624,12 +624,10 @@ if (BUILD_TESTING)
 
             # Tests that use fork()
             s2n_examples_test
-            s2n_fragmentation_coalescing_test
-            s2n_handshake_test
             s2n_init_test
             s2n_io_test
             s2n_key_update_threads_test
-            s2n_malformed_handshake_test
+            s2n_mem_allocator_test
             s2n_random_test
             s2n_self_talk_alerts_test
             s2n_self_talk_broken_pipe_test

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -627,7 +627,6 @@ if (BUILD_TESTING)
             s2n_init_test
             s2n_io_test
             s2n_key_update_threads_test
-            s2n_mem_allocator_test
             s2n_random_test
             s2n_self_talk_alerts_test
             s2n_self_talk_broken_pipe_test

--- a/tests/unit/s2n_fragmentation_coalescing_test.c
+++ b/tests/unit/s2n_fragmentation_coalescing_test.c
@@ -14,12 +14,10 @@
  */
 
 #include <stdint.h>
-#include <stdlib.h>
-#include <sys/wait.h>
-#include <unistd.h>
 
 #include "api/s2n.h"
 #include "s2n_test.h"
+#include "testlib/s2n_testlib.h"
 #include "tls/s2n_connection.h"
 #include "tls/s2n_handshake.h"
 
@@ -28,8 +26,8 @@
  * tests check that fragmented messages are recombined, that several messages in the same record work
  * and that messages interleaved with alerts (including a fragmented alert message) all work.
  *
- * To do this we fork() subprocesses that write records to a pipe, s2n is configured to read fragments
- * from the pipe.
+ * Instead of forking subprocesses that write records to a pipe, we write the
+ * raw TLS record bytes directly into the connection's input stuffer.
  */
 
 #define TLS_ALERT     21
@@ -41,7 +39,8 @@
 
 uint8_t zero_to_thirty_one[] = { ZERO_TO_THIRTY_ONE };
 
-uint8_t server_hello_message[] = { /* SERVER HELLO */
+uint8_t server_hello_message[] = {
+    /* SERVER HELLO */
     0x02,
 
     /* Length */
@@ -66,7 +65,8 @@ uint8_t server_hello_message[] = { /* SERVER HELLO */
     0x00
 };
 
-uint8_t server_cert[] = { /* SERVER CERT */
+uint8_t server_cert[] = {
+    /* SERVER CERT */
     0x0B,
 
     /* Length of the handshake message */
@@ -163,482 +163,259 @@ uint8_t fatal_alert[] = { /* Fatal: unexpected message */
     0x02, 0x0a
 };
 
-void fragmented_message(int write_fd)
+/* Write a TLS record header + payload into a stuffer */
+int write_record(struct s2n_stuffer *in, uint8_t content_type,
+        const uint8_t *payload, uint32_t payload_len)
 {
-    int written = 0;
-    /* Split the hello message into 5 fragments and write it */
-    for (int i = 0; i < 5; i++) {
-        int length = sizeof(server_hello_message) / 5;
-
-        if (i == 0) {
-            length += sizeof(server_hello_message) % 5;
-        }
-
-        uint8_t record_header[5] = { TLS_HANDSHAKE, 0x03, 0x03, (length >> 8), length & 0xff };
-
-        if (write(write_fd, record_header, 5) != 5) {
-            _exit(100);
-        }
-
-        if (write(write_fd, server_hello_message + written, length) != length) {
-            _exit(100);
-        }
-
-        written += length;
-    }
-
-    /* Close the pipe and exit */
-    close(write_fd);
-}
-
-void coalesced_message(int write_fd)
-{
-    int length = sizeof(server_hello_message) + sizeof(server_cert);
-
-    uint8_t record_header[5] = { TLS_HANDSHAKE, 0x03, 0x03, (length >> 8), length & 0xff };
-
-    if (write(write_fd, record_header, 5) != 5) {
-        _exit(100);
-    }
-
-    if (write(write_fd, server_hello_message, sizeof(server_hello_message)) != sizeof(server_hello_message)) {
-        _exit(100);
-    }
-
-    if (write(write_fd, server_cert, sizeof(server_cert)) != sizeof(server_cert)) {
-        _exit(100);
-    }
-
-    close(write_fd);
-}
-
-void interleaved_message(int write_fd)
-{
-    int length = sizeof(server_hello_message) / 2;
-    uint8_t record_header[5] = { TLS_HANDSHAKE, 0x03, 0x03, (length >> 8), length & 0xff };
-    int written = 0;
-
-    /* Write half of the message */
-    if (write(write_fd, record_header, 5) != 5) {
-        _exit(100);
-    }
-    if (write(write_fd, server_hello_message, length) != length) {
-        _exit(100);
-    }
-    written += length;
-
-    /* Write the heartbeat record */
-    record_header[0] = TLS_HEARTBEAT;
-    record_header[3] = sizeof(heartbeat_message) >> 8;
-    record_header[4] = sizeof(heartbeat_message) & 0xff;
-
-    if (write(write_fd, record_header, 5) != 5) {
-        _exit(100);
-    }
-    if (write(write_fd, heartbeat_message, sizeof(heartbeat_message)) != sizeof(heartbeat_message)) {
-        _exit(100);
-    }
-
-    /* Write the rest of the hello message */
-    length = sizeof(server_hello_message) - written;
-    record_header[0] = TLS_HANDSHAKE;
-    record_header[3] = length >> 8;
-    record_header[4] = length & 0xff;
-    if (write(write_fd, record_header, 5) != 5) {
-        _exit(100);
-    }
-    if (write(write_fd, server_hello_message + written, length) != length) {
-        _exit(100);
-    }
-
-    /* Close the pipe and exit */
-    close(write_fd);
-}
-
-void interleaved_fragmented_fatal_alert(int write_fd)
-{
-    int length = sizeof(server_hello_message) / 2;
-    uint8_t record_header[5] = { TLS_HANDSHAKE, 0x03, 0x03, (length >> 8), length & 0xff };
-    int written = 0;
-
-    /* Write half of the message */
-    if (write(write_fd, record_header, 5) != 5) {
-        _exit(100);
-    }
-    if (write(write_fd, server_hello_message, length) != length) {
-        _exit(100);
-    }
-    written += length;
-
-    /* Write half of the alert message */
-    record_header[0] = TLS_ALERT;
-    record_header[3] = 0;
-    record_header[4] = 1;
-
-    if (write(write_fd, record_header, 5) != 5) {
-        _exit(100);
-    }
-    if (write(write_fd, fatal_alert, 1) != 1) {
-        _exit(100);
-    }
-
-    /* Write another quarter of the of the hello message */
-    length = sizeof(server_hello_message) / 4;
-    record_header[0] = TLS_HANDSHAKE;
-    record_header[3] = length >> 8;
-    record_header[4] = length & 0xff;
-    if (write(write_fd, record_header, 5) != 5) {
-        _exit(100);
-    }
-    if (write(write_fd, server_hello_message + written, length) != length) {
-        _exit(100);
-    }
-    written += length;
-
-    /* Write second half of the alert message */
-    record_header[0] = TLS_ALERT;
-    record_header[3] = 0;
-    record_header[4] = 1;
-
-    if (write(write_fd, record_header, 5) != 5) {
-        _exit(100);
-    }
-    if (write(write_fd, fatal_alert + 1, 1) != 1) {
-        _exit(100);
-    }
-
-    /* Write the rest of the hello message */
-    length = sizeof(server_hello_message) - written;
-    record_header[0] = TLS_HANDSHAKE;
-    record_header[3] = length >> 8;
-    record_header[4] = length & 0xff;
-    if (write(write_fd, record_header, 5) != 5) {
-        _exit(100);
-    }
-    if (write(write_fd, server_hello_message + written, length) != length) {
-        _exit(100);
-    }
-
-    /* Close the pipe and exit */
-    close(write_fd);
-}
-
-void interleaved_fragmented_warning_alert(int write_fd)
-{
-    int length = sizeof(server_hello_message) / 2;
-    uint8_t record_header[5] = { TLS_HANDSHAKE, 0x03, 0x03, (length >> 8), length & 0xff };
-    int written = 0;
-
-    /* Write half of the message */
-    if (write(write_fd, record_header, 5) != 5) {
-        _exit(100);
-    }
-    if (write(write_fd, server_hello_message, length) != length) {
-        _exit(100);
-    }
-    written += length;
-
-    /* Write half of the alert message */
-    record_header[0] = TLS_ALERT;
-    record_header[3] = 0;
-    record_header[4] = 1;
-    if (write(write_fd, warning_alert, 1) != 1) {
-        _exit(100);
-    }
-
-    /* Write another quarter of the of the hello message */
-    length = sizeof(server_hello_message) / 4;
-    record_header[0] = TLS_HANDSHAKE;
-    record_header[3] = length >> 8;
-    record_header[4] = length & 0xff;
-    if (write(write_fd, record_header, 5) != 5) {
-        _exit(100);
-    }
-    if (write(write_fd, server_hello_message + written, length) != length) {
-        _exit(100);
-    }
-    written += length;
-
-    /* Write second half of the alert message */
-    record_header[0] = TLS_ALERT;
-    record_header[3] = 0;
-    record_header[4] = 1;
-
-    if (write(write_fd, record_header, 5) != 5) {
-        _exit(100);
-    }
-    if (write(write_fd, warning_alert + 1, 1) != 1) {
-        _exit(100);
-    }
-
-    /* Write the rest of the hello message */
-    length = sizeof(server_hello_message) - written;
-    record_header[0] = TLS_HANDSHAKE;
-    record_header[3] = length >> 8;
-    record_header[4] = length & 0xff;
-    if (write(write_fd, record_header, 5) != 5) {
-        _exit(100);
-    }
-    if (write(write_fd, server_hello_message + written, length) != length) {
-        _exit(100);
-    }
-
-    /* Close the pipe and exit */
-    close(write_fd);
+    uint8_t record_header[5] = { content_type, 0x03, 0x03, (payload_len >> 8), payload_len & 0xff };
+    POSIX_GUARD(s2n_stuffer_write_bytes(in, record_header, 5));
+    POSIX_GUARD(s2n_stuffer_write_bytes(in, payload, payload_len));
+    return S2N_SUCCESS;
 }
 
 int main(int argc, char **argv)
 {
-    struct s2n_connection *conn = NULL;
-    struct s2n_config *config = NULL;
-
-    s2n_blocked_status blocked;
-    int status = 0;
-    pid_t pid = 0;
-    int p[2];
-
     BEGIN_TEST();
     EXPECT_SUCCESS(s2n_disable_tls13_in_test());
 
-    EXPECT_NOT_NULL(config = s2n_config_new());
+    DEFER_CLEANUP(struct s2n_config *config = s2n_config_new(), s2n_config_ptr_free);
+    EXPECT_NOT_NULL(config);
     EXPECT_SUCCESS(s2n_config_disable_x509_verification(config));
     EXPECT_SUCCESS(s2n_config_set_check_stapled_ocsp_response(config, 0));
     /* The server hello has TLS_RSA_WITH_AES_256_CBC_SHA256 hardcoded,
        so we need to set a cipher preference that will accept that value */
     EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "20170328"));
-    EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
-    EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
 
-    conn->server_protocol_version = S2N_TLS12;
-    conn->client_protocol_version = S2N_TLS12;
-    conn->actual_protocol_version = S2N_TLS12;
+    /* Test: fragmented message (server hello split into 5 records) */
+    {
+        DEFER_CLEANUP(struct s2n_connection *conn = s2n_connection_new(S2N_CLIENT),
+                s2n_connection_ptr_free);
+        EXPECT_NOT_NULL(conn);
+        EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
 
-    /* Create a pipe */
-    EXPECT_SUCCESS(pipe(p));
+        conn->server_protocol_version = S2N_TLS12;
+        conn->client_protocol_version = S2N_TLS12;
+        conn->actual_protocol_version = S2N_TLS12;
 
-    /* Set up the connection to read from the fd */
-    EXPECT_SUCCESS(s2n_connection_set_read_fd(conn, p[0]));
+        /* Use a stuffer as the input IO */
+        DEFER_CLEANUP(struct s2n_stuffer in = { 0 }, s2n_stuffer_free);
+        EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&in, 0));
+        EXPECT_SUCCESS(s2n_connection_set_recv_io_stuffer(&in, conn));
 
-    /* Pretend the client hello has already been set */
-    conn->handshake.handshake_type = NEGOTIATED | FULL_HANDSHAKE;
-    conn->handshake.message_number = SERVER_HELLO;
+        /* Pretend the client hello has already been set */
+        conn->handshake.handshake_type = NEGOTIATED | FULL_HANDSHAKE;
+        conn->handshake.message_number = SERVER_HELLO;
 
-    /* Create a child process */
-    pid = fork();
-    if (pid == 0) {
-        /* This is the child process, close the read end of the pipe */
-        EXPECT_SUCCESS(close(p[0]));
+        /* Split the hello message into 5 fragments */
+        uint32_t written = 0;
+        for (int i = 0; i < 5; i++) {
+            uint32_t length = sizeof(server_hello_message) / 5;
+            if (i == 0) {
+                length += sizeof(server_hello_message) % 5;
+            }
+            EXPECT_SUCCESS(write_record(&in, TLS_HANDSHAKE,
+                    server_hello_message + written, length));
+            written += length;
+        }
 
-        /* Write the fragmented hello message */
-        fragmented_message(p[1]);
-        EXPECT_SUCCESS(s2n_config_free(config));
-        EXPECT_SUCCESS(s2n_connection_free(conn));
-        exit(0);
-    }
+        /* Negotiate the handshake. This will fail due to EOF, but that's ok. */
+        s2n_blocked_status blocked;
+        EXPECT_FAILURE(s2n_negotiate(conn, &blocked));
 
-    /* This is the parent process, close the write end of the pipe */
-    EXPECT_SUCCESS(close(p[1]));
+        /* Verify that the data is as we expect it */
+        EXPECT_BYTEARRAY_EQUAL(conn->handshake_params.server_random,
+                zero_to_thirty_one, 32);
 
-    /* Negotiate the handshake. This will fail due to EOF, but that's ok. */
-    EXPECT_FAILURE(s2n_negotiate(conn, &blocked));
+        /* Check that the server hello message was processed */
+        EXPECT_EQUAL(s2n_conn_get_current_message_type(conn), SERVER_CERT);
+    };
 
-    /* Verify that the data is as we expect it */
-    EXPECT_EQUAL(memcmp(conn->handshake_params.server_random, zero_to_thirty_one, 32), 0);
+    /* Test: coalesced message (server hello + cert in one record) */
+    {
+        DEFER_CLEANUP(struct s2n_connection *conn = s2n_connection_new(S2N_CLIENT),
+                s2n_connection_ptr_free);
+        EXPECT_NOT_NULL(conn);
+        EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
 
-    /* Check that the server hello message was processed */
-    EXPECT_EQUAL(s2n_conn_get_current_message_type(conn), SERVER_CERT);
+        conn->server_protocol_version = S2N_TLS12;
+        conn->client_protocol_version = S2N_TLS12;
+        conn->actual_protocol_version = S2N_TLS12;
 
-    /* Clean up */
-    EXPECT_EQUAL(waitpid(pid, &status, 0), pid);
-    EXPECT_EQUAL(status, 0);
-    EXPECT_SUCCESS(close(p[0]));
+        DEFER_CLEANUP(struct s2n_stuffer in = { 0 }, s2n_stuffer_free);
+        EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&in, 0));
+        EXPECT_SUCCESS(s2n_connection_set_recv_io_stuffer(&in, conn));
 
-    /* Create a pipe */
-    EXPECT_SUCCESS(pipe(p));
+        conn->handshake.handshake_type = NEGOTIATED | FULL_HANDSHAKE;
+        conn->handshake.message_number = SERVER_HELLO;
 
-    /* Wipe the connection */
-    EXPECT_SUCCESS(s2n_connection_wipe(conn));
-    conn->server_protocol_version = S2N_TLS12;
-    conn->client_protocol_version = S2N_TLS12;
-    conn->actual_protocol_version = S2N_TLS12;
+        /* Write both messages in a single record */
+        uint32_t length = sizeof(server_hello_message) + sizeof(server_cert);
+        uint8_t record_header[5] = { TLS_HANDSHAKE, 0x03, 0x03, (length >> 8), length & 0xff };
+        EXPECT_SUCCESS(s2n_stuffer_write_bytes(&in, record_header, 5));
+        EXPECT_SUCCESS(s2n_stuffer_write_bytes(&in, server_hello_message,
+                sizeof(server_hello_message)));
+        EXPECT_SUCCESS(s2n_stuffer_write_bytes(&in, server_cert,
+                sizeof(server_cert)));
 
-    /* Set up the connection to read from the fd */
-    EXPECT_SUCCESS(s2n_connection_set_read_fd(conn, p[0]));
+        s2n_blocked_status blocked;
+        EXPECT_FAILURE(s2n_negotiate(conn, &blocked));
 
-    /* Pretend the client hello has already been set */
-    conn->handshake.handshake_type = NEGOTIATED | FULL_HANDSHAKE;
-    conn->handshake.message_number = SERVER_HELLO;
+        EXPECT_BYTEARRAY_EQUAL(conn->handshake_params.server_random,
+                zero_to_thirty_one, 32);
 
-    /* Create a child process */
-    pid = fork();
-    if (pid == 0) {
-        /* This is the child process, close the read end of the pipe */
-        EXPECT_SUCCESS(close(p[0]));
+        /* Check that the server done message was processed */
+        EXPECT_EQUAL(s2n_conn_get_current_message_type(conn), SERVER_HELLO_DONE);
+    };
 
-        /* Write the fragmented hello message */
-        coalesced_message(p[1]);
-        EXPECT_SUCCESS(s2n_connection_free(conn));
-        EXPECT_SUCCESS(s2n_config_free(config));
-        exit(0);
-    }
+    /* Test: interleaved message (hello split with heartbeat in between) */
+    {
+        DEFER_CLEANUP(struct s2n_connection *conn = s2n_connection_new(S2N_CLIENT),
+                s2n_connection_ptr_free);
+        EXPECT_NOT_NULL(conn);
+        EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
 
-    /* This is the parent process, close the write end of the pipe */
-    EXPECT_SUCCESS(close(p[1]));
+        conn->server_protocol_version = S2N_TLS12;
+        conn->client_protocol_version = S2N_TLS12;
+        conn->actual_protocol_version = S2N_TLS12;
 
-    /* Negotiate the handshake. This will fail due to EOF, but that's ok. */
-    EXPECT_FAILURE(s2n_negotiate(conn, &blocked));
+        DEFER_CLEANUP(struct s2n_stuffer in = { 0 }, s2n_stuffer_free);
+        EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&in, 0));
+        EXPECT_SUCCESS(s2n_connection_set_recv_io_stuffer(&in, conn));
 
-    /* Verify that the data is as we expect it */
-    EXPECT_EQUAL(memcmp(conn->handshake_params.server_random, zero_to_thirty_one, 32), 0);
+        conn->handshake.handshake_type = NEGOTIATED | FULL_HANDSHAKE;
+        conn->handshake.message_number = SERVER_HELLO;
 
-    /* Check that the server done message was processed */
-    EXPECT_EQUAL(s2n_conn_get_current_message_type(conn), SERVER_HELLO_DONE);
+        /* Write first half of hello */
+        uint32_t half = sizeof(server_hello_message) / 2;
+        EXPECT_SUCCESS(write_record(&in, TLS_HANDSHAKE,
+                server_hello_message, half));
 
-    /* Clean up */
-    EXPECT_EQUAL(waitpid(pid, &status, 0), pid);
-    EXPECT_EQUAL(status, 0);
-    EXPECT_SUCCESS(close(p[0]));
+        /* Write heartbeat record in between */
+        EXPECT_SUCCESS(write_record(&in, TLS_HEARTBEAT,
+                heartbeat_message, sizeof(heartbeat_message)));
 
-    /* Create a pipe */
-    EXPECT_SUCCESS(pipe(p));
+        /* Write second half of hello */
+        uint32_t remaining = sizeof(server_hello_message) - half;
+        EXPECT_SUCCESS(write_record(&in, TLS_HANDSHAKE,
+                server_hello_message + half, remaining));
 
-    /* Wipe the connection */
-    EXPECT_SUCCESS(s2n_connection_wipe(conn));
-    conn->server_protocol_version = S2N_TLS12;
-    conn->client_protocol_version = S2N_TLS12;
-    conn->actual_protocol_version = S2N_TLS12;
+        s2n_blocked_status blocked;
+        EXPECT_FAILURE(s2n_negotiate(conn, &blocked));
 
-    /* Set up the connection to read from the fd */
-    EXPECT_SUCCESS(s2n_connection_set_read_fd(conn, p[0]));
+        EXPECT_BYTEARRAY_EQUAL(conn->handshake_params.server_random,
+                zero_to_thirty_one, 32);
 
-    /* Pretend the client hello has already been set */
-    conn->handshake.handshake_type = NEGOTIATED | FULL_HANDSHAKE;
-    conn->handshake.message_number = SERVER_HELLO;
+        /* Check that the server hello message was processed */
+        EXPECT_EQUAL(s2n_conn_get_current_message_type(conn), SERVER_CERT);
+    };
 
-    /* Create a child process */
-    pid = fork();
-    if (pid == 0) {
-        /* This is the child process, close the read end of the pipe */
-        EXPECT_SUCCESS(close(p[0]));
+    /* Test: interleaved fragmented warning alert */
+    {
+        DEFER_CLEANUP(struct s2n_connection *conn = s2n_connection_new(S2N_CLIENT),
+                s2n_connection_ptr_free);
+        EXPECT_NOT_NULL(conn);
+        EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
 
-        /* Write the fragmented hello message */
-        interleaved_message(p[1]);
-        EXPECT_SUCCESS(s2n_connection_free(conn));
-        EXPECT_SUCCESS(s2n_config_free(config));
-        exit(0);
-    }
+        conn->server_protocol_version = S2N_TLS12;
+        conn->client_protocol_version = S2N_TLS12;
+        conn->actual_protocol_version = S2N_TLS12;
 
-    /* This is the parent process, close the write end of the pipe */
-    EXPECT_SUCCESS(close(p[1]));
+        DEFER_CLEANUP(struct s2n_stuffer in = { 0 }, s2n_stuffer_free);
+        EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&in, 0));
+        EXPECT_SUCCESS(s2n_connection_set_recv_io_stuffer(&in, conn));
 
-    /* Negotiate the handshake. This will fail due to EOF, but that's ok. */
-    EXPECT_FAILURE(s2n_negotiate(conn, &blocked));
+        conn->handshake.handshake_type = NEGOTIATED | FULL_HANDSHAKE;
+        conn->handshake.message_number = SERVER_HELLO;
 
-    /* Verify that the data is as we expect it */
-    EXPECT_EQUAL(memcmp(conn->handshake_params.server_random, zero_to_thirty_one, 32), 0);
+        uint32_t half = sizeof(server_hello_message) / 2;
+        uint32_t quarter = sizeof(server_hello_message) / 4;
+        uint32_t written = 0;
 
-    /* Check that the server hello message was processed */
-    EXPECT_EQUAL(s2n_conn_get_current_message_type(conn), SERVER_CERT);
+        /* Write first half of hello */
+        EXPECT_SUCCESS(write_record(&in, TLS_HANDSHAKE,
+                server_hello_message, half));
+        written += half;
 
-    /* Clean up */
-    EXPECT_EQUAL(waitpid(pid, &status, 0), pid);
-    EXPECT_EQUAL(status, 0);
-    EXPECT_SUCCESS(close(p[0]));
+        /* Write first byte of warning alert */
+        EXPECT_SUCCESS(write_record(&in, TLS_ALERT, warning_alert, 1));
 
-    /* Create a pipe */
-    EXPECT_SUCCESS(pipe(p));
+        /* Write another quarter of hello */
+        EXPECT_SUCCESS(write_record(&in, TLS_HANDSHAKE,
+                server_hello_message + written, quarter));
+        written += quarter;
 
-    /* Wipe the connection */
-    EXPECT_SUCCESS(s2n_connection_wipe(conn));
-    conn->server_protocol_version = S2N_TLS12;
-    conn->client_protocol_version = S2N_TLS12;
-    conn->actual_protocol_version = S2N_TLS12;
+        /* Write second byte of warning alert */
+        EXPECT_SUCCESS(write_record(&in, TLS_ALERT, warning_alert + 1, 1));
 
-    /* Set up the connection to read from the fd */
-    EXPECT_SUCCESS(s2n_connection_set_read_fd(conn, p[0]));
+        /* Write rest of hello */
+        uint32_t rest = sizeof(server_hello_message) - written;
+        EXPECT_SUCCESS(write_record(&in, TLS_HANDSHAKE,
+                server_hello_message + written, rest));
 
-    /* Pretend the client hello has already been set */
-    conn->handshake.handshake_type = NEGOTIATED | FULL_HANDSHAKE;
-    conn->handshake.message_number = SERVER_HELLO;
+        s2n_blocked_status blocked;
+        EXPECT_FAILURE(s2n_negotiate(conn, &blocked));
 
-    /* Create a child process */
-    pid = fork();
-    if (pid == 0) {
-        /* This is the child process, close the read end of the pipe */
-        EXPECT_SUCCESS(close(p[0]));
+        /* Warning alert should have prevented processing */
+        EXPECT_BYTEARRAY_NOT_EQUAL(conn->handshake_params.server_random,
+                zero_to_thirty_one, 32);
 
-        /* Write the fragmented hello message */
-        interleaved_fragmented_warning_alert(p[1]);
-        EXPECT_SUCCESS(s2n_connection_free(conn));
-        EXPECT_SUCCESS(s2n_config_free(config));
-        exit(0);
-    }
+        /* Check that the server hello message was not processed */
+        EXPECT_EQUAL(s2n_conn_get_current_message_type(conn), SERVER_HELLO);
+    };
 
-    /* This is the parent process, close the write end of the pipe */
-    EXPECT_SUCCESS(close(p[1]));
+    /* Test: interleaved fragmented fatal alert */
+    {
+        DEFER_CLEANUP(struct s2n_connection *conn = s2n_connection_new(S2N_CLIENT),
+                s2n_connection_ptr_free);
+        EXPECT_NOT_NULL(conn);
+        EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
 
-    /* Negotiate the handshake. This will fail due to EOF, but that's ok. */
-    EXPECT_FAILURE(s2n_negotiate(conn, &blocked));
+        conn->server_protocol_version = S2N_TLS12;
+        conn->client_protocol_version = S2N_TLS12;
+        conn->actual_protocol_version = S2N_TLS12;
 
-    /* Verify that the data is as we expect it */
-    EXPECT_NOT_EQUAL(memcmp(conn->handshake_params.server_random, zero_to_thirty_one, 32), 0);
+        DEFER_CLEANUP(struct s2n_stuffer in = { 0 }, s2n_stuffer_free);
+        EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&in, 0));
+        EXPECT_SUCCESS(s2n_connection_set_recv_io_stuffer(&in, conn));
 
-    /* Check that the server hello message was not processed */
-    EXPECT_EQUAL(s2n_conn_get_current_message_type(conn), SERVER_HELLO);
+        conn->handshake.handshake_type = NEGOTIATED | FULL_HANDSHAKE;
+        conn->handshake.message_number = SERVER_HELLO;
 
-    /* Clean up */
-    EXPECT_EQUAL(waitpid(pid, &status, 0), pid);
-    EXPECT_EQUAL(status, 0);
-    EXPECT_SUCCESS(close(p[0]));
+        uint32_t half = sizeof(server_hello_message) / 2;
+        uint32_t quarter = sizeof(server_hello_message) / 4;
+        uint32_t written = 0;
 
-    /* Create a pipe */
-    EXPECT_SUCCESS(pipe(p));
+        /* Write first half of hello */
+        EXPECT_SUCCESS(write_record(&in, TLS_HANDSHAKE,
+                server_hello_message, half));
+        written += half;
 
-    /* Wipe the connection */
-    EXPECT_SUCCESS(s2n_connection_wipe(conn));
-    conn->server_protocol_version = S2N_TLS12;
-    conn->client_protocol_version = S2N_TLS12;
-    conn->actual_protocol_version = S2N_TLS12;
+        /* Write first byte of fatal alert */
+        EXPECT_SUCCESS(write_record(&in, TLS_ALERT, fatal_alert, 1));
 
-    /* Set up the connection to read from the fd */
-    EXPECT_SUCCESS(s2n_connection_set_read_fd(conn, p[0]));
+        /* Write another quarter of hello */
+        EXPECT_SUCCESS(write_record(&in, TLS_HANDSHAKE,
+                server_hello_message + written, quarter));
+        written += quarter;
 
-    /* Pretend the client hello has already been set */
-    conn->handshake.handshake_type = NEGOTIATED | FULL_HANDSHAKE;
-    conn->handshake.message_number = SERVER_HELLO;
+        /* Write second byte of fatal alert */
+        EXPECT_SUCCESS(write_record(&in, TLS_ALERT, fatal_alert + 1, 1));
 
-    /* Create a child process */
-    pid = fork();
-    if (pid == 0) {
-        /* This is the child process, close the read end of the pipe */
-        EXPECT_SUCCESS(close(p[0]));
+        /* Write rest of hello */
+        uint32_t rest = sizeof(server_hello_message) - written;
+        EXPECT_SUCCESS(write_record(&in, TLS_HANDSHAKE,
+                server_hello_message + written, rest));
 
-        /* Write the fragmented hello message */
-        interleaved_fragmented_fatal_alert(p[1]);
-        EXPECT_SUCCESS(s2n_connection_free(conn));
-        EXPECT_SUCCESS(s2n_config_free(config));
-        exit(0);
-    }
+        s2n_blocked_status blocked;
+        EXPECT_FAILURE(s2n_negotiate(conn, &blocked));
 
-    /* This is the parent process, close the write end of the pipe */
-    EXPECT_SUCCESS(close(p[1]));
+        /* Fatal alert should have prevented processing */
+        EXPECT_BYTEARRAY_NOT_EQUAL(conn->handshake_params.server_random,
+                zero_to_thirty_one, 32);
 
-    /* Negotiate the handshake. This will fail due to EOF, but that's ok. */
-    EXPECT_FAILURE(s2n_negotiate(conn, &blocked));
-
-    /* Verify that the data failed */
-    EXPECT_NOT_EQUAL(memcmp(conn->handshake_params.server_random, zero_to_thirty_one, 32), 0);
-
-    /* Check that the server hello message was not processed */
-    EXPECT_NOT_EQUAL(s2n_conn_get_current_message_type(conn), SERVER_CERT);
-
-    /* Clean up */
-    EXPECT_EQUAL(waitpid(pid, &status, 0), pid);
-    EXPECT_EQUAL(status, 0);
-    EXPECT_SUCCESS(close(p[0]));
-
-    EXPECT_SUCCESS(s2n_connection_free(conn));
-    EXPECT_SUCCESS(s2n_config_free(config));
+        /* Check that the server hello message was not processed */
+        EXPECT_NOT_EQUAL(s2n_conn_get_current_message_type(conn), SERVER_CERT);
+    };
 
     END_TEST();
 }

--- a/tests/unit/s2n_handshake_test.c
+++ b/tests/unit/s2n_handshake_test.c
@@ -19,8 +19,11 @@
 #include <fcntl.h>
 #include <stdint.h>
 #include <stdlib.h>
-#include <sys/wait.h>
-#include <unistd.h>
+
+#ifndef _WIN32
+    #include <sys/wait.h>
+    #include <unistd.h>
+#endif
 
 #include "api/s2n.h"
 #include "crypto/s2n_fips.h"
@@ -509,11 +512,14 @@ int main(int argc, char **argv)
         }
     }
 
-    /* Ensure that a handshake can be performed after all file descriptors are closed */
+    /* Ensure that a handshake can be performed after all file descriptors are closed.
+     *
+     * This test relies on POSIX-specific APIs (sysconf(_SC_OPEN_MAX) to discover
+     * open file descriptors, and fork() to isolate the fd closure from the test
+     * harness). These are not available on Windows.
+     */
+#ifndef _WIN32
     {
-        /* A fork is created to ensure that closing file descriptors (like stdout) won't impact
-         * other tests.
-         */
         pid_t pid = fork();
         if (pid == 0) {
             long max_file_descriptors = sysconf(_SC_OPEN_MAX);
@@ -548,6 +554,7 @@ int main(int argc, char **argv)
         EXPECT_EQUAL(waitpid(pid, &status, 0), pid);
         EXPECT_EQUAL(status, EXIT_SUCCESS);
     }
+#endif
 
     END_TEST();
 }

--- a/tests/unit/s2n_malformed_handshake_test.c
+++ b/tests/unit/s2n_malformed_handshake_test.c
@@ -14,12 +14,10 @@
  */
 
 #include <stdint.h>
-#include <stdlib.h>
-#include <sys/wait.h>
-#include <unistd.h>
 
 #include "api/s2n.h"
 #include "s2n_test.h"
+#include "testlib/s2n_testlib.h"
 #include "tls/s2n_connection.h"
 #include "tls/s2n_handshake.h"
 
@@ -196,342 +194,186 @@ static uint8_t certificate_too_large[] = {
     0x00, 0x00, 0x10
 };
 
-void send_messages(int write_fd, uint8_t *server_hello, uint32_t server_hello_len, uint8_t *server_cert, uint32_t server_cert_len)
+/* Write a TLS record (header + payload) into a stuffer */
+int write_record(struct s2n_stuffer *in, uint8_t content_type,
+        const uint8_t *payload, uint32_t payload_len)
 {
-    uint8_t record_header[5] = { TLS_HANDSHAKE, 0x03, 0x03, (server_hello_len >> 8), server_hello_len & 0xff };
+    uint8_t record_header[5] = { content_type, 0x03, 0x03, (payload_len >> 8), payload_len & 0xff };
+    POSIX_GUARD(s2n_stuffer_write_bytes(in, record_header, 5));
+    POSIX_GUARD(s2n_stuffer_write_bytes(in, payload, payload_len));
+    return S2N_SUCCESS;
+}
 
-    if (write(write_fd, record_header, 5) != 5) {
-        _exit(100);
-    }
+/* Write server_hello + a certificate message as separate records */
+int send_messages(struct s2n_stuffer *in, uint8_t *server_hello,
+        uint32_t server_hello_len, uint8_t *cert, uint32_t cert_len)
+{
+    POSIX_GUARD(write_record(in, TLS_HANDSHAKE, server_hello, server_hello_len));
+    POSIX_GUARD(write_record(in, TLS_HANDSHAKE, cert, cert_len));
+    return S2N_SUCCESS;
+}
 
-    if (write(write_fd, server_hello, server_hello_len) != server_hello_len) {
-        _exit(100);
-    }
+/* Set up a fresh client connection ready to receive a ServerHello */
+int setup_conn(struct s2n_connection *conn, struct s2n_config *config,
+        struct s2n_stuffer *in)
+{
+    POSIX_GUARD(s2n_connection_set_config(conn, config));
+    POSIX_GUARD(s2n_connection_set_recv_io_stuffer(in, conn));
+    POSIX_GUARD(s2n_connection_set_blinding(conn, S2N_SELF_SERVICE_BLINDING));
 
-    record_header[3] = (server_cert_len >> 8);
-    record_header[4] = server_cert_len & 0xff;
+    conn->handshake.handshake_type = NEGOTIATED | FULL_HANDSHAKE;
+    conn->handshake.message_number = SERVER_HELLO;
+    conn->server_protocol_version = S2N_TLS12;
+    conn->client_protocol_version = S2N_TLS12;
+    conn->actual_protocol_version = S2N_TLS12;
 
-    if (write(write_fd, record_header, 5) != 5) {
-        _exit(100);
-    }
-
-    if (write(write_fd, server_cert, server_cert_len) != server_cert_len) {
-        _exit(100);
-    }
-
-    /* Close the pipe and exit */
-    close(write_fd);
+    return S2N_SUCCESS;
 }
 
 int main(int argc, char **argv)
 {
     s2n_blocked_status blocked;
-    int status = 0;
-    pid_t pid = 0;
-    int p[2];
 
     BEGIN_TEST();
     EXPECT_SUCCESS(s2n_disable_tls13_in_test());
 
     DEFER_CLEANUP(struct s2n_config *config = s2n_config_new(), s2n_config_ptr_free);
-    DEFER_CLEANUP(struct s2n_connection *conn = s2n_connection_new(S2N_CLIENT), s2n_connection_ptr_free);
+    EXPECT_NOT_NULL(config);
     EXPECT_SUCCESS(s2n_config_disable_x509_verification(config));
     EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "test_all"));
-    EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
 
     /* Test a good certificate list */
+    {
+        DEFER_CLEANUP(struct s2n_connection *conn = s2n_connection_new(S2N_CLIENT),
+                s2n_connection_ptr_free);
+        EXPECT_NOT_NULL(conn);
+        DEFER_CLEANUP(struct s2n_stuffer in = { 0 }, s2n_stuffer_free);
+        EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&in, 0));
+        EXPECT_SUCCESS(setup_conn(conn, config, &in));
 
-    /* Create a pipe */
-    EXPECT_SUCCESS(pipe(p));
+        EXPECT_SUCCESS(send_messages(&in, server_hello_message,
+                sizeof(server_hello_message), good_certificate_list,
+                sizeof(good_certificate_list)));
 
-    EXPECT_SUCCESS(s2n_connection_wipe(conn));
+        EXPECT_FAILURE(s2n_negotiate(conn, &blocked));
 
-    /* Set up the connection to read from the fd */
-    EXPECT_SUCCESS(s2n_connection_set_read_fd(conn, p[0]));
+        /* Verify that the data is as we expect it */
+        EXPECT_BYTEARRAY_EQUAL(conn->handshake_params.server_random,
+                zero_to_thirty_one, 32);
 
-    /* Pretend the client hello has already been set */
-    conn->handshake.handshake_type = NEGOTIATED | FULL_HANDSHAKE;
-    conn->handshake.message_number = SERVER_HELLO;
-    conn->server_protocol_version = S2N_TLS12;
-    conn->client_protocol_version = S2N_TLS12;
-    conn->actual_protocol_version = S2N_TLS12;
-
-    /* Create a child process */
-    pid = fork();
-    if (pid == 0) {
-        /* This is the child process, close the read end of the pipe */
-        EXPECT_SUCCESS(close(p[0]));
-
-        send_messages(p[1], server_hello_message, sizeof(server_hello_message), good_certificate_list, sizeof(good_certificate_list));
-
-        EXPECT_SUCCESS(s2n_connection_free(conn));
-        EXPECT_SUCCESS(s2n_config_free(config));
-        exit(0);
-    }
-
-    /* This is the parent process, close the write end of the pipe */
-    EXPECT_SUCCESS(close(p[1]));
-
-    /* Negotiate the handshake. This will fail due to EOF, but that's ok. Turn off Blinding before negotiation so that
-     * server doesn't delay its response and test finishes quickly. */
-    EXPECT_SUCCESS(s2n_connection_set_blinding(conn, S2N_SELF_SERVICE_BLINDING));
-    EXPECT_FAILURE(s2n_negotiate(conn, &blocked));
-
-    /* Verify that the data is as we expect it */
-    EXPECT_EQUAL(memcmp(conn->handshake_params.server_random, zero_to_thirty_one, 32), 0);
-
-    /* Check that the server hello message was processed .. we should be HELLO DONE */
-    EXPECT_EQUAL(s2n_conn_get_current_message_type(conn), SERVER_HELLO_DONE);
-
-    /* Clean up */
-    EXPECT_EQUAL(waitpid(pid, &status, 0), pid);
-    EXPECT_EQUAL(status, 0);
-    EXPECT_SUCCESS(close(p[0]));
+        /* Check that the server hello message was processed .. we should be HELLO DONE */
+        EXPECT_EQUAL(s2n_conn_get_current_message_type(conn), SERVER_HELLO_DONE);
+    };
 
     /* Test an empty certificate list */
+    {
+        DEFER_CLEANUP(struct s2n_connection *conn = s2n_connection_new(S2N_CLIENT),
+                s2n_connection_ptr_free);
+        EXPECT_NOT_NULL(conn);
+        DEFER_CLEANUP(struct s2n_stuffer in = { 0 }, s2n_stuffer_free);
+        EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&in, 0));
+        EXPECT_SUCCESS(setup_conn(conn, config, &in));
 
-    /* Create a pipe */
-    EXPECT_SUCCESS(pipe(p));
+        EXPECT_SUCCESS(send_messages(&in, server_hello_message,
+                sizeof(server_hello_message), empty_certificate_list,
+                sizeof(empty_certificate_list)));
 
-    EXPECT_SUCCESS(s2n_connection_wipe(conn));
+        EXPECT_FAILURE(s2n_negotiate(conn, &blocked));
 
-    /* Set up the connection to read from the fd */
-    EXPECT_SUCCESS(s2n_connection_set_read_fd(conn, p[0]));
+        EXPECT_BYTEARRAY_EQUAL(conn->handshake_params.server_random,
+                zero_to_thirty_one, 32);
 
-    /* Pretend the client hello has already been set */
-    conn->handshake.handshake_type = NEGOTIATED | FULL_HANDSHAKE;
-    conn->handshake.message_number = SERVER_HELLO;
-    conn->server_protocol_version = S2N_TLS12;
-    conn->client_protocol_version = S2N_TLS12;
-    conn->actual_protocol_version = S2N_TLS12;
-
-    /* Create a child process */
-    pid = fork();
-    if (pid == 0) {
-        /* This is the child process, close the read end of the pipe */
-        EXPECT_SUCCESS(close(p[0]));
-
-        send_messages(p[1], server_hello_message, sizeof(server_hello_message), empty_certificate_list, sizeof(empty_certificate_list));
-
-        EXPECT_SUCCESS(s2n_connection_free(conn));
-        EXPECT_SUCCESS(s2n_config_free(config));
-        exit(0);
-    }
-
-    /* This is the parent process, close the write end of the pipe */
-    EXPECT_SUCCESS(close(p[1]));
-
-    /* Negotiate the handshake. This will fail due to EOF, but that's ok. Turn off Blinding before negotiation so that
-     * server doesn't delay its response and test finishes quickly. */
-    EXPECT_SUCCESS(s2n_connection_set_blinding(conn, S2N_SELF_SERVICE_BLINDING));
-    EXPECT_FAILURE(s2n_negotiate(conn, &blocked));
-
-    /* Verify that the data is as we expect it */
-    EXPECT_EQUAL(memcmp(conn->handshake_params.server_random, zero_to_thirty_one, 32), 0);
-
-    /* Check that the server hello message was not processed, we're stuck in SERVER_CERT */
-    EXPECT_EQUAL(s2n_conn_get_current_message_type(conn), SERVER_CERT);
-
-    /* Clean up */
-    EXPECT_EQUAL(waitpid(pid, &status, 0), pid);
-    EXPECT_EQUAL(status, 0);
-    EXPECT_SUCCESS(close(p[0]));
+        /* Check that the server hello message was not processed, we're stuck in SERVER_CERT */
+        EXPECT_EQUAL(s2n_conn_get_current_message_type(conn), SERVER_CERT);
+    };
 
     /* Test an empty certificate */
+    {
+        DEFER_CLEANUP(struct s2n_connection *conn = s2n_connection_new(S2N_CLIENT),
+                s2n_connection_ptr_free);
+        EXPECT_NOT_NULL(conn);
+        DEFER_CLEANUP(struct s2n_stuffer in = { 0 }, s2n_stuffer_free);
+        EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&in, 0));
+        EXPECT_SUCCESS(setup_conn(conn, config, &in));
 
-    /* Create a pipe */
-    EXPECT_SUCCESS(pipe(p));
+        EXPECT_SUCCESS(send_messages(&in, server_hello_message,
+                sizeof(server_hello_message), empty_certificate,
+                sizeof(empty_certificate)));
 
-    EXPECT_SUCCESS(s2n_connection_wipe(conn));
+        EXPECT_FAILURE(s2n_negotiate(conn, &blocked));
 
-    /* Set up the connection to read from the fd */
-    EXPECT_SUCCESS(s2n_connection_set_read_fd(conn, p[0]));
+        EXPECT_BYTEARRAY_EQUAL(conn->handshake_params.server_random,
+                zero_to_thirty_one, 32);
 
-    /* Pretend the client hello has already been set */
-    conn->handshake.handshake_type = NEGOTIATED | FULL_HANDSHAKE;
-    conn->handshake.message_number = SERVER_HELLO;
-    conn->server_protocol_version = S2N_TLS12;
-    conn->client_protocol_version = S2N_TLS12;
-    conn->actual_protocol_version = S2N_TLS12;
+        /* Check that the server hello message was not processed, we're stuck in SERVER_CERT */
+        EXPECT_EQUAL(s2n_conn_get_current_message_type(conn), SERVER_CERT);
+    };
 
-    /* Create a child process */
-    pid = fork();
-    if (pid == 0) {
-        /* This is the child process, close the read end of the pipe */
-        EXPECT_SUCCESS(close(p[0]));
+    /* Test a 'too large' certificate list */
+    {
+        DEFER_CLEANUP(struct s2n_connection *conn = s2n_connection_new(S2N_CLIENT),
+                s2n_connection_ptr_free);
+        EXPECT_NOT_NULL(conn);
+        DEFER_CLEANUP(struct s2n_stuffer in = { 0 }, s2n_stuffer_free);
+        EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&in, 0));
+        EXPECT_SUCCESS(setup_conn(conn, config, &in));
 
-        send_messages(p[1], server_hello_message, sizeof(server_hello_message), empty_certificate, sizeof(empty_certificate));
+        EXPECT_SUCCESS(send_messages(&in, server_hello_message,
+                sizeof(server_hello_message), certificate_list_too_large,
+                sizeof(certificate_list_too_large)));
 
-        EXPECT_SUCCESS(s2n_connection_free(conn));
-        EXPECT_SUCCESS(s2n_config_free(config));
-        exit(0);
-    }
+        EXPECT_FAILURE(s2n_negotiate(conn, &blocked));
 
-    /* This is the parent process, close the write end of the pipe */
-    EXPECT_SUCCESS(close(p[1]));
+        EXPECT_BYTEARRAY_EQUAL(conn->handshake_params.server_random,
+                zero_to_thirty_one, 32);
 
-    /* Negotiate the handshake. This will fail due to EOF, but that's ok. Turn off Blinding before negotiation so that
-     * server doesn't delay its response and test finishes quickly. */
-    EXPECT_SUCCESS(s2n_connection_set_blinding(conn, S2N_SELF_SERVICE_BLINDING));
-    EXPECT_FAILURE(s2n_negotiate(conn, &blocked));
+        /* Check that the server hello message was not processed, we're stuck in SERVER_CERT */
+        EXPECT_EQUAL(s2n_conn_get_current_message_type(conn), SERVER_CERT);
+    };
 
-    /* Verify that the data is as we expect it */
-    EXPECT_EQUAL(memcmp(conn->handshake_params.server_random, zero_to_thirty_one, 32), 0);
+    /* Test a 'too large' certificate */
+    {
+        DEFER_CLEANUP(struct s2n_connection *conn = s2n_connection_new(S2N_CLIENT),
+                s2n_connection_ptr_free);
+        EXPECT_NOT_NULL(conn);
+        DEFER_CLEANUP(struct s2n_stuffer in = { 0 }, s2n_stuffer_free);
+        EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&in, 0));
+        EXPECT_SUCCESS(setup_conn(conn, config, &in));
 
-    /* Check that the server hello message was not processed, we're stuck in SERVER_CERT */
-    EXPECT_EQUAL(s2n_conn_get_current_message_type(conn), SERVER_CERT);
+        EXPECT_SUCCESS(send_messages(&in, server_hello_message,
+                sizeof(server_hello_message), certificate_too_large,
+                sizeof(certificate_too_large)));
 
-    /* Clean up */
-    EXPECT_EQUAL(waitpid(pid, &status, 0), pid);
-    EXPECT_EQUAL(status, 0);
-    EXPECT_SUCCESS(close(p[0]));
+        EXPECT_FAILURE(s2n_negotiate(conn, &blocked));
 
-    /* Test an 'too large' certificate list */
+        EXPECT_BYTEARRAY_EQUAL(conn->handshake_params.server_random,
+                zero_to_thirty_one, 32);
 
-    /* Create a pipe */
-    EXPECT_SUCCESS(pipe(p));
+        /* Check that the server hello message was not processed, we're stuck in SERVER_CERT */
+        EXPECT_EQUAL(s2n_conn_get_current_message_type(conn), SERVER_CERT);
+    };
 
-    EXPECT_SUCCESS(s2n_connection_wipe(conn));
+    /* Test a 'too large' handshake */
+    {
+        DEFER_CLEANUP(struct s2n_connection *conn = s2n_connection_new(S2N_CLIENT),
+                s2n_connection_ptr_free);
+        EXPECT_NOT_NULL(conn);
+        DEFER_CLEANUP(struct s2n_stuffer in = { 0 }, s2n_stuffer_free);
+        EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&in, 0));
+        EXPECT_SUCCESS(setup_conn(conn, config, &in));
 
-    /* Set up the connection to read from the fd */
-    EXPECT_SUCCESS(s2n_connection_set_read_fd(conn, p[0]));
+        EXPECT_SUCCESS(send_messages(&in, server_hello_message,
+                sizeof(server_hello_message), certificate_list_too_large,
+                sizeof(certificate_list_too_large)));
 
-    /* Pretend the client hello has already been set */
-    conn->handshake.handshake_type = NEGOTIATED | FULL_HANDSHAKE;
-    conn->handshake.message_number = SERVER_HELLO;
-    conn->server_protocol_version = S2N_TLS12;
-    conn->client_protocol_version = S2N_TLS12;
-    conn->actual_protocol_version = S2N_TLS12;
+        EXPECT_FAILURE(s2n_negotiate(conn, &blocked));
 
-    /* Create a child process */
-    pid = fork();
-    if (pid == 0) {
-        /* This is the child process, close the read end of the pipe */
-        EXPECT_SUCCESS(close(p[0]));
+        EXPECT_BYTEARRAY_EQUAL(conn->handshake_params.server_random,
+                zero_to_thirty_one, 32);
 
-        send_messages(p[1], server_hello_message, sizeof(server_hello_message), certificate_list_too_large, sizeof(certificate_list_too_large));
-
-        EXPECT_SUCCESS(s2n_connection_free(conn));
-        EXPECT_SUCCESS(s2n_config_free(config));
-        exit(0);
-    }
-
-    /* This is the parent process, close the write end of the pipe */
-    EXPECT_SUCCESS(close(p[1]));
-
-    /* Negotiate the handshake. This will fail due to EOF, but that's ok. Turn off Blinding before negotiation so that
-     * server doesn't delay its response and test finishes quickly. */
-    EXPECT_SUCCESS(s2n_connection_set_blinding(conn, S2N_SELF_SERVICE_BLINDING));
-    EXPECT_FAILURE(s2n_negotiate(conn, &blocked));
-
-    /* Verify that the data is as we expect it */
-    EXPECT_EQUAL(memcmp(conn->handshake_params.server_random, zero_to_thirty_one, 32), 0);
-
-    /* Check that the server hello message was not processed, we're stuck in SERVER_CERT */
-    EXPECT_EQUAL(s2n_conn_get_current_message_type(conn), SERVER_CERT);
-
-    /* Clean up */
-    EXPECT_EQUAL(waitpid(pid, &status, 0), pid);
-    EXPECT_EQUAL(status, 0);
-    EXPECT_SUCCESS(close(p[0]));
-
-    /* Test an 'too large' certificate */
-
-    /* Create a pipe */
-    EXPECT_SUCCESS(pipe(p));
-
-    EXPECT_SUCCESS(s2n_connection_wipe(conn));
-
-    /* Set up the connection to read from the fd */
-    EXPECT_SUCCESS(s2n_connection_set_read_fd(conn, p[0]));
-
-    /* Pretend the client hello has already been set */
-    conn->handshake.handshake_type = NEGOTIATED | FULL_HANDSHAKE;
-    conn->handshake.message_number = SERVER_HELLO;
-    conn->server_protocol_version = S2N_TLS12;
-    conn->client_protocol_version = S2N_TLS12;
-    conn->actual_protocol_version = S2N_TLS12;
-
-    /* Create a child process */
-    pid = fork();
-    if (pid == 0) {
-        /* This is the child process, close the read end of the pipe */
-        EXPECT_SUCCESS(close(p[0]));
-
-        send_messages(p[1], server_hello_message, sizeof(server_hello_message), certificate_too_large, sizeof(certificate_too_large));
-
-        EXPECT_SUCCESS(s2n_connection_free(conn));
-        EXPECT_SUCCESS(s2n_config_free(config));
-        exit(0);
-    }
-
-    /* This is the parent process, close the write end of the pipe */
-    EXPECT_SUCCESS(close(p[1]));
-
-    /* Negotiate the handshake. This will fail due to EOF, but that's ok. Turn off Blinding before negotiation so that
-     * server doesn't delay its response and test finishes quickly. */
-    EXPECT_SUCCESS(s2n_connection_set_blinding(conn, S2N_SELF_SERVICE_BLINDING));
-    EXPECT_FAILURE(s2n_negotiate(conn, &blocked));
-
-    /* Verify that the data is as we expect it */
-    EXPECT_EQUAL(memcmp(conn->handshake_params.server_random, zero_to_thirty_one, 32), 0);
-
-    /* Check that the server hello message was not processed, we're stuck in SERVER_CERT */
-    EXPECT_EQUAL(s2n_conn_get_current_message_type(conn), SERVER_CERT);
-
-    /* Clean up */
-    EXPECT_EQUAL(waitpid(pid, &status, 0), pid);
-    EXPECT_EQUAL(status, 0);
-    EXPECT_SUCCESS(close(p[0]));
-
-    /* Test an 'too large' handshake */
-
-    /* Create a pipe */
-    EXPECT_SUCCESS(pipe(p));
-
-    EXPECT_SUCCESS(s2n_connection_wipe(conn));
-
-    /* Set up the connection to read from the fd */
-    EXPECT_SUCCESS(s2n_connection_set_read_fd(conn, p[0]));
-
-    /* Pretend the client hello has already been set */
-    conn->handshake.handshake_type = NEGOTIATED | FULL_HANDSHAKE;
-    conn->handshake.message_number = SERVER_HELLO;
-    conn->server_protocol_version = S2N_TLS12;
-    conn->client_protocol_version = S2N_TLS12;
-    conn->actual_protocol_version = S2N_TLS12;
-
-    /* Create a child process */
-    pid = fork();
-    if (pid == 0) {
-        /* This is the child process, close the read end of the pipe */
-        EXPECT_SUCCESS(close(p[0]));
-
-        send_messages(p[1], server_hello_message, sizeof(server_hello_message), certificate_list_too_large, sizeof(certificate_list_too_large));
-
-        EXPECT_SUCCESS(s2n_connection_free(conn));
-        EXPECT_SUCCESS(s2n_config_free(config));
-        exit(0);
-    }
-
-    /* This is the parent process, close the write end of the pipe */
-    EXPECT_SUCCESS(close(p[1]));
-
-    /* Negotiate the handshake. This will fail due to EOF, but that's ok. Turn off Blinding before negotiation so that
-     * server doesn't delay its response and test finishes quickly. */
-    EXPECT_SUCCESS(s2n_connection_set_blinding(conn, S2N_SELF_SERVICE_BLINDING));
-    EXPECT_FAILURE(s2n_negotiate(conn, &blocked));
-
-    /* Verify that the data is as we expect it */
-    EXPECT_EQUAL(memcmp(conn->handshake_params.server_random, zero_to_thirty_one, 32), 0);
-
-    /* Check that the server hello message was not processed, we're stuck in SERVER_CERT */
-    EXPECT_EQUAL(s2n_conn_get_current_message_type(conn), SERVER_CERT);
-
-    /* Clean up */
-    EXPECT_EQUAL(waitpid(pid, &status, 0), pid);
-    EXPECT_EQUAL(status, 0);
-    EXPECT_SUCCESS(close(p[0]));
+        /* Check that the server hello message was not processed, we're stuck in SERVER_CERT */
+        EXPECT_EQUAL(s2n_conn_get_current_message_type(conn), SERVER_CERT);
+    };
 
     END_TEST();
 }


### PR DESCRIPTION
# Goal

Refactor forked base self talk tests to use in memory io pair. Then those tests can be ran on Windows platforms.

## Why


Some existing test uses forks which is difficult to work on Windows. Hence, we are refactoring the test to use in memory IO pair to conduct handshakes.

## How

This PR will enable three different tests to run on Windows: s2n_fragmentation_coalescing_test, s2n_handshake_test, and s2n_malformed_handshake_test. For s2n_fragmentation_coalescing_test and s2n_malformed_handshake_test, we will use the s2n-tls's test io_pair to send and recv messages for client and servers instead of using pipe + two separate processes.

s2n_handshake_test is mostly working already except for the last test case. The last one uses Linux specific functions to close file descriptors, which won't work on Windows. Hence, we gate that section for Windows and let other parts of the test run.

## Callouts

I decided to do this refactor step by step. The reviewer and I need to verify that my refactor change doesn't remove test coverage compared to the original test. Hence, doing it in small PRs will help to make that verification.

## Testing

Those three tests are removed from the CMakeLists.txt exclude list, so that they should be ran on our Windows CI.
https://github.com/aws/s2n-tls/actions/runs/27723190713/job/82013381104?pr=5940
```
93/256 Test  #94: s2n_fragmentation_coalescing_test ................   Passed    0.08 sec
...
116/256 Test #119: s2n_malformed_handshake_test .....................   Passed    0.11 sec
...
178/256 Test #105: s2n_handshake_test ...............................   Passed    8.22 sec
```


### Related

Relate to https://github.com/aws/s2n-tls/issues/4018 and https://github.com/aws/s2n-tls/pull/5939.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
