### PR TITLE
refactor: additional self talk and memory tests to use in memory io pair

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -616,13 +616,10 @@ if (BUILD_TESTING)
             s2n_io_test
             s2n_key_update_threads_test
             s2n_malformed_handshake_test
-            s2n_mem_allocator_test
             s2n_random_test
-            s2n_release_non_empty_buffers_test
             s2n_self_talk_alerts_test
             s2n_self_talk_broken_pipe_test
             s2n_self_talk_client_hello_cb_test
-            s2n_self_talk_custom_io_test
             s2n_self_talk_nonblocking_test
             s2n_self_talk_session_id_test
         )

--- a/tests/unit/s2n_mem_allocator_test.c
+++ b/tests/unit/s2n_mem_allocator_test.c
@@ -14,15 +14,11 @@
  */
 
 #include <stdint.h>
-#include <sys/wait.h>
-#include <time.h>
-#include <unistd.h>
 
 #include "api/s2n.h"
 #include "s2n_test.h"
 #include "testlib/s2n_testlib.h"
 #include "tls/s2n_connection.h"
-#include "tls/s2n_handshake.h"
 
 #define SUPPORTED_CERTIFICATE_FORMATS (2)
 
@@ -75,81 +71,17 @@ static int custom_mem_free(void *ptr, uint32_t size)
     return 0;
 }
 
-void mock_client(struct s2n_test_io_pair *io_pair)
+static uint64_t s2n_test_mock_time = 0;
+
+static int s2n_test_mock_clock(void *in, uint64_t *out)
 {
-    char buffer[0xffff];
-    struct s2n_connection *conn = NULL;
-    struct s2n_config *config = NULL;
-    s2n_blocked_status blocked;
-
-    /* Give the server a chance to listen */
-    sleep(1);
-
-    conn = s2n_connection_new(S2N_CLIENT);
-    config = s2n_config_new();
-    s2n_config_disable_x509_verification(config);
-    EXPECT_OK(s2n_config_set_tls12_security_policy(config));
-    s2n_connection_set_config(conn, config);
-    conn->server_protocol_version = S2N_TLS12;
-    conn->client_protocol_version = S2N_TLS12;
-    conn->actual_protocol_version = S2N_TLS12;
-
-    s2n_connection_set_io_pair(conn, io_pair);
-
-    s2n_negotiate(conn, &blocked);
-
-    s2n_connection_free_handshake(conn);
-
-    uint16_t timeout = 1;
-    s2n_connection_set_dynamic_record_threshold(conn, 0x7fff, timeout);
-    int i = 0;
-    for (i = 1; i < 0xffff - 100; i += 100) {
-        for (int j = 0; j < i; j++) {
-            buffer[j] = 33;
-        }
-        s2n_send(conn, buffer, i, &blocked);
-    }
-
-    for (int j = 0; j < i; j++) {
-        buffer[j] = 33;
-    }
-
-    /* release the buffers here to validate we can continue IO after */
-    s2n_connection_release_buffers(conn);
-
-    /* Simulate timeout second conneciton inactivity and tolerate 50 ms error */
-    struct timespec sleep_time = { .tv_sec = timeout, .tv_nsec = 50000000 };
-    int r = 0;
-    do {
-        r = nanosleep(&sleep_time, &sleep_time);
-    } while (r != 0);
-    /* Active application bytes consumed is reset to 0 in before writing data. */
-    /* Its value should equal to bytes written after writing */
-    ssize_t bytes_written = s2n_send(conn, buffer, i, &blocked);
-    if ((uint64_t) bytes_written != conn->active_application_bytes_consumed) {
-        exit(0);
-    }
-
-    int shutdown_rc = -1;
-    while (shutdown_rc != 0) {
-        shutdown_rc = s2n_shutdown(conn, &blocked);
-    }
-
-    s2n_connection_free(conn);
-    s2n_config_free(config);
-
-    /* Give the server a chance to a void a sigpipe */
-    sleep(1);
-
-    s2n_io_pair_close_one_end(io_pair, S2N_CLIENT);
-
-    exit(0);
+    *out = s2n_test_mock_time;
+    return 0;
 }
 
 int main(int argc, char **argv)
 {
     s2n_blocked_status blocked;
-    int status = 0;
     char *cert_chain_pem = NULL;
     char *private_key_pem = NULL;
     char *dhparams_pem = NULL;
@@ -170,93 +102,134 @@ int main(int argc, char **argv)
     for (size_t is_dh_key_exchange = 0; is_dh_key_exchange <= 1; is_dh_key_exchange++) {
         struct s2n_cert_chain_and_key *chain_and_keys[SUPPORTED_CERTIFICATE_FORMATS];
 
-        /* Create a pipe */
-        struct s2n_test_io_pair io_pair;
-        EXPECT_SUCCESS(s2n_io_pair_init(&io_pair));
-
-        /* Create a child process */
-        pid_t pid = fork();
-        if (pid == 0) {
-            /* This is the client process, close the server end of the pipe */
-            EXPECT_SUCCESS(s2n_io_pair_close_one_end(&io_pair, S2N_SERVER));
-
-            /* Write the fragmented hello message */
-            mock_client(&io_pair);
-        }
-
         EXPECT_NOT_NULL(cert_chain_pem = malloc(S2N_MAX_TEST_PEM_SIZE));
         EXPECT_NOT_NULL(private_key_pem = malloc(S2N_MAX_TEST_PEM_SIZE));
         EXPECT_NOT_NULL(dhparams_pem = malloc(S2N_MAX_TEST_PEM_SIZE));
 
-        DEFER_CLEANUP(struct s2n_config *config = s2n_config_new(),
-                s2n_config_ptr_free);
-        EXPECT_OK(s2n_config_set_tls12_security_policy(config));
-        DEFER_CLEANUP(struct s2n_connection *conn = s2n_connection_new(S2N_SERVER),
-                s2n_connection_ptr_free);
-
-        /* This is the server process, close the client end of the pipe */
-        EXPECT_SUCCESS(s2n_io_pair_close_one_end(&io_pair, S2N_CLIENT));
-
-        conn->server_protocol_version = S2N_TLS12;
-        conn->client_protocol_version = S2N_TLS12;
-        conn->actual_protocol_version = S2N_TLS12;
+        /* Set up server config */
+        DEFER_CLEANUP(struct s2n_config *server_config = s2n_config_new(), s2n_config_ptr_free);
+        EXPECT_NOT_NULL(server_config);
+        EXPECT_OK(s2n_config_set_tls12_security_policy(server_config));
+        EXPECT_SUCCESS(s2n_config_set_monotonic_clock(server_config, s2n_test_mock_clock, NULL));
 
         for (size_t cert = 0; cert < SUPPORTED_CERTIFICATE_FORMATS; cert++) {
             EXPECT_SUCCESS(s2n_read_test_pem(certificate_paths[cert], cert_chain_pem, S2N_MAX_TEST_PEM_SIZE));
             EXPECT_SUCCESS(s2n_read_test_pem(private_key_paths[cert], private_key_pem, S2N_MAX_TEST_PEM_SIZE));
             EXPECT_NOT_NULL(chain_and_keys[cert] = s2n_cert_chain_and_key_new());
             EXPECT_SUCCESS(s2n_cert_chain_and_key_load_pem(chain_and_keys[cert], cert_chain_pem, private_key_pem));
-            EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(config, chain_and_keys[cert]));
+            EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(server_config, chain_and_keys[cert]));
         }
 
         if (is_dh_key_exchange) {
             EXPECT_SUCCESS(s2n_read_test_pem(S2N_DEFAULT_TEST_DHPARAMS, dhparams_pem, S2N_MAX_TEST_PEM_SIZE));
-            EXPECT_SUCCESS(s2n_config_add_dhparams(config, dhparams_pem));
+            EXPECT_SUCCESS(s2n_config_add_dhparams(server_config, dhparams_pem));
         }
 
-        EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
+        /* Set up client config */
+        DEFER_CLEANUP(struct s2n_config *client_config = s2n_config_new(), s2n_config_ptr_free);
+        EXPECT_NOT_NULL(client_config);
+        EXPECT_OK(s2n_config_set_tls12_security_policy(client_config));
+        EXPECT_SUCCESS(s2n_config_disable_x509_verification(client_config));
+        EXPECT_SUCCESS(s2n_config_set_monotonic_clock(client_config, s2n_test_mock_clock, NULL));
 
-        /* Set up the connection to read from the fd */
-        EXPECT_SUCCESS(s2n_connection_set_io_pair(conn, &io_pair));
+        /* Set up server connection */
+        DEFER_CLEANUP(struct s2n_connection *server_conn = s2n_connection_new(S2N_SERVER), s2n_connection_ptr_free);
+        EXPECT_NOT_NULL(server_conn);
+        EXPECT_SUCCESS(s2n_connection_set_config(server_conn, server_config));
 
-        /* Negotiate the handshake. */
-        EXPECT_SUCCESS(s2n_negotiate(conn, &blocked));
+        /* Set up client connection */
+        DEFER_CLEANUP(struct s2n_connection *client_conn = s2n_connection_new(S2N_CLIENT), s2n_connection_ptr_free);
+        EXPECT_NOT_NULL(client_conn);
+        EXPECT_SUCCESS(s2n_connection_set_config(client_conn, client_config));
 
-        char buffer[0xffff];
-        for (int i = 1; i < 0xffff; i += 100) {
-            char *ptr = buffer;
+        /* Use in-memory IO stuffer pair */
+        DEFER_CLEANUP(struct s2n_test_io_stuffer_pair io_pair = { 0 }, s2n_io_stuffer_pair_free);
+        EXPECT_OK(s2n_io_stuffer_pair_init(&io_pair));
+        EXPECT_OK(s2n_connections_set_io_stuffer_pair(client_conn, server_conn, &io_pair));
+
+        /* Negotiate the handshake */
+        EXPECT_SUCCESS(s2n_negotiate_test_server_and_client(server_conn, client_conn));
+        EXPECT_EQUAL(server_conn->actual_protocol_version, S2N_TLS12);
+        EXPECT_EQUAL(client_conn->actual_protocol_version, S2N_TLS12);
+
+        /* Release handshake buffers on client */
+        EXPECT_SUCCESS(s2n_connection_free_handshake(client_conn));
+
+        /* Client sends data in increasing chunks, server reads and verifies */
+        char send_buffer[0xffff];
+        char recv_buffer[0xffff];
+
+        uint16_t timeout = 1;
+        EXPECT_SUCCESS(s2n_connection_set_dynamic_record_threshold(client_conn, 0x7fff, timeout));
+
+        int i = 0;
+        for (i = 1; i < 0xffff - 100; i += 100) {
+            for (int j = 0; j < i; j++) {
+                send_buffer[j] = 33;
+            }
+            EXPECT_EQUAL(s2n_send(client_conn, send_buffer, i, &blocked), i);
+
+            /* Server reads the data */
+            char *ptr = recv_buffer;
             int size = i;
-
             do {
                 int bytes_read = 0;
-                EXPECT_SUCCESS(bytes_read = s2n_recv(conn, ptr, size, &blocked));
-
+                EXPECT_SUCCESS(bytes_read = s2n_recv(server_conn, ptr, size, &blocked));
                 size -= bytes_read;
                 ptr += bytes_read;
             } while (size);
 
             for (int j = 0; j < i; j++) {
-                EXPECT_EQUAL(buffer[j], 33);
+                EXPECT_EQUAL(recv_buffer[j], 33);
             }
 
             /* release the buffers here to validate we can continue IO after */
-            EXPECT_SUCCESS(s2n_connection_release_buffers(conn));
+            EXPECT_SUCCESS(s2n_connection_release_buffers(server_conn));
+
+            /* Reset the IO stuffer cursors after all data is consumed */
+            EXPECT_EQUAL(s2n_stuffer_data_available(&io_pair.server_in), 0);
+            EXPECT_SUCCESS(s2n_stuffer_rewrite(&io_pair.server_in));
         }
 
-        int shutdown_rc = -1;
-        do {
-            shutdown_rc = s2n_shutdown(conn, &blocked);
-            EXPECT_TRUE(shutdown_rc == 0 || (errno == EAGAIN && blocked));
-        } while (shutdown_rc != 0);
+        /* Fill the buffer for the final send */
+        for (int j = 0; j < i; j++) {
+            send_buffer[j] = 33;
+        }
 
+        /* Release buffers on client to validate we can continue IO after */
+        EXPECT_SUCCESS(s2n_connection_release_buffers(client_conn));
+
+        /* Simulate timeout for dynamic record threshold by advancing mock clock.
+         * After the timeout period, active_application_bytes_consumed is reset
+         * to 0 before writing data, so its value should equal bytes written
+         * after the send.
+         */
+        s2n_test_mock_time += (uint64_t) timeout * 1000000000 + 1;
+
+        ssize_t bytes_written = s2n_send(client_conn, send_buffer, i, &blocked);
+        EXPECT_TRUE(bytes_written > 0);
+        EXPECT_EQUAL((uint64_t) bytes_written, client_conn->active_application_bytes_consumed);
+
+        /* Server reads the final chunk */
+        {
+            char *ptr = recv_buffer;
+            int size = i;
+            do {
+                int bytes_read = 0;
+                EXPECT_SUCCESS(bytes_read = s2n_recv(server_conn, ptr, size, &blocked));
+                size -= bytes_read;
+                ptr += bytes_read;
+            } while (size);
+        }
+
+        /* Graceful shutdown */
+        EXPECT_SUCCESS(s2n_shutdown_test_server_and_client(server_conn, client_conn));
+
+        /* Clean up cert chains */
         for (size_t cert = 0; cert < SUPPORTED_CERTIFICATE_FORMATS; cert++) {
             EXPECT_SUCCESS(s2n_cert_chain_and_key_free(chain_and_keys[cert]));
         }
 
-        /* Clean up */
-        EXPECT_EQUAL(waitpid(-1, &status, 0), pid);
-        EXPECT_EQUAL(status, 0);
-        EXPECT_SUCCESS(s2n_io_pair_close_one_end(&io_pair, S2N_SERVER));
         free(cert_chain_pem);
         free(private_key_pem);
         free(dhparams_pem);

--- a/tests/unit/s2n_release_non_empty_buffers_test.c
+++ b/tests/unit/s2n_release_non_empty_buffers_test.c
@@ -13,57 +13,14 @@
  * permissions and limitations under the License.
  */
 
-#include <fcntl.h>
-#include <poll.h>
-#include <signal.h>
 #include <stdint.h>
-#include <sys/wait.h>
-#include <unistd.h>
 
 #include "api/s2n.h"
 #include "s2n_test.h"
 #include "testlib/s2n_testlib.h"
 #include "tls/s2n_connection.h"
-#include "tls/s2n_handshake.h"
-#include "utils/s2n_random.h"
-
-#define MAX_BUF_SIZE 10000
 
 static const uint8_t buf_to_send[1023] = { 27 };
-
-int mock_client(struct s2n_test_io_pair *io_pair)
-{
-    struct s2n_connection *conn = NULL;
-    struct s2n_config *client_config = NULL;
-    s2n_blocked_status blocked;
-    int result = 0;
-
-    conn = s2n_connection_new(S2N_CLIENT);
-    client_config = s2n_config_new();
-    s2n_config_disable_x509_verification(client_config);
-    EXPECT_OK(s2n_config_set_tls12_security_policy(client_config));
-    s2n_connection_set_config(conn, client_config);
-
-    /* Unlike the server, the client just passes ownership of I/O to s2n */
-    s2n_connection_set_io_pair(conn, io_pair);
-
-    result = s2n_negotiate(conn, &blocked);
-    if (result < 0) {
-        _exit(1);
-    }
-
-    if (s2n_send(conn, buf_to_send, sizeof(buf_to_send), &blocked) != sizeof(buf_to_send)) {
-        _exit(2);
-    }
-
-    s2n_shutdown(conn, &blocked);
-    s2n_connection_free(conn);
-    s2n_config_free(client_config);
-    EXPECT_SUCCESS(s2n_io_pair_close_one_end(io_pair, S2N_CLIENT));
-    s2n_cleanup();
-
-    exit(0);
-}
 
 /**
  * This test ensures that we don't allow releasing connection buffers if they contain part
@@ -72,134 +29,128 @@ int mock_client(struct s2n_test_io_pair *io_pair)
 int main(int argc, char **argv)
 {
     s2n_blocked_status blocked;
-    int status = 0;
-    pid_t pid = 0;
-    char *cert_chain_pem = NULL;
-    char *private_key_pem = NULL;
     uint8_t buf[sizeof(buf_to_send)];
-    uint32_t n = 0;
-    ssize_t ret = 0;
 
     BEGIN_TEST();
     EXPECT_SUCCESS(s2n_disable_tls13_in_test());
 
-    /* Create a pipe */
-    DEFER_CLEANUP(struct s2n_test_io_pair io_pair = { 0 }, s2n_io_pair_close);
-    EXPECT_SUCCESS(s2n_io_pair_init(&io_pair));
-
-    /* Create a child process */
-    pid = fork();
-    if (pid == 0) {
-        /* This is the client process, close the server end of the pipe */
-        EXPECT_SUCCESS(s2n_io_pair_close_one_end(&io_pair, S2N_SERVER));
-
-        /* Run the client */
-        mock_client(&io_pair);
-    }
-
-    DEFER_CLEANUP(struct s2n_config *config = s2n_config_new(),
+    DEFER_CLEANUP(struct s2n_config *server_config = s2n_config_new(),
             s2n_config_ptr_free);
-    EXPECT_OK(s2n_config_set_tls12_security_policy(config));
-    DEFER_CLEANUP(struct s2n_connection *conn = s2n_connection_new(S2N_SERVER),
-            s2n_connection_ptr_free);
+    EXPECT_OK(s2n_config_set_tls12_security_policy(server_config));
     DEFER_CLEANUP(struct s2n_cert_chain_and_key *chain_and_key = s2n_cert_chain_and_key_new(),
             s2n_cert_chain_and_key_ptr_free);
-    DEFER_CLEANUP(struct s2n_stuffer in, s2n_stuffer_free);
-    DEFER_CLEANUP(struct s2n_stuffer out, s2n_stuffer_free);
-
+    char *cert_chain_pem = NULL;
+    char *private_key_pem = NULL;
     EXPECT_NOT_NULL(cert_chain_pem = malloc(S2N_MAX_TEST_PEM_SIZE));
     EXPECT_NOT_NULL(private_key_pem = malloc(S2N_MAX_TEST_PEM_SIZE));
     EXPECT_SUCCESS(s2n_read_test_pem(S2N_DEFAULT_TEST_CERT_CHAIN, cert_chain_pem, S2N_MAX_TEST_PEM_SIZE));
     EXPECT_SUCCESS(s2n_read_test_pem(S2N_DEFAULT_TEST_PRIVATE_KEY, private_key_pem, S2N_MAX_TEST_PEM_SIZE));
     EXPECT_SUCCESS(s2n_cert_chain_and_key_load_pem(chain_and_key, cert_chain_pem, private_key_pem));
-    EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(config, chain_and_key));
+    EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(server_config, chain_and_key));
 
-    /* This is the server process, close the client end of the pipe */
-    EXPECT_SUCCESS(s2n_io_pair_close_one_end(&io_pair, S2N_CLIENT));
+    DEFER_CLEANUP(struct s2n_config *client_config = s2n_config_new(),
+            s2n_config_ptr_free);
+    EXPECT_OK(s2n_config_set_tls12_security_policy(client_config));
+    EXPECT_SUCCESS(s2n_config_disable_x509_verification(client_config));
 
-    EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
+    DEFER_CLEANUP(struct s2n_connection *server_conn = s2n_connection_new(S2N_SERVER),
+            s2n_connection_ptr_free);
+    EXPECT_SUCCESS(s2n_connection_set_config(server_conn, server_config));
 
-    /* Make pipes non-blocking */
-    EXPECT_SUCCESS(s2n_fd_set_non_blocking(io_pair.server));
-    EXPECT_SUCCESS(s2n_fd_set_non_blocking(io_pair.server));
+    DEFER_CLEANUP(struct s2n_connection *client_conn = s2n_connection_new(S2N_CLIENT),
+            s2n_connection_ptr_free);
+    EXPECT_SUCCESS(s2n_connection_set_config(client_conn, client_config));
 
-    /* Set up our I/O callbacks. Use stuffers for the "I/O context" */
-    EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&in, 0));
-    EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&out, 0));
-    EXPECT_SUCCESS(s2n_connection_set_io_stuffers(&in, &out, conn));
+    /* Use a stuffer pair for the client-server I/O, but set up the server
+     * with a separate intermediate stuffer so we can control how much data
+     * it sees at a time (to simulate partial record delivery).
+     */
+    DEFER_CLEANUP(struct s2n_test_io_stuffer_pair io_pair = { 0 }, s2n_io_stuffer_pair_free);
+    EXPECT_OK(s2n_io_stuffer_pair_init(&io_pair));
 
-    /* Negotiate the handshake. */
-    do {
-        ret = s2n_negotiate(conn, &blocked);
-        EXPECT_TRUE(ret == 0 || (blocked && (errno == EAGAIN || errno == EWOULDBLOCK)));
+    /* Client uses the stuffer pair normally */
+    EXPECT_SUCCESS(s2n_connection_set_io_stuffers(&io_pair.client_in, &io_pair.server_in, client_conn));
 
-        /* check to see if we need to copy more over from the pipes to the buffers
-         * to continue the handshake */
-        s2n_stuffer_recv_from_fd(&in, io_pair.server, MAX_BUF_SIZE, NULL);
-        s2n_stuffer_send_to_fd(&out, io_pair.server, s2n_stuffer_data_available(&out), NULL);
-    } while (blocked);
+    /* Server uses a separate "in" stuffer so we can manually control how
+     * much data is available for reading. Server still writes directly to
+     * client_in so the client can read responses.
+     */
+    DEFER_CLEANUP(struct s2n_stuffer server_in = { 0 }, s2n_stuffer_free);
+    EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&server_in, 0));
+    EXPECT_SUCCESS(s2n_connection_set_io_stuffers(&server_in, &io_pair.client_in, server_conn));
 
-    /* Receive only 100 bytes of the record and try to call s2n_recv */
-    while (n < 100) {
-        ret = s2n_stuffer_recv_from_fd(&in, io_pair.server, 100 - n, &n);
+    /* Negotiate the handshake by shuttling data between io_pair.server_in
+     * and server_in manually, similar to how the original test shuttled
+     * data between a pipe and a stuffer.
+     */
+    {
+        bool server_done = false, client_done = false;
 
-        if (errno == EAGAIN || errno == EWOULDBLOCK) {
-            continue;
-        } else {
-            POSIX_GUARD(ret);
-        }
+        do {
+            if (!client_done) {
+                int ret = s2n_negotiate(client_conn, &blocked);
+                EXPECT_TRUE(ret == 0 || s2n_error_get_type(s2n_errno) == S2N_ERR_T_BLOCKED);
+                if (ret == 0) {
+                    client_done = true;
+                }
+            }
+
+            /* Move data from io_pair.server_in to the server's actual input stuffer */
+            uint32_t available = s2n_stuffer_data_available(&io_pair.server_in);
+            if (available > 0) {
+                EXPECT_SUCCESS(s2n_stuffer_copy(&io_pair.server_in, &server_in, available));
+            }
+
+            if (!server_done) {
+                int ret = s2n_negotiate(server_conn, &blocked);
+                EXPECT_TRUE(ret == 0 || s2n_error_get_type(s2n_errno) == S2N_ERR_T_BLOCKED);
+                if (ret == 0) {
+                    server_done = true;
+                }
+            }
+        } while (!client_done || !server_done);
     }
 
+    /* Client sends data. The encrypted record lands in io_pair.server_in. */
+    EXPECT_EQUAL(s2n_send(client_conn, buf_to_send, sizeof(buf_to_send), &blocked), sizeof(buf_to_send));
+
+    /* Copy only 100 bytes of the record into the server's input stuffer,
+     * simulating partial record delivery.
+     */
+    uint32_t total_available = s2n_stuffer_data_available(&io_pair.server_in);
+    EXPECT_TRUE(total_available > 100);
+    EXPECT_SUCCESS(s2n_stuffer_copy(&io_pair.server_in, &server_in, 100));
+
     /* s2n_recv should fail as we received only part of the record */
-    EXPECT_FAILURE(s2n_recv(conn, buf, sizeof(buf), &blocked));
-    EXPECT_TRUE(blocked == S2N_BLOCKED_ON_READ);
+    EXPECT_FAILURE(s2n_recv(server_conn, buf, sizeof(buf), &blocked));
+    EXPECT_EQUAL(blocked, S2N_BLOCKED_ON_READ);
 
     /* Now try to release the buffers and expect failure as buffers are not empty */
-    EXPECT_FAILURE(s2n_connection_release_buffers(conn));
+    EXPECT_FAILURE(s2n_connection_release_buffers(server_conn));
 
-    /* Read the rest of the buffer and expect s2n_recv to succeed */
-    do {
-        ret = s2n_stuffer_recv_from_fd(&in, io_pair.server, MAX_BUF_SIZE, NULL);
+    /* Copy the rest of the record into the server's input stuffer */
+    uint32_t remaining = s2n_stuffer_data_available(&io_pair.server_in);
+    EXPECT_SUCCESS(s2n_stuffer_copy(&io_pair.server_in, &server_in, remaining));
 
-        if (errno == EAGAIN || errno == EWOULDBLOCK) {
-            continue;
-        } else {
-            POSIX_GUARD(ret);
-        }
-
-        ret = s2n_recv(conn, buf, sizeof(buf), &blocked);
-    } while (ret < 0 && s2n_error_get_type(s2n_errno) == S2N_ERR_T_BLOCKED
-            && blocked == S2N_BLOCKED_ON_READ);
-
-    /* Expect that we read the data client sent us */
-    EXPECT_TRUE(ret == sizeof(buf_to_send));
-    EXPECT_TRUE(memcmp(buf, buf_to_send, ret) == 0);
+    /* s2n_recv should now succeed with the full record available */
+    ssize_t ret = s2n_recv(server_conn, buf, sizeof(buf), &blocked);
+    EXPECT_EQUAL(ret, sizeof(buf_to_send));
+    EXPECT_BYTEARRAY_EQUAL(buf, buf_to_send, ret);
 
     /* Since full record was processed, we should be able to release buffers */
-    EXPECT_SUCCESS(s2n_connection_release_buffers(conn));
+    EXPECT_SUCCESS(s2n_connection_release_buffers(server_conn));
 
-    /* Shutdown after negotiating */
-    uint8_t server_shutdown = 0;
-    do {
-        ret = s2n_shutdown(conn, &blocked);
-        EXPECT_TRUE(ret == 0 || (blocked && (errno == EAGAIN || errno == EWOULDBLOCK)));
-        if (ret == 0) {
-            server_shutdown = 1;
-        }
+    /* Reconnect the server to read directly from the stuffer pair for shutdown,
+     * since the intermediate stuffer was only needed for partial-record testing.
+     */
+    EXPECT_SUCCESS(s2n_connection_set_io_stuffers(&io_pair.server_in, &io_pair.client_in, server_conn));
 
-        s2n_stuffer_recv_from_fd(&in, io_pair.server, MAX_BUF_SIZE, NULL);
-        s2n_stuffer_send_to_fd(&out, io_pair.server, s2n_stuffer_data_available(&out), NULL);
-    } while (!server_shutdown);
-
-    EXPECT_EQUAL(waitpid(-1, &status, 0), pid);
-    EXPECT_EQUAL(status, 0);
+    /* Shutdown */
+    EXPECT_SUCCESS(s2n_shutdown_test_server_and_client(server_conn, client_conn));
 
     /* Clean up */
     free(cert_chain_pem);
     free(private_key_pem);
-
-    EXPECT_SUCCESS(s2n_io_pair_close_one_end(&io_pair, S2N_SERVER));
-    s2n_cleanup();
 
     END_TEST();
 

--- a/tests/unit/s2n_self_talk_custom_io_test.c
+++ b/tests/unit/s2n_self_talk_custom_io_test.c
@@ -13,99 +13,31 @@
  * permissions and limitations under the License.
  */
 
-#include <fcntl.h>
-#include <poll.h>
-#include <signal.h>
 #include <stdint.h>
-#include <sys/wait.h>
-#include <unistd.h>
 
 #include "api/s2n.h"
 #include "s2n_test.h"
 #include "testlib/s2n_testlib.h"
 #include "tls/s2n_connection.h"
-#include "tls/s2n_handshake.h"
-#include "utils/s2n_random.h"
-
-#define MAX_BUF_SIZE 10000
-
-int mock_client(struct s2n_test_io_pair *io_pair)
-{
-    struct s2n_connection *conn = NULL;
-    struct s2n_config *client_config = NULL;
-    s2n_blocked_status blocked;
-    int result = 0;
-
-    conn = s2n_connection_new(S2N_CLIENT);
-    client_config = s2n_config_new();
-    s2n_config_disable_x509_verification(client_config);
-    EXPECT_OK(s2n_config_set_tls12_security_policy(client_config));
-    s2n_connection_set_config(conn, client_config);
-
-    /* Unlike the server, the client just passes ownership of I/O to s2n */
-    s2n_connection_set_io_pair(conn, io_pair);
-
-    result = s2n_negotiate(conn, &blocked);
-    if (result < 0) {
-        exit(1);
-    }
-
-    s2n_shutdown(conn, &blocked);
-    s2n_connection_free(conn);
-    s2n_config_free(client_config);
-    s2n_cleanup();
-    s2n_io_pair_close_one_end(io_pair, S2N_CLIENT);
-
-    exit(0);
-}
 
 int main(int argc, char **argv)
 {
     BEGIN_TEST();
+
     /**
-     * This test creates a server, client, and a pair of pipes. The client uses the
-     * pipes directly for I/O in s2n. The server copies data from the pipes into
-     * stuffers and manages s2n I/O with a set of I/O callbacks that read and write
-     * from the stuffers.
+     * This test verifies that a server using custom I/O callbacks
+     * can successfully negotiate and shutdown a TLS connection, and that
+     * s2n_connection_use_corked_io() correctly fails when custom I/O is set.
      */
     {
-        s2n_blocked_status blocked;
-        int status = 0;
-        pid_t pid = 0;
+        DEFER_CLEANUP(struct s2n_config *server_config = s2n_config_new(),
+                s2n_config_ptr_free);
+        EXPECT_OK(s2n_config_set_tls12_security_policy(server_config));
+        DEFER_CLEANUP(struct s2n_cert_chain_and_key *chain_and_key = s2n_cert_chain_and_key_new(),
+                s2n_cert_chain_and_key_ptr_free);
         char *cert_chain_pem = NULL;
         char *private_key_pem = NULL;
         char *dhparams_pem = NULL;
-
-        /* For convenience, this test will intentionally try to write to closed pipes during shutdown. Ignore the signal to
-        * avoid exiting the process on SIGPIPE.
-        */
-        signal(SIGPIPE, SIG_IGN);
-
-        /* Create a pipe */
-        struct s2n_test_io_pair io_pair;
-        EXPECT_SUCCESS(s2n_io_pair_init(&io_pair));
-
-        /* Create a child process */
-        pid = fork();
-        if (pid == 0) {
-            /* This is the client process, close the server end of the pipe */
-            EXPECT_SUCCESS(s2n_io_pair_close_one_end(&io_pair, S2N_SERVER));
-
-            /* Run the client */
-            mock_client(&io_pair);
-        }
-
-        DEFER_CLEANUP(struct s2n_config *config = s2n_config_new(),
-                s2n_config_ptr_free);
-        EXPECT_OK(s2n_config_set_tls12_security_policy(config));
-
-        DEFER_CLEANUP(struct s2n_connection *conn = s2n_connection_new(S2N_SERVER),
-                s2n_connection_ptr_free);
-        DEFER_CLEANUP(struct s2n_cert_chain_and_key *chain_and_key = s2n_cert_chain_and_key_new(),
-                s2n_cert_chain_and_key_ptr_free);
-        DEFER_CLEANUP(struct s2n_stuffer in, s2n_stuffer_free);
-        DEFER_CLEANUP(struct s2n_stuffer out, s2n_stuffer_free);
-
         EXPECT_NOT_NULL(cert_chain_pem = malloc(S2N_MAX_TEST_PEM_SIZE));
         EXPECT_NOT_NULL(private_key_pem = malloc(S2N_MAX_TEST_PEM_SIZE));
         EXPECT_NOT_NULL(dhparams_pem = malloc(S2N_MAX_TEST_PEM_SIZE));
@@ -113,64 +45,51 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_read_test_pem(S2N_DEFAULT_TEST_PRIVATE_KEY, private_key_pem, S2N_MAX_TEST_PEM_SIZE));
         EXPECT_SUCCESS(s2n_read_test_pem(S2N_DEFAULT_TEST_DHPARAMS, dhparams_pem, S2N_MAX_TEST_PEM_SIZE));
         EXPECT_SUCCESS(s2n_cert_chain_and_key_load_pem(chain_and_key, cert_chain_pem, private_key_pem));
-        EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(config, chain_and_key));
-        EXPECT_SUCCESS(s2n_config_add_dhparams(config, dhparams_pem));
+        EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(server_config, chain_and_key));
+        EXPECT_SUCCESS(s2n_config_add_dhparams(server_config, dhparams_pem));
 
-        /* This is the server process, close the client end of the pipe */
-        EXPECT_SUCCESS(s2n_io_pair_close_one_end(&io_pair, S2N_CLIENT));
+        DEFER_CLEANUP(struct s2n_config *client_config = s2n_config_new(),
+                s2n_config_ptr_free);
+        EXPECT_OK(s2n_config_set_tls12_security_policy(client_config));
+        EXPECT_SUCCESS(s2n_config_disable_x509_verification(client_config));
 
-        EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
+        DEFER_CLEANUP(struct s2n_connection *server_conn = s2n_connection_new(S2N_SERVER),
+                s2n_connection_ptr_free);
+        EXPECT_SUCCESS(s2n_connection_set_config(server_conn, server_config));
 
-        EXPECT_FAILURE(s2n_connection_use_corked_io(conn));
+        DEFER_CLEANUP(struct s2n_connection *client_conn = s2n_connection_new(S2N_CLIENT),
+                s2n_connection_ptr_free);
+        EXPECT_SUCCESS(s2n_connection_set_config(client_conn, client_config));
 
-        /* Set up our I/O callbacks. Use stuffers for the "I/O context" */
-        EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&in, 0));
-        EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&out, 0));
-        EXPECT_SUCCESS(s2n_connection_set_io_stuffers(&in, &out, conn));
+        /* Set up the server with custom I/O callbacks (stuffers) */
+        DEFER_CLEANUP(struct s2n_test_io_stuffer_pair io_pair = { 0 }, s2n_io_stuffer_pair_free);
+        EXPECT_OK(s2n_io_stuffer_pair_init(&io_pair));
+        EXPECT_OK(s2n_connections_set_io_stuffer_pair(client_conn, server_conn, &io_pair));
 
-        /* Make our pipes non-blocking */
-        EXPECT_SUCCESS(s2n_fd_set_non_blocking(io_pair.server));
-        EXPECT_SUCCESS(s2n_fd_set_non_blocking(io_pair.server));
+        /* Corked IO should fail because the server is using custom I/O callbacks.
+         * s2n_connection_use_corked_io is not available on Windows.
+         */
+#ifndef _WIN32
+        EXPECT_FAILURE(s2n_connection_use_corked_io(server_conn));
+#endif
 
-        /* Negotiate the handshake. */
-        do {
-            int ret = 0;
-
-            ret = s2n_negotiate(conn, &blocked);
-            EXPECT_TRUE(ret == 0 || (blocked && (errno == EAGAIN || errno == EWOULDBLOCK)));
-
-            /* check to see if we need to copy more over from the pipes to the buffers
-            * to continue the handshake
-            */
-            s2n_stuffer_recv_from_fd(&in, io_pair.server, MAX_BUF_SIZE, NULL);
-            s2n_stuffer_send_to_fd(&out, io_pair.server, s2n_stuffer_data_available(&out), NULL);
-        } while (blocked);
+        /* Negotiate the handshake */
+        EXPECT_SUCCESS(s2n_negotiate_test_server_and_client(server_conn, client_conn));
 
         /* Shutdown after negotiating */
-        uint8_t server_shutdown = 0;
-        do {
-            int ret = 0;
+        EXPECT_SUCCESS(s2n_shutdown_test_server_and_client(server_conn, client_conn));
 
-            ret = s2n_shutdown(conn, &blocked);
-            EXPECT_TRUE(ret == 0 || (blocked && (errno == EAGAIN || errno == EWOULDBLOCK)));
-            if (ret == 0) {
-                server_shutdown = 1;
-            }
-
-            s2n_stuffer_recv_from_fd(&in, io_pair.server, MAX_BUF_SIZE, NULL);
-            s2n_stuffer_send_to_fd(&out, io_pair.server, s2n_stuffer_data_available(&out), NULL);
-        } while (!server_shutdown);
-
-        /* Clean up */
-        EXPECT_EQUAL(waitpid(-1, &status, 0), pid);
-        EXPECT_EQUAL(status, 0);
-        EXPECT_SUCCESS(s2n_io_pair_close_one_end(&io_pair, S2N_SERVER));
         free(cert_chain_pem);
         free(private_key_pem);
         free(dhparams_pem);
     };
 
-    /* Clients and servers can utilize both custom IO and default IO for their sending and receiving */
+    /**
+     * Clients and servers can utilize both custom IO and default IO for their sending and receiving.
+     * This test uses s2n_connection_set_write_fd/s2n_connection_set_read_fd which are not
+     * available on Windows.
+     */
+#ifndef _WIN32
     {
         /* Setup connections */
         struct s2n_connection *client_conn = NULL;
@@ -215,6 +134,7 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_io_pair_close(&io_pair));
         EXPECT_SUCCESS(s2n_cert_chain_and_key_free(chain_and_key));
     };
+#endif
 
     END_TEST();
 }


### PR DESCRIPTION
# Goal

Refactor forked base self talk tests to use in memory io pair. Then those tests can be ran on Windows platforms.

## Why

Some existing test uses forks which is difficult to work on Windows. Hence, we are refactoring the test to use in memory IO pair to conduct handshakes.

## How

This PR is a continuation of the fork tests refactor. This PR refactors another three different: s2n_mem_allocator_test, s2n_release_non_empty_buffers_test, and s2n_self_talk_custom_io_test.

A general pattern is to use s2n_tls' io_pair to remove the needs for fork. Also, use new test functions like s2n_negotiate_test_server_and_client to remove old handshake and shutdown code.

s2n_self_talk_customer_io_test uses functions like s2n_connection_use_corked_io which will not be available on Windows. I have to add some ifdef gates for the test to make it works on Windows. With those gates, the test is nothing more than a tls12 self talk test on Windows, but it doesn't lose any coverage on Linux. I would still argue that this refactor is worth it, since it gets rid of fork and some repetitive code.

## Callouts

This is the third PR of such refactoring. I decided to do this refactor step by step. The reviewer and I need to verify that my refactor change doesn't remove test coverage compared to the original test. Hence, doing it in small PRs will help to make that verification.

We want to reduce the number of fork based tests in the exclude list. At this point, I have identified 7 tests that might have to remain excluded with no refactor. Here are the tests and the reason for them to be excluded:
| Test | Why |
|------|-----|
| `s2n_self_talk_nonblocking_test` | Tests write-blocking caused by full kernel pipe buffer. Uses SIGSTOP/SIGCONT to coordinate a slow consumer. Stuffers never block on write. |
| `s2n_self_talk_broken_pipe_test` | Tests EPIPE errno when writing to a half-closed socket. This is OS-level socket behavior with no in-memory equivalent. |
| `s2n_examples_test` | Forks both client and server processes for isolation, uses `fclose(stdout)` to suppress example output. Tests the example API functions as real programs would use them. |
| `s2n_key_update_threads_test` | Forks both client and server, uses pthreads for concurrent read/write on real sockets to stress-test key update race conditions. |
| `s2n_init_test` | Tests that s2n detects it's running in a forked child process. Fork detection IS the feature under test. |
| `s2n_random_test` | Tests PRNG re-seeding after fork to ensure parent/child get different random data. Fork safety IS the feature under test. |
| `s2n_io_test` | Tests `S2N_IO_RETRY_EINTR` with real signal delivery — parent sends SIGUSR1 to a child blocked on `read()`. Requires cross-process signaling. |

Two more tests s2n_self_talk_session_id_test and s2n_self_talk_alerts_test can probably be further refactored. That refactor and a comment for why those 7 tests might have to be gated eventually will be added in the next PR.

## Testing

Those three tests should run and pass in our Windows CI.
https://github.com/aws/s2n-tls/actions/runs/27787301286/job/82227149403?pr=5944
```
126/259 Test #119: s2n_mem_allocator_test ...........................   Passed    1.50 sec
...
155/259 Test #157: s2n_release_non_empty_buffers_test ...............   Passed    0.08 sec
...
181/259 Test #174: s2n_self_talk_custom_io_test .....................   Passed    1.14 sec
```

### Related

Relate to https://github.com/aws/s2n-tls/issues/4018, https://github.com/aws/s2n-tls/pull/5939, and https://github.com/aws/s2n-tls/pull/5940.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
