### PR TITLE
test(metrics): pseudo-stability of event APIs

### DIFF
--- a/bindings/rust/extended/s2n-tls/src/events.rs
+++ b/bindings/rust/extended/s2n-tls/src/events.rs
@@ -51,6 +51,21 @@ impl<'a> HandshakeEvent<'a> {
             HandshakeResult::Failure(HandshakeFailure(self.0))
         }
     }
+
+    #[deprecated(note = "will be removed with the release of subscriber 0.0.5")]
+    pub fn protocol_version(&self) -> crate::enums::Version {
+        HandshakeSuccess(self.0).protocol_version()
+    }
+
+    #[deprecated(note = "will be removed with the release of subscriber 0.0.5")]
+    pub fn cipher(&self) -> &'static str {
+        HandshakeSuccess(self.0).cipher()
+    }
+
+    #[deprecated(note = "will be removed with the release of subscriber 0.0.5")]
+    pub fn group(&self) -> Option<&'static str> {
+        HandshakeSuccess(self.0).group()
+    }
 }
 
 impl HandshakeSuccess<'_> {

--- a/bindings/rust/standard/integration/Cargo.toml
+++ b/bindings/rust/standard/integration/Cargo.toml
@@ -21,7 +21,7 @@ pq = [ "s2n-tls/pq" ]
 boringssl = ["tls-harness/boringssl"]
 
 [dependencies]
-s2n-tls = { path = "../../extended/s2n-tls", features = ["unstable-testing", "unstable-crl"]}
+s2n-tls = { path = "../../extended/s2n-tls", features = ["unstable-testing", "unstable-crl", "unstable-events"]}
 s2n-tls-hyper = { path = "../s2n-tls-hyper" }
 s2n-tls-tokio = { path = "../../extended/s2n-tls-tokio" }
 s2n-tls-sys = { path = "../../extended/s2n-tls-sys", features = ["unstable-async_offload", "unstable-renegotiate"] }
@@ -49,6 +49,9 @@ hyper-util = "0.1"
 
 dhat = "0.3.3"
 tabled = "0.21.0"
+# This should be the latest version of metrics subscriber available on crates.io
+old-metrics-subscriber = { package = "s2n-tls-metrics-subscriber", version = "0.0.3" }
+serde_json = "1"
 
 # NOTE: BoringSSL is disabled on macOS to avoid symbol collisions with
 # OpenSSL; see https://github.com/aws/s2n-tls/pull/5659 for details.

--- a/bindings/rust/standard/integration/tests/metrics_stability.rs
+++ b/bindings/rust/standard/integration/tests/metrics_stability.rs
@@ -1,0 +1,110 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! This test verifies that the most recent released version of
+//! s2n-tls-metrics-subscriber (currently 0.0.3) builds and runs against the
+//! mainline s2n-tls bindings.
+//!
+//! If this file fails to compile, it means mainline has broken backward
+//! compatibility with the released subscriber. The fix is to restore the
+//! missing APIs (with #[deprecated] annotations) in the bindings.
+
+use old_metrics_subscriber::{
+    AggregatedMetricsSubscriber, Attribution, MetricRecord, TelemetrySink,
+};
+use s2n_tls::{
+    security::DEFAULT_TLS13,
+    testing::{build_config, config_builder, TestPair},
+};
+use std::sync::{Arc, Mutex};
+
+#[derive(Debug, Clone)]
+struct VecSink {
+    records: Arc<Mutex<Vec<MetricRecord>>>,
+}
+
+impl VecSink {
+    fn new() -> Self {
+        Self {
+            records: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+}
+
+impl TelemetrySink for VecSink {
+    fn export_record(&self, record: &MetricRecord) {
+        self.records.lock().unwrap().push(record.clone());
+    }
+}
+
+/// The released s2n-tls-metrics-subscriber 0.0.3 must build and run
+/// a handshake against mainline s2n-tls bindings.
+#[test]
+fn old_event_subscriber_builds() {
+    let sink = VecSink::new();
+    let attribution = Attribution {
+        service: "test-service".to_owned(),
+        resource: "test-resource".to_owned(),
+        component: "test-component".to_owned(),
+    };
+    let subscriber = AggregatedMetricsSubscriber::new(sink.clone(), attribution);
+
+    let server_config = {
+        let mut cfg = config_builder(&DEFAULT_TLS13).unwrap();
+        cfg.set_event_subscriber(subscriber.clone()).unwrap();
+        cfg.build().unwrap()
+    };
+    let client_config = build_config(&DEFAULT_TLS13).unwrap();
+
+    let mut pair = TestPair::from_configs(&client_config, &server_config);
+    pair.handshake().unwrap();
+
+    subscriber.finish_record();
+
+    let records = sink.records.lock().unwrap();
+    assert_eq!(records.len(), 1);
+
+    // Serialize the record and assert on the content to verify the event APIs
+    // populated the subscriber correctly (not just that it compiled).
+    let json: serde_json::Value = serde_json::to_value(&records[0]).unwrap();
+    let handshake = &json["handshake"];
+
+    // One successful handshake was recorded
+    assert_eq!(handshake["handshake_count"], 1);
+    assert_eq!(handshake["synthetic_traffic_count"], 0);
+
+    // Negotiated parameters: exactly one of each was counted
+    assert_eq!(total_count(&handshake["negotiated_protocols"]), 1);
+    assert_eq!(total_count(&handshake["negotiated_ciphers"]), 1);
+    assert_eq!(total_count(&handshake["negotiated_groups"]), 1);
+    assert_eq!(total_count(&handshake["negotiated_signatures"]), 1);
+
+    // Supported parameters from the client hello should be non-empty
+    assert!(total_count(&handshake["supported_protocols"]) >= 1);
+    assert!(total_count(&handshake["supported_ciphers"]) >= 1);
+    assert!(total_count(&handshake["supported_groups"]) >= 1);
+    assert!(total_count(&handshake["supported_signatures"]) >= 1);
+
+    // Timers were populated (non-zero)
+    assert!(handshake["handshake_duration_us"].as_u64().unwrap() > 0);
+    assert!(handshake["handshake_compute_us"].as_u64().unwrap() > 0);
+
+    // Attribution was passed through
+    assert_eq!(json["attribution"]["service"], "test-service");
+    assert_eq!(json["attribution"]["resource"], "test-resource");
+    assert_eq!(json["attribution"]["component"], "test-component");
+}
+
+/// Sum all counts in a frozen counter. The serialized form is an array of
+/// `[key, count]` pairs (where key may itself be a nested array).
+fn total_count(counter: &serde_json::Value) -> u64 {
+    counter
+        .as_array()
+        .expect("counter should be an array")
+        .iter()
+        .filter_map(|entry| {
+            let arr = entry.as_array()?;
+            arr.last()?.as_u64()
+        })
+        .sum()
+}

--- a/bindings/rust/standard/s2n-tls-metrics-subscriber/Cargo.toml
+++ b/bindings/rust/standard/s2n-tls-metrics-subscriber/Cargo.toml
@@ -18,9 +18,9 @@ metrique-writer = "0.1.19"
 arc-swap = "1.8.0"
 # minimum versions set for workspace-wide cargo minimal-versions compatibility
 serde = { version = "1.0.225", features = ["derive"] }
-# we at least need 0.3.36, because that is when the CNSA security policies were introduced
-s2n-tls = { version = "0.3.36", path = "../../extended/s2n-tls", features = ["unstable-events", "unstable-testing"] }
-s2n-tls-sys = { version = "0.3.36", path = "../../extended/s2n-tls-sys"}
+# we at least need 0.3.38, because of the Connection::mode() API
+s2n-tls = { version = "0.3.38", path = "../../extended/s2n-tls", features = ["unstable-events", "unstable-testing"] }
+s2n-tls-sys = { version = "0.3.38", path = "../../extended/s2n-tls-sys"}
 const-oid = "0.10.2"
 
 [features]


### PR DESCRIPTION
# Goal
Ensure that our event apis are "pseudo-stable". Specifically, that the most recently released version of the metrics subscriber can build with the mainline bindings.

## Why
Otherwise it's very difficult for consumers to upgrade without breaking, especially if some other s2n-tls consumer in their build dependencies has pinned their binding version because also rely on unstable APIs

## How
We just pull the old crate into the workspace and confirm that the metrics is emitted as expected.

## Testing
The test failed as expected, so we had to add back the old APIs.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
