### PR TITLE
ci: enable ASAN for Windows tests

### DIFF
--- a/.github/workflows/ci_windows.yml
+++ b/.github/workflows/ci_windows.yml
@@ -30,6 +30,7 @@ jobs:
           - sys: clang64
             pkg-prefix: mingw-w64-clang-x86_64
             env-path: /clang64
+            asan: ON
     steps:
       - uses: actions/checkout@v6
 
@@ -71,7 +72,8 @@ jobs:
             -DCMAKE_BUILD_TYPE=RelWithDebInfo \
             -DCMAKE_PREFIX_PATH=${{matrix.env-path}}/local \
             -DS2N_ENFORCE_PROPER_LIBCRYPTO_FEATURE_PROBE=ON \
-            -DBUILD_TESTING=ON
+            -DBUILD_TESTING=ON \
+            -DASAN=${{matrix.asan || 'OFF'}}
           cmake --build ./build -j $(nproc)
 
       - name: Run unit tests


### PR DESCRIPTION
# Goal

Add ASAN checks for Windows tests.

## Why

We need ASAN checks for Windows CI to check for errors that ASAN typically check.

## How

Add -DASAN=ON option to the build script.

## Callouts

Seems like ASAN only works with clang64: https://github.com/msys2/MINGW-packages/issues/11899. It's missing on ucrt64, and mingw64.

https://www.msys2.org/docs/environments/#gcc-vs-llvmclang
```
LLVM/Clang based environments:

Only uses LLVM tools, LLD as a linker, LIBC++ as a C++ standard library
Clang provides ASAN support
LLD is faster than LD, but does not support all the features LD supports
Some tools lack feature parity with equivalent GNU tools
Supports ARM64/AArch64 architecture on Microsoft Windows 10
```

## Testing

Windows CI should pass.

### Related

Related to https://github.com/aws/s2n-tls/issues/4018.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
