### PR TITLE
fix: add extern "C" guards to unstable API headers

### DIFF
--- a/api/unstable/allow_ip_in_cn.h
+++ b/api/unstable/allow_ip_in_cn.h
@@ -17,6 +17,10 @@
 
 #include <s2n.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @file allow_ip_in_cn.h
  *
@@ -42,3 +46,7 @@
  * @returns S2N_SUCCESS on success, S2N_FAILURE on failure.
  */
 S2N_API extern int s2n_config_allow_ip_in_cn(struct s2n_config *config);
+
+#ifdef __cplusplus
+}
+#endif

--- a/api/unstable/async_offload.h
+++ b/api/unstable/async_offload.h
@@ -17,6 +17,10 @@
 
 #include <s2n.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @file async_offload.h
  * 
@@ -87,3 +91,7 @@ S2N_API extern int s2n_config_set_async_offload_callback(struct s2n_config *conf
  * @param op An opaque object representing the async operation
  */
 S2N_API extern int s2n_async_offload_op_perform(struct s2n_async_offload_op *op);
+
+#ifdef __cplusplus
+}
+#endif

--- a/api/unstable/cert_authorities.h
+++ b/api/unstable/cert_authorities.h
@@ -35,6 +35,10 @@
     #include <sys/uio.h>
 #endif
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 struct s2n_certificate_request;
 struct s2n_certificate_authority_list;
 
@@ -117,3 +121,7 @@ typedef int (*s2n_cert_request_callback)(struct s2n_connection *conn, void *ctx,
  * @returns S2N_SUCCESS on success. S2N_FAILURE on failure.
  */
 S2N_API int s2n_config_set_cert_request_callback(struct s2n_config *config, s2n_cert_request_callback cert_req_callback, void *ctx);
+
+#ifdef __cplusplus
+}
+#endif

--- a/api/unstable/cleanup.h
+++ b/api/unstable/cleanup.h
@@ -17,6 +17,10 @@
 
 #include <s2n.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @deprecated Thread-local random state has been removed. This function is a
  * no-op kept for backwards compatibility.
@@ -24,3 +28,7 @@
  * @returns S2N_SUCCESS on success. S2N_FAILURE on failure
  */
 S2N_API extern int s2n_cleanup_thread(void);
+
+#ifdef __cplusplus
+}
+#endif

--- a/api/unstable/crl.h
+++ b/api/unstable/crl.h
@@ -17,6 +17,10 @@
 
 #include <s2n.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @file crl.h
  *
@@ -237,3 +241,7 @@ S2N_API int s2n_cert_validation_accept(struct s2n_cert_validation_info *info);
  * @returns S2N_SUCCESS on success, S2N_FAILURE on failure.
  */
 S2N_API int s2n_cert_validation_reject(struct s2n_cert_validation_info *info);
+
+#ifdef __cplusplus
+}
+#endif

--- a/api/unstable/custom_x509_extensions.h
+++ b/api/unstable/custom_x509_extensions.h
@@ -17,6 +17,10 @@
 
 #include <s2n.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @file custom_x509_extensions.h
  *
@@ -51,3 +55,7 @@
  * @returns S2N_SUCCESS on success. S2N_FAILURE on failure
  */
 S2N_API extern int s2n_config_add_custom_x509_extension(struct s2n_config *config, uint8_t *extension_oid, uint32_t extension_oid_len);
+
+#ifdef __cplusplus
+}
+#endif

--- a/api/unstable/events.h
+++ b/api/unstable/events.h
@@ -18,6 +18,10 @@
 #include <s2n.h>
 #include <stdint.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* This is a special value assigned to handshake_start_epoch_ns to indicate that
  * it has already been sent to the application and should not be sent again.
  */
@@ -68,3 +72,7 @@ S2N_API extern int s2n_config_set_subscriber(struct s2n_config *config, void *su
  * error_code field will be set with the relevant error information.
  */
 S2N_API extern int s2n_config_set_handshake_event(struct s2n_config *config, s2n_event_on_handshake_cb callback);
+
+#ifdef __cplusplus
+}
+#endif

--- a/api/unstable/fingerprint.h
+++ b/api/unstable/fingerprint.h
@@ -17,6 +17,10 @@
 
 #include <s2n.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @file fingerprint.h
  *
@@ -202,3 +206,7 @@ S2N_API int s2n_client_hello_get_fingerprint_hash(struct s2n_client_hello *ch,
 S2N_API int s2n_client_hello_get_fingerprint_string(struct s2n_client_hello *ch,
         s2n_fingerprint_type type, uint32_t max_size,
         uint8_t *output, uint32_t *output_size);
+
+#ifdef __cplusplus
+}
+#endif

--- a/api/unstable/ktls.h
+++ b/api/unstable/ktls.h
@@ -20,9 +20,9 @@
 
     #include <s2n.h>
 
-#ifdef __cplusplus
+    #ifdef __cplusplus
 extern "C" {
-#endif
+    #endif
 
 /**
  * @file ktls.h
@@ -165,8 +165,8 @@ S2N_API int s2n_connection_get_key_update_counts(struct s2n_connection *conn,
 S2N_API int s2n_sendfile(struct s2n_connection *conn, int fd, off_t offset, size_t count,
         size_t *bytes_written, s2n_blocked_status *blocked);
 
-#ifdef __cplusplus
+    #ifdef __cplusplus
 }
-#endif
+    #endif
 
 #endif

--- a/api/unstable/ktls.h
+++ b/api/unstable/ktls.h
@@ -20,6 +20,10 @@
 
     #include <s2n.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @file ktls.h
  *
@@ -160,5 +164,9 @@ S2N_API int s2n_connection_get_key_update_counts(struct s2n_connection *conn,
  */
 S2N_API int s2n_sendfile(struct s2n_connection *conn, int fd, off_t offset, size_t count,
         size_t *bytes_written, s2n_blocked_status *blocked);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/api/unstable/npn.h
+++ b/api/unstable/npn.h
@@ -17,6 +17,10 @@
 
 #include <s2n.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @file npn.h
  *
@@ -48,3 +52,7 @@
  * @returns S2N_SUCCESS on success, S2N_FAILURE on error.
  */
 S2N_API int s2n_config_set_npn(struct s2n_config *config, bool enable);
+
+#ifdef __cplusplus
+}
+#endif

--- a/api/unstable/renegotiate.h
+++ b/api/unstable/renegotiate.h
@@ -17,6 +17,10 @@
 
 #include <s2n.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @file renegotiate.h
  *
@@ -171,3 +175,7 @@ S2N_API int s2n_renegotiate_wipe(struct s2n_connection *conn);
  */
 S2N_API int s2n_renegotiate(struct s2n_connection *conn, uint8_t *app_data_buf, ssize_t app_data_buf_size,
         ssize_t *app_data_size, s2n_blocked_status *blocked);
+
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
# Goal
Add extern "C" guards to unstable API headers for C++ compatibility

## Why
The unstable headers are missing extern "C" guards, causing C++ compilers to apply name mangling. This prevents C++ consumers from linking against the headers without wrapping the includes in `extern "C" { ... }` manually.

## How
Added `#ifdef __cplusplus extern "C"` guards around the function declaration, matching the pattern used in `s2n.h`.

## Testing
Existing CI should pass. This is a declaration-only change with no behavioral impact on C consumers.

### Related
#5897 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
