### PR TITLE
feat: enable rust bindings build and tests on Windows

### DIFF
--- a/.github/workflows/ci_windows.yml
+++ b/.github/workflows/ci_windows.yml
@@ -127,8 +127,9 @@ jobs:
           rustup default stable-${{matrix.rust-target}}
           rustup component add rustfmt
 
-      - name: Generate Rust bindings
+      - name: Generate and build Rust bindings
         shell: msys2 {0}
         run: |
           set -eu
           ./bindings/rust/extended/generate.sh --skip-tests
+          cargo build --manifest-path bindings/rust/extended/s2n-tls/Cargo.toml

--- a/.github/workflows/ci_windows.yml
+++ b/.github/workflows/ci_windows.yml
@@ -81,3 +81,54 @@ jobs:
         run: |
           set -eu
           ctest --test-dir build --output-on-failure -j $(nproc)
+
+  rust-bindings:
+    runs-on: windows-latest
+    name: Rust Bindings (${{matrix.sys}})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - sys: ucrt64
+            pkg-prefix: mingw-w64-ucrt-x86_64
+            env-path: /ucrt64
+            rust-target: x86_64-pc-windows-gnu
+          - sys: mingw64
+            pkg-prefix: mingw-w64-x86_64
+            env-path: /mingw64
+            rust-target: x86_64-pc-windows-gnu
+          - sys: clang64
+            pkg-prefix: mingw-w64-clang-x86_64
+            env-path: /clang64
+            rust-target: x86_64-pc-windows-gnullvm
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup MSYS2
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: ${{matrix.sys}}
+          update: true
+          install: >-
+            ${{matrix.pkg-prefix}}-clang
+            ${{matrix.pkg-prefix}}-clang-libs
+            ${{matrix.pkg-prefix}}-cmake
+            ${{matrix.pkg-prefix}}-ninja
+            ${{matrix.pkg-prefix}}-go
+            ${{matrix.pkg-prefix}}-nasm
+            ${{matrix.pkg-prefix}}-rustup
+            make
+            git
+            diffutils
+
+      - name: Install Rust toolchain
+        shell: msys2 {0}
+        run: |
+          rustup default stable-${{matrix.rust-target}}
+          rustup component add rustfmt
+
+      - name: Generate Rust bindings
+        shell: msys2 {0}
+        run: |
+          set -eu
+          ./bindings/rust/extended/generate.sh --skip-tests

--- a/bindings/rust/extended/generate/src/main.rs
+++ b/bindings/rust/extended/generate/src/main.rs
@@ -18,6 +18,28 @@ use bindgen::callbacks::ItemKind;
 /// modules.
 const FEATURE_TOKEN_PLACEHOLDER: &str = "<TOKEN_REPLACED_WITH_UNSTABLE_FEATURES>";
 
+/// Functions that are not available on Windows because their implementations
+/// are gated behind `#ifndef _WIN32` in the C source code.
+const WINDOWS_UNAVAILABLE_FUNCTIONS: &[&str] = &[
+    "s2n_connection_set_fd",
+    "s2n_connection_set_read_fd",
+    "s2n_connection_set_write_fd",
+    "s2n_connection_get_read_fd",
+    "s2n_connection_get_write_fd",
+    "s2n_connection_use_corked_io",
+    "s2n_sendv",
+    "s2n_sendv_with_offset",
+    "s2n_sendfile",
+    "s2n_config_ktls_enable_unsafe_tls13",
+];
+
+/// Feature modules that are entirely excluded on Windows because their headers
+/// or implementations are not available on the platform.
+const WINDOWS_EXCLUDED_FEATURES: &[&str] = &[
+    "internal",
+    "unstable-ktls",
+];
+
 /// This binary is only expected to run in the context of the generate.sh script
 /// which handles certain behaviors such as copying header files to
 /// s2n-tls-sys/lib and other sundry actions.
@@ -39,6 +61,11 @@ fn main() {
     .unwrap()
     .write_to_file(out_dir.join("src/api.rs"))
     .unwrap();
+
+    // Post-process api.rs to add #[cfg(not(windows))] to functions that are
+    // not available on Windows (their C implementations are gated behind
+    // #ifndef _WIN32).
+    postprocess_api_for_windows(&out_dir.join("src/api.rs"));
 
     write_feature_bindings(
         out_dir.join("lib/tls/s2n_internal.h"),
@@ -87,6 +114,13 @@ fn main() {
         );
     }
 
+    // Post-process all feature module files for Windows-unavailable functions
+    postprocess_api_for_windows(&out_dir.join("src/features/internal.rs"));
+    postprocess_api_for_windows(&out_dir.join("src/features/quic.rs"));
+    for (header_name, _) in unstable_headers.iter() {
+        postprocess_api_for_windows(&out_dir.join(format!("src/features/{}.rs", header_name)));
+    }
+
     // generate a cargo.toml that defines the correct features
     let mut features_definition_token = unstable_headers
         .iter()
@@ -102,7 +136,12 @@ fn main() {
     let features_module_token = unstable_headers
         .iter()
         .map(|(header_name, _header)| {
-            format!("conditional_module!({header_name}, \"unstable-{header_name}\");")
+            // ktls.h is entirely wrapped in #ifndef _WIN32, so exclude on Windows
+            if header_name == "ktls" {
+                format!("conditional_module_not_windows!({header_name}, \"unstable-{header_name}\");")
+            } else {
+                format!("conditional_module!({header_name}, \"unstable-{header_name}\");")
+            }
         })
         .collect::<Vec<String>>()
         .join("\n");
@@ -124,11 +163,42 @@ const COPYRIGHT: &str = r#"
 const PRELUDE: &str = r#"
 #![allow(unused_imports, non_camel_case_types)]
 
-use libc::{iovec, FILE, off_t};
+#[cfg(not(windows))]
+use libc::{iovec, FILE};
+
+#[cfg(not(windows))]
+pub use libc::off_t;
+
+#[cfg(windows)]
+use libc::FILE;
+
+// iovec is not available in the libc crate on Windows.
+// Define it to match the struct in s2n.h for Windows.
+#[cfg(windows)]
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct iovec {
+    pub iov_base: *mut ::libc::c_void,
+    pub iov_len: usize,
+}
+
+// off_t is not available in the libc crate on Windows.
+#[cfg(windows)]
+pub type off_t = i64;
+
 // specify that aws-lc-rs is used, so that the rust compiler will link in the appropriate
 // libcrypto artifact.
 #[cfg(not(s2n_tls_external_build))]
 extern crate aws_lc_rs as _;
+"#;
+
+/// A simpler prelude for feature modules that import types from the main api
+/// module via `use crate::api::*` instead of defining them locally.
+/// off_t is re-exported by crate::api via `pub use libc::off_t` (on non-windows)
+/// or `pub type off_t = i64` (on windows), so feature modules get it via
+/// `use crate::api::*`.
+const FEATURE_PRELUDE: &str = r#"
+#![allow(unused_imports, non_camel_case_types)]
 "#;
 
 fn base_builder() -> bindgen::Builder {
@@ -145,6 +215,21 @@ fn base_builder() -> bindgen::Builder {
         .blocklist_item("s2n_errno")
         .raw_line(COPYRIGHT)
         .raw_line(PRELUDE)
+        .ctypes_prefix("::libc")
+}
+
+fn feature_builder() -> bindgen::Builder {
+    bindgen::Builder::default()
+        .use_core()
+        .layout_tests(true)
+        .detect_include_paths(true)
+        .size_t_is_usize(true)
+        .enable_function_attribute_detection()
+        .default_enum_style(bindgen::EnumVariation::ModuleConsts)
+        .rust_target(bindgen::RustTarget::Stable_1_47)
+        .blocklist_item("s2n_errno")
+        .raw_line(COPYRIGHT)
+        .raw_line(FEATURE_PRELUDE)
         .ctypes_prefix("::libc")
 }
 
@@ -171,7 +256,19 @@ fn write_feature_bindings(
 ) {
     let header_path_str = format!("{}", header_path.as_ref().display());
     let lib_path = s2n_tls_sys_dir.join("lib");
-    base_builder()
+    // Use just the filename for allowlist_file matching. On Windows, the full
+    // path reported by clang may differ in format from what Rust provides
+    // (e.g. MSYS2 paths vs Windows paths), causing regex mismatches.
+    let file_name = header_path
+        .as_ref()
+        .file_name()
+        .unwrap()
+        .to_str()
+        .unwrap();
+    // Escape regex special chars in the filename (mainly the dot in .h)
+    let escaped_name = file_name.replace('.', "\\.");
+    let allowlist_pattern = format!(".*{}", escaped_name);
+    feature_builder()
         .header(&header_path_str)
         .parse_callbacks(Box::new(
             functions.with_feature(Some(feature_flag.to_owned())),
@@ -180,7 +277,7 @@ fn write_feature_bindings(
         .clang_arg(format!("-I{}/api", lib_path.display()))
         .clang_arg(format!("-I{}", lib_path.display()))
         .allowlist_recursively(false)
-        .allowlist_file(&header_path_str)
+        .allowlist_file(&allowlist_pattern)
         // s2n_internal.h defines opaque handles to these structs, but we want
         // them to be imported from the main api module
         .blocklist_type("s2n_connection")
@@ -190,6 +287,44 @@ fn write_feature_bindings(
         .unwrap()
         .write_to_file(output_path)
         .unwrap();
+}
+
+/// Post-processes a generated bindings file to add `#[cfg(not(windows))]`
+/// to `extern "C"` blocks containing Windows-unavailable functions.
+fn postprocess_api_for_windows(path: &Path) {
+    let content = fs::read_to_string(path).expect("failed to read generated file");
+    let lines: Vec<&str> = content.lines().collect();
+    let mut output = String::with_capacity(content.len());
+
+    for (i, line) in lines.iter().enumerate() {
+        // Before each `extern "C" {`, check if it contains a Windows-unavailable fn
+        if line.trim() == "extern \"C\" {" && block_needs_windows_cfg(&lines[i + 1..]) {
+            output.push_str("#[cfg(not(windows))]\n");
+        }
+        output.push_str(line);
+        output.push('\n');
+    }
+
+    fs::write(path, output).expect("failed to write post-processed file");
+}
+
+/// Looks inside an extern block (starting after the opening brace) for a
+/// `pub fn` whose name is in WINDOWS_UNAVAILABLE_FUNCTIONS.
+fn block_needs_windows_cfg(lines: &[&str]) -> bool {
+    for line in lines {
+        let trimmed = line.trim();
+        if trimmed.starts_with("pub fn ") {
+            let name = trimmed["pub fn ".len()..]
+                .split(|c: char| c == '(' || c == ' ')
+                .next()
+                .unwrap_or("");
+            return WINDOWS_UNAVAILABLE_FUNCTIONS.contains(&name);
+        }
+        if trimmed == "}" {
+            return false;
+        }
+    }
+    false
 }
 
 fn gen_files(input: &Path, out: &Path) -> io::Result<()> {
@@ -249,8 +384,18 @@ impl FunctionCallbacks {
 
             // if the function is behind a feature, gate it with `cfg`
             if let Some(feature) = feature {
-                writeln!(o, "#[cfg(feature = {:?})]", feature)?;
+                // Features not available on Windows need a combined cfg gate
+                if WINDOWS_EXCLUDED_FEATURES.contains(&feature.as_str()) {
+                    writeln!(o, "#[cfg(all(feature = {:?}, not(windows)))]", feature)?;
+                } else {
+                    writeln!(o, "#[cfg(feature = {:?})]", feature)?;
+                }
             };
+
+            // if the function is not available on Windows, gate the test
+            if WINDOWS_UNAVAILABLE_FUNCTIONS.contains(&function.as_str()) {
+                writeln!(o, "#[cfg(not(windows))]")?;
+            }
 
             writeln!(o, "fn {} () {{", function)?;
             writeln!(o, "    let ptr = crate::{} as *const ();", function)?;

--- a/bindings/rust/extended/generate/src/main.rs
+++ b/bindings/rust/extended/generate/src/main.rs
@@ -36,7 +36,6 @@ const WINDOWS_UNAVAILABLE_FUNCTIONS: &[&str] = &[
 /// Feature modules that are entirely excluded on Windows because their headers
 /// or implementations are not available on the platform.
 const WINDOWS_EXCLUDED_FEATURES: &[&str] = &[
-    "internal",
     "unstable-ktls",
 ];
 

--- a/bindings/rust/extended/generate/src/main.rs
+++ b/bindings/rust/extended/generate/src/main.rs
@@ -172,8 +172,7 @@ pub use libc::off_t;
 #[cfg(windows)]
 use libc::FILE;
 
-// iovec is not available in the libc crate on Windows.
-// Define it to match the struct in s2n.h for Windows.
+// This iovec matches the `struct iovec` that s2n.h defines for Windows.
 #[cfg(windows)]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]

--- a/bindings/rust/extended/generate/src/main.rs
+++ b/bindings/rust/extended/generate/src/main.rs
@@ -209,7 +209,7 @@ fn base_builder() -> bindgen::Builder {
         .size_t_is_usize(true)
         .enable_function_attribute_detection()
         .default_enum_style(bindgen::EnumVariation::ModuleConsts)
-        .rust_target(bindgen::RustTarget::Stable_1_47)
+        .rust_target(bindgen::RustTarget::Stable_1_71)
         // rust can't access thread-local variables
         // https://github.com/rust-lang/rust/issues/29594
         .blocklist_item("s2n_errno")
@@ -226,8 +226,7 @@ fn feature_builder() -> bindgen::Builder {
         .size_t_is_usize(true)
         .enable_function_attribute_detection()
         .default_enum_style(bindgen::EnumVariation::ModuleConsts)
-        .rust_target(bindgen::RustTarget::Stable_1_47)
-        .blocklist_item("s2n_errno")
+        .rust_target(bindgen::RustTarget::Stable_1_71)
         .raw_line(COPYRIGHT)
         .raw_line(FEATURE_PRELUDE)
         .ctypes_prefix("::libc")
@@ -313,8 +312,8 @@ fn postprocess_api_for_windows(path: &Path) {
 fn block_needs_windows_cfg(lines: &[&str]) -> bool {
     for line in lines {
         let trimmed = line.trim();
-        if trimmed.starts_with("pub fn ") {
-            let name = trimmed["pub fn ".len()..]
+        if let Some(after_pub_fn) = trimmed.strip_prefix("pub fn ") {
+            let name = after_pub_fn
                 .split(|c: char| c == '(' || c == ' ')
                 .next()
                 .unwrap_or("");

--- a/bindings/rust/extended/s2n-tls-sys/templates/features.template
+++ b/bindings/rust/extended/s2n-tls-sys/templates/features.template
@@ -35,8 +35,6 @@ macro_rules! conditional_module_not_windows {
 }
 
 conditional_module!(quic, "quic");
-// s2n_internal.h uses S2N_PRIVATE_API which doesn't export symbols on Windows,
-// causing bindgen to produce an empty module. Exclude on Windows.
-conditional_module_not_windows!(internal, "internal");
+conditional_module!(internal, "internal");
 <TOKEN_REPLACED_WITH_UNSTABLE_FEATURES>
 // conditional_module!(foo, "unstable-foo");

--- a/bindings/rust/extended/s2n-tls-sys/templates/features.template
+++ b/bindings/rust/extended/s2n-tls-sys/templates/features.template
@@ -19,7 +19,24 @@ macro_rules! conditional_module {
     };
 }
 
+/// Same as conditional_module but also excludes the module on Windows.
+/// Used for modules whose headers are not available on Windows (e.g. gated
+/// behind #ifndef _WIN32).
+#[rustfmt::skip]
+macro_rules! conditional_module_not_windows {
+    ($mod_name:ident, $feature_name:literal) => {
+        #[cfg(all(feature = $feature_name, not(windows)))]
+        #[rustfmt::skip]
+        mod $mod_name;
+
+        #[cfg(all(feature = $feature_name, not(windows)))]
+        pub use $mod_name::*;
+    };
+}
+
 conditional_module!(quic, "quic");
-conditional_module!(internal, "internal");
+// s2n_internal.h uses S2N_PRIVATE_API which doesn't export symbols on Windows,
+// causing bindgen to produce an empty module. Exclude on Windows.
+conditional_module_not_windows!(internal, "internal");
 <TOKEN_REPLACED_WITH_UNSTABLE_FEATURES>
 // conditional_module!(foo, "unstable-foo");

--- a/bindings/rust/extended/s2n-tls/src/connection.rs
+++ b/bindings/rust/extended/s2n-tls/src/connection.rs
@@ -358,7 +358,7 @@ impl Connection {
     /// This only applies to TLS1.3. Earlier versions do not support key updates.
     ///
     /// Corresponds to [`s2n_connection_get_key_update_counts`].
-    #[cfg(feature = "unstable-ktls")]
+    #[cfg(all(feature = "unstable-ktls", not(windows)))]
     pub fn key_update_counts(&self) -> Result<KeyUpdateCount, Error> {
         let mut send_key_updates = 0;
         let mut recv_key_updates = 0;
@@ -529,6 +529,10 @@ impl Connection {
     }
 
     /// Corresponds to [`s2n_connection_use_corked_io`].
+    ///
+    /// Not available on Windows: the underlying C implementation is gated
+    /// behind `#ifndef _WIN32`.
+    #[cfg(not(windows))]
     pub fn use_corked_io(&mut self) -> Result<&mut Self, Error> {
         unsafe { s2n_connection_use_corked_io(self.connection.as_ptr()).into_result() }?;
         Ok(self)

--- a/bindings/rust/extended/s2n-tls/src/testing/s2n_tls.rs
+++ b/bindings/rust/extended/s2n-tls/src/testing/s2n_tls.rs
@@ -580,7 +580,7 @@ mod tests {
         Ok(())
     }
 
-    #[cfg(feature = "unstable-ktls")]
+    #[cfg(all(feature = "unstable-ktls", not(windows)))]
     #[test]
     fn key_updates() -> Result<(), Error> {
         use crate::{connection::KeyUpdateCount, enums::PeerKeyUpdate};


### PR DESCRIPTION
# Goal

Make s2n-tls' rust bindings generate and build on Windows.

## Why

s2n-tls C code can now fully run and tested on Windows. We need to make rust bindings works on it as well, since there are customers who want to use s2n-tls' rust bindings on Windows.

## How

1. Change in bindings/rust/extended/generate/src/main.rs to make it works

There are a couple features that can not be ran on Windows which are internal and KTLS. We need to gate them from Windows. While we are generating rust code, we also need to gate functions that are not available on Windows. We need to place the cfg(not(windows)) header on relevant code. We also need to implement a iovec for Windows specifically. This is the same approach that we took in https://github.com/aws/s2n-tls/pull/5880.

2. Set up rust on Windows CI

We need to also set up rust toolchain on Windows CI. For now, we just want to verify that the rust bindings can be generated and build, so we will run ./bindings/rust/extended/generate.sh --skip-tests command on the CI.

## Callouts

The next step is to enable tests for our rust bindings. I already experimented with that and can confirm cargo test would work on the CI. However, the CI seems to have some troubles to test some other features, since those features requires aws-lc-rs, and doesn't support some Windows toolchains: https://aws.github.io/aws-lc-rs/requirements/windows. I need to investigate those in the next PR. Since this PR specifically deals with making the rust bindings generated and built, the current CI provides enough coverage.

## Testing

Rust bindings would build on my EC2 instance.

The CI should run these tests. I already tested it on my fork:
https://github.com/boquan-fang/s2n-tls/actions/runs/28062675560

CI runs on this PR:
https://github.com/aws/s2n-tls/actions/runs/28205648774/job/83555627965?pr=5958

### Related

Related to https://github.com/aws/s2n-tls/issues/4018.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
