### PR TITLE
chore: metrics-subscriber release v0.0.4

### DIFF
--- a/bindings/rust/standard/s2n-tls-metrics-subscriber/Cargo.toml
+++ b/bindings/rust/standard/s2n-tls-metrics-subscriber/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "s2n-tls-metrics-subscriber"
-version = "0.0.3"
+version = "0.0.4"
 edition = "2024"
 description = "Telemetry provider for s2n-tls"
 authors = ["AWS s2n"]
@@ -18,9 +18,12 @@ metrique-writer = "0.1.19"
 arc-swap = "1.8.0"
 # minimum versions set for workspace-wide cargo minimal-versions compatibility
 serde = { version = "1.0.225", features = ["derive"] }
-# we at least need 0.3.38, because of the Connection::mode() API
-s2n-tls = { version = "0.3.38", path = "../../extended/s2n-tls", features = ["unstable-events", "unstable-testing"] }
-s2n-tls-sys = { version = "0.3.38", path = "../../extended/s2n-tls-sys"}
+# Pinned to an exact bindings version so the subscriber cannot roll forward onto
+# a future, incompatible revision of the unstable event API (see PR #5913).
+# s2n-tls and s2n-tls-sys must stay on the same version: parsing/mod.rs casts
+# between their types and guards it with a static_assertions size check.
+s2n-tls = { version = "=0.3.39", path = "../../extended/s2n-tls", features = ["unstable-events", "unstable-testing"] }
+s2n-tls-sys = { version = "=0.3.39", path = "../../extended/s2n-tls-sys"}
 const-oid = "0.10.2"
 
 [features]


### PR DESCRIPTION
# Goal
Release `s2n-tls-metrics-subscriber` 0.0.4, pinned to a known-good bindings version.

## Why
The subscriber uses s2n-tls's unstable event API, which can change in any 0.3.x release (#5913). The `version = "0.3.38"` caret range let consumers float forward onto an incompatible API and break.

## How
Bump to 0.0.4 and pin `s2n-tls` and `s2n-tls-sys` to `=0.3.39`.

## Callouts
N/A

## Testing
Pin should resolve against the workspace. No code changes.

### Related
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
