### PR TITLE
docs: Windows MinGW support is available

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,11 @@ We’ve listed the distributions and platforms under two tiers: Tier 1 platforms
 |OpenBSD [7.4](https://github.com/cross-platform-actions/action/blob/master/readme.md#supported-platforms)| x86_64 |
 |FreeBSD [latest](https://github.com/vmactions/freebsd-vm/blob/v1/conf/default.release.conf)| x86_64  |
 |OSX [latest](https://github.com/actions/runner-images?tab=readme-ov-file#available-images) | aarch64 |
+|Windows (MSYS2 / MinGW)*                               | x86_64          |
 
 **Work in Progress
+
+*Windows is supported through the MSYS2 environment with a MinGW toolchain (`UCRT64`, `MINGW64`, and `CLANG64`). The MSVC toolchain is not supported. On Windows, AWS-LC is the only supported libcrypto. Some POSIX-specific features (such as kTLS) are not available on Windows. See the [build documentation](docs/BUILD.md) for details.
 
 ### Tier 2
 

--- a/bindings/rust/README.md
+++ b/bindings/rust/README.md
@@ -23,6 +23,28 @@ $ ./bindings/rust/extended/generate.sh
 This script generates the low-level bindings in the crate `s2n-tls-sys`, which is used by the `s2n-tls` crate to provide higher-level bindings.
 See [s2n-tls-sys](https://github.com/aws/s2n-tls/blob/main/bindings/rust/s2n-tls-sys/README.md) for more information on `s2n-tls-sys` crate.
 
+## Windows
+
+The rust bindings are supported on Windows through the [MSYS2](https://www.msys2.org/) environment with a MinGW toolchain. Use a GNU Rust target rather than an MSVC target: `x86_64-pc-windows-gnu` for the `UCRT64`/`MINGW64` environments, or `x86_64-pc-windows-gnullvm` for the `CLANG64` environment. The MSVC toolchain (`*-pc-windows-msvc`) is not supported.
+
+On Windows, AWS-LC is the only supported libcrypto. The bindings link against AWS-LC through the `aws-lc-rs` crate (which builds AWS-LC from source), so no separate libcrypto needs to be installed.
+
+From a MinGW shell, install the toolchain and dependencies (the package prefix depends on the environment, e.g. `mingw-w64-ucrt-x86_64` for `UCRT64`), then generate the bindings as usual:
+
+```bash
+# example for the UCRT64 environment
+pacman -S --needed \
+    mingw-w64-ucrt-x86_64-clang \
+    mingw-w64-ucrt-x86_64-clang-libs \
+    mingw-w64-ucrt-x86_64-cmake \
+    mingw-w64-ucrt-x86_64-ninja \
+    mingw-w64-ucrt-x86_64-rustup \
+    make
+
+rustup default stable-x86_64-pc-windows-gnu
+./bindings/rust/extended/generate.sh
+```
+
 ## Minimum Supported Rust Version (MSRV)
 
 There are two rust bindings workspaces that have different MSRV policies. Crates in `standard` maintain a rolling MSRV policy of at least 6 months. Crates in `extended` maintain an older MSRV for increased support.

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -68,7 +68,38 @@ cmake3 --install build
 ```
 </details>
 
-Note that we currently do not support building on Windows. See https://github.com/aws/s2n-tls/issues/497 for more information.
+<details>
+<summary>Windows (MSYS2 / MinGW)</summary>
+
+Windows is supported using the [MSYS2](https://www.msys2.org/) environment with a MinGW toolchain. Building with the MSVC toolchain is not currently supported.
+
+After installing MSYS2, open a MinGW shell (one of `UCRT64`, `MINGW64`, or `CLANG64`) and install the build dependencies. The package prefix depends on the environment you chose (`mingw-w64-ucrt-x86_64` for `UCRT64`, `mingw-w64-x86_64` for `MINGW64`, or `mingw-w64-clang-x86_64` for `CLANG64`):
+
+```bash
+# example for the UCRT64 environment
+pacman -S --needed \
+    mingw-w64-ucrt-x86_64-clang \
+    mingw-w64-ucrt-x86_64-cmake \
+    mingw-w64-ucrt-x86_64-ninja \
+    make git
+```
+
+A supported libcrypto must also be available. On Windows, **AWS-LC is the only supported and tested libcrypto** — it is the only backend exercised by our Windows CI, and other libcryptos (OpenSSL, BoringSSL, LibreSSL) are not supported on Windows. See [Building with a specific libcrypto](#building-with-a-specific-libcrypto) and the [AWS-LC build documentation](https://github.com/aws/aws-lc/blob/main/BUILDING.md). Once AWS-LC is installed, build s2n-tls:
+
+```bash
+# build s2n-tls
+cmake . -Bbuild -GNinja \
+    -DCMAKE_C_COMPILER=clang \
+    -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+    -DCMAKE_PREFIX_PATH=<path to libcrypto install> \
+    -DCMAKE_INSTALL_PREFIX=./s2n-tls-install
+cmake --build build -j $(nproc)
+CTEST_PARALLEL_LEVEL=$(nproc) ctest --test-dir build
+cmake --install build
+```
+
+Note that some POSIX-specific features are not available on Windows. The `s2nc` and `s2nd` test utilities, kTLS, and a handful of unit tests that depend on POSIX socket or memory APIs are not built or run on Windows.
+</details>
 
 Using the commands above, the libraries and headers will be located in the `s2n-tls-install` directory.
 

--- a/docs/development/APPLICATION_DATA.md
+++ b/docs/development/APPLICATION_DATA.md
@@ -20,6 +20,8 @@ Applications are responsible for opening and configuring the file descriptors. s
 
 See [tls/s2n_socket.c](https://github.com/aws/s2n-tls/blob/main/utils/s2n_socket.c) for the file descriptor related logic.
 
+These file descriptor based behaviors rely on POSIX socket APIs and are not available on Windows. On Windows, applications cannot set a file descriptor and must instead supply custom send/receive callbacks (see [Custom callbacks](#custom-callbacks) below). `utils/s2n_socket.c` compiles to an empty translation unit on Windows.
+
 ### Custom callbacks
 
 If calling `read` or `write` on a file descriptor is not sufficient, applications can use s2n_connection_set_recv_cb and s2n_connection_set_send_cb to set custom IO callbacks to implement whatever read and write logic they need. These custom callbacks replace the default callbacks set when file descriptors are configured.

--- a/docs/usage-guide/topics/ch07-io.md
+++ b/docs/usage-guide/topics/ch07-io.md
@@ -14,6 +14,16 @@ including socket options. s2n-tls itself sets a few socket options:
 used during the TLS handshake. TCP_NOPUSH or TCP_NODELAY may be used if TCP_CORK
 is not available.
 
+**Note for Windows:**
+The file descriptor based APIs (`s2n_connection_set_fd()`,
+`s2n_connection_set_read_fd()`, `s2n_connection_set_write_fd()`, and
+`s2n_connection_use_corked_io()`) rely on POSIX socket semantics and are **not
+available on Windows**. On Windows, applications must instead provide their own
+I/O methods using the custom I/O callbacks described in
+[Custom IO Callbacks](#custom-io-callbacks). The callbacks can wrap a Winsock
+`SOCKET` (using `recv()`/`send()`) or any other transport. The socket options
+listed above are also only set on platforms that support them.
+
 **Important Note:**
 If the read end of the pipe is closed unexpectedly, writing to the pipe will raise
 a SIGPIPE signal. **s2n-tls does NOT handle SIGPIPE.** A SIGPIPE signal will cause
@@ -21,6 +31,7 @@ the process to terminate unless it is handled or ignored by the application.
 See the [signal man page](https://linux.die.net/man/2/signal) for instructions on
 how to handle C signals, or simply ignore the SIGPIPE signal by calling
 `signal(SIGPIPE, SIG_IGN)` before calling any s2n-tls IO methods.
+(SIGPIPE does not exist on Windows, so this does not apply there.)
 
 ## Blocking or Non-Blocking?
 
@@ -50,6 +61,11 @@ int flags = fcntl(fd, F_GETFL, 0);
 if (flags < 0) return S2N_FAILURE;
 if (fcntl(fd, F_SETFL, flags | O_NONBLOCK) < 0) return S2N_FAILURE;
 ```
+
+On Windows, `fcntl()` is not available. Configure the non-blocking mode of the
+underlying transport directly (for example, with `ioctlsocket()` and `FIONBIO`
+for a Winsock `SOCKET`) and drive I/O through the custom I/O callbacks described
+in [Custom IO Callbacks](#custom-io-callbacks).
 
 Note: If an application requires non-blocking IO, it likely also requires self-service blinding. See [Blinding](./ch03-error-handling.md#Blinding).
 
@@ -231,8 +247,19 @@ to the custom IO methods by using `s2n_connection_set_recv_ctx()` and `s2n_conne
 s2n-tls will call the custom IO methods with the custom context instead of calling
 the default implementation.
 
+On Windows, the default file descriptor based I/O is not available (see
+[Basic IO setup](#basic-io-setup)), so providing custom I/O callbacks is the only
+way to connect s2n-tls to a transport. A typical implementation wraps a Winsock
+`SOCKET` and calls `recv()`/`send()`.
+
 The custom IO methods may send or receive less than the requested length. They
 should return the number of bytes sent/received, or set errno and return an error code < 0.
 s2n-tls will interpret errno set to EWOULDBLOCK or EAGAIN as indicating a retriable
 blocking error, and set **s2n_errno** and the s2n_blocked_status appropriately.
 s2n-tls will interpret a return value of 0 as a closed connection.
+
+On Windows, Winsock reports a blocking condition through `WSAGetLastError()`
+returning `WSAEWOULDBLOCK` rather than through `errno`. A custom callback should
+translate this into a retriable blocking error by setting `errno` to `EWOULDBLOCK`
+(or `EAGAIN`) before returning a negative value, so that s2n-tls reports
+`S2N_ERR_T_BLOCKED` as expected.


### PR DESCRIPTION
# Goal

Update s2n-tls doc to say that the library provides Windows support now.

## Why

I made s2n-tls able to build on Windows for both of C code and rust bindings. A dedicated CI was also added to test it. Windows is our tier one supported platform now.

## How

The doc indicate following thing:
1. Widows is a tier 1 supported platform for s2n-tls.
2. System set up prerequisite.
3. C and rust build instructions.
4. IO callbacks mandate.

## Callouts

This should be merged in after https://github.com/aws/s2n-tls/pull/5969 is merged in.

## Testing


### Related

related to https://github.com/aws/s2n-tls/issues/4018

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
