### PR TITLE
refactor(metrics): make record update infallible

### DIFF
--- a/bindings/rust/standard/s2n-tls-metrics-schema/src/metric_names.rs
+++ b/bindings/rust/standard/s2n-tls-metrics-schema/src/metric_names.rs
@@ -86,6 +86,7 @@ pub const SSLV2_CLIENT_HELLO: &str = "sslv2_client_hello";
 pub const HANDSHAKE_DURATION_US: &str = "handshake_duration_us";
 pub const HANDSHAKE_COMPUTE_US: &str = "handshake_compute_us";
 pub const SYNTHETIC_TRAFFIC_COUNT: &str = "synthetic_traffic_count";
+pub const INTERNAL_FAILURE: &str = "internal_failure";
 
 pub const ALL_SCALARS: &[&str] = &[
     COMPATIBILITY_GENERAL20251201,
@@ -100,6 +101,7 @@ pub const ALL_SCALARS: &[&str] = &[
     SYNTHETIC_TRAFFIC_COUNT,
     SERVER_CERT_PARSE_FAILURE,
     CLIENT_CERT_PARSE_FAILURE,
+    INTERNAL_FAILURE,
 ];
 
 /// A counter group descriptor: prefix string, element count, and cached name accessor.

--- a/bindings/rust/standard/s2n-tls-metrics-schema/src/record.rs
+++ b/bindings/rust/standard/s2n-tls-metrics-schema/src/record.rs
@@ -281,10 +281,7 @@ impl metrique_writer::Entry for FrozenHandshakeRecord {
             names::SYNTHETIC_TRAFFIC_COUNT,
             &self.synthetic_traffic_count,
         );
-        writer.value(
-            names::INTERNAL_FAILURE,
-            &self.internal_failure,
-        );
+        writer.value(names::INTERNAL_FAILURE, &self.internal_failure);
     }
 }
 

--- a/bindings/rust/standard/s2n-tls-metrics-schema/src/record.rs
+++ b/bindings/rust/standard/s2n-tls-metrics-schema/src/record.rs
@@ -124,6 +124,11 @@ pub struct FrozenHandshakeRecord {
 
     #[serde(default)]
     pub synthetic_traffic_count: u64,
+
+    /// Number of handshakes where an internal error prevented the metrics
+    /// subscriber from fully recording metrics.
+    #[serde(default)]
+    pub internal_failure: u64,
 }
 
 impl Default for FrozenHandshakeRecord {
@@ -159,6 +164,7 @@ impl Default for FrozenHandshakeRecord {
             handshake_duration_us: 0,
             handshake_compute_us: 0,
             synthetic_traffic_count: 0,
+            internal_failure: 0,
             security_policies: Default::default(),
         }
     }
@@ -274,6 +280,10 @@ impl metrique_writer::Entry for FrozenHandshakeRecord {
         writer.value(
             names::SYNTHETIC_TRAFFIC_COUNT,
             &self.synthetic_traffic_count,
+        );
+        writer.value(
+            names::INTERNAL_FAILURE,
+            &self.internal_failure,
         );
     }
 }

--- a/bindings/rust/standard/s2n-tls-metrics-subscriber/src/record.rs
+++ b/bindings/rust/standard/s2n-tls-metrics-subscriber/src/record.rs
@@ -263,7 +263,7 @@ impl HandshakeRecordInProgress {
                     return;
                 }
                 (_, Err(e)) => {
-                    // never expected to fail: a failure means that s2n-tls 
+                    // never expected to fail: a failure means that s2n-tls
                     // considered the client hello well-formed, but our parser
                     // didn't
                     tracing::error!("failed to parse client hello supported parameters: {e}");
@@ -421,9 +421,7 @@ impl HandshakeRecordInProgress {
             handshake_duration_us: self.handshake_duration_us.load(Ordering::Relaxed),
             handshake_compute_us: self.handshake_compute_us.load(Ordering::Relaxed),
             synthetic_traffic_count: self.synthetic_traffic_count.load(Ordering::Relaxed),
-            internal_failure: self
-                .internal_failure
-                .load(Ordering::Relaxed),
+            internal_failure: self.internal_failure.load(Ordering::Relaxed),
             security_policies: self.security_policies.freeze(),
         }
     }
@@ -1031,54 +1029,58 @@ mod tests {
         assert_eq!(record.server_leaf_cert_key.get(&CertKeyType::Secp384r1), 0);
     }
 
-    /// After a Hello Retry Request, the server's client_hello may not be
-    /// available. This test documents that behavior by asserting that an
-    /// internal_failure is recorded for the server-side HRR handshake.
+    /// A handshake that fails before the client hello is received should still
+    /// record a failure metric without panicking.
     #[test]
-    fn hello_retry_request_internal_failure() {
-        use s2n_tls::security::Policy;
+    fn failure_without_client_hello() {
+        use std::{io::Write, task::Poll};
 
         let sink = crate::test_utils::VecSink::new();
         let attribution = crate::Attribution {
-            service: "test_server".to_owned(),
-            resource: "test_resource".to_owned(),
-            component: "test_component".to_owned(),
+            service: "test".to_owned(),
+            resource: "test".to_owned(),
+            component: "test".to_owned(),
         };
         let subscriber = crate::AggregatedMetricsSubscriber::new(sink.clone(), attribution);
 
-        // Use a server policy with strongly preferred groups to force HRR.
-        // "20251117" strongly prefers secp384r1, so a client that sends a
-        // secp256r1 key share will trigger a HelloRetryRequest.
-        let hrr_policy = Policy::from_version("20251117").unwrap();
         let server_config = {
-            let mut config = s2n_tls::testing::config_builder(&hrr_policy).unwrap();
+            let mut config =
+                s2n_tls::testing::config_builder(&s2n_tls::security::DEFAULT_TLS13).unwrap();
             config.set_event_subscriber(subscriber.clone()).unwrap();
+            config.set_max_blinding_delay(0).unwrap();
             config.build().unwrap()
         };
-
-        // Client uses default_tls13 which sends secp256r1 as its initial key share
         let client_config =
             s2n_tls::testing::build_config(&s2n_tls::security::DEFAULT_TLS13).unwrap();
-        let mut pair =
-            s2n_tls::testing::TestPair::from_configs(&client_config, &server_config);
-        pair.handshake().unwrap();
+
+        let mut pair = s2n_tls::testing::TestPair::from_configs(&client_config, &server_config);
+
+        // Write garbage that looks like a TLS record but with invalid content.
+        // Record header: content_type(1) | version(2) | length(2) | payload
+        // Use content_type 0xFF (invalid) to trigger an immediate error.
+        let garbage_record: &[u8] = &[
+            0x16, // content_type: handshake
+            0x03, 0x01, // version: TLS 1.0
+            0x00, 0x05, // length: 5 bytes
+            0xFF, 0xFF, 0xFF, 0xFF, 0xFF, // garbage handshake payload
+        ];
+        pair.io
+            .client_tx_stream
+            .borrow_mut()
+            .write_all(garbage_record)
+            .unwrap();
+
+        // The server should fail because it received garbage instead of a client hello.
+        match pair.server.poll_negotiate() {
+            Poll::Ready(Err(_)) => {}
+            other => panic!("expected server error, got {:?}", other),
+        }
 
         subscriber.finish_record();
         let records = sink.records.lock().unwrap();
         let record = &records[0].as_schema().handshake;
 
-        // The handshake succeeded
-        assert_eq!(record.handshake_success_count, 1);
-
-        // Check if HRR actually happened by looking at the negotiated group.
-        // If HRR happened, the server should have negotiated secp384r1 even
-        // though the client initially offered secp256r1.
-        let negotiated_group = pair.server.selected_key_exchange_group();
-        eprintln!("negotiated group: {:?}", negotiated_group);
-        eprintln!("internal_failure: {}", record.internal_failure);
-        eprintln!("handshake_success_count: {}", record.handshake_success_count);
-
-        // But the client hello was unavailable after HRR, causing an internal failure
-        assert_eq!(record.internal_failure, 1);
+        assert_eq!(record.handshake_failure_count, 1);
+        assert_eq!(record.internal_failure, 0);
     }
 }

--- a/bindings/rust/standard/s2n-tls-metrics-subscriber/src/record.rs
+++ b/bindings/rust/standard/s2n-tls-metrics-subscriber/src/record.rs
@@ -96,6 +96,10 @@ pub(crate) struct HandshakeRecordInProgress {
     /// [`SyntheticTrafficDetector`]. Synthetic handshakes are excluded from
     /// every other counter on this record (including `handshake_success_count`).
     synthetic_traffic_count: AtomicU64,
+
+    /// Number of handshakes where an internal error prevented the metrics
+    /// subscriber from fully recording metrics.
+    internal_failure: AtomicU64,
 }
 
 impl HandshakeRecordInProgress {
@@ -136,19 +140,25 @@ impl HandshakeRecordInProgress {
             handshake_duration_us: Default::default(),
             handshake_compute_us: Default::default(),
             synthetic_traffic_count: Default::default(),
+            internal_failure: Default::default(),
             exporter,
         }
     }
 
+    // This method should always be infallible. If there is an internal error
+    // e.g. being unable to retrieve something from s2n-tls, you should increment
+    // the internal_failure metric and log the error with `tracing::error!`
     pub fn update(
         &self,
         conn: &s2n_tls::connection::Connection,
         event: &s2n_tls::events::HandshakeEvent,
         detector: Option<&dyn SyntheticTrafficDetector>,
-    ) -> Result<(), Box<dyn std::error::Error>> {
-        // client_hello is only available on the server side of the connection
+    ) {
+        // client_hello is only available on the server side of the connection.
+        // Even on the server side, the client hello may not be populated if the
+        // handshake failed before the client hello was fully received/parsed.
         let client_hello = if conn.mode() == s2n_tls::enums::Mode::Server {
-            Some(conn.client_hello()?)
+            conn.client_hello().ok()
         } else {
             None
         };
@@ -162,7 +172,7 @@ impl HandshakeRecordInProgress {
             if let Some(client_hello) = client_hello {
                 if detector.is_synthetic(client_hello) {
                     self.synthetic_traffic_count.fetch_add(1, Ordering::Relaxed);
-                    return Ok(());
+                    return;
                 }
             }
         }
@@ -174,7 +184,7 @@ impl HandshakeRecordInProgress {
                 if let Some(alert) = alert {
                     self.alerts.increment(&alert);
                 }
-                return Ok(());
+                return;
             }
             s2n_tls::events::HandshakeResult::Success(s) => {
                 self.handshake_success_count.fetch_add(1, Ordering::Relaxed);
@@ -182,49 +192,83 @@ impl HandshakeRecordInProgress {
             }
         };
 
+        // if it was a successful handshake and we're a server, then the client
+        // hello should always be available. If not, increment an internal failure
+        // metric and give up.
+        if conn.mode() == s2n_tls::enums::Mode::Server && client_hello.is_none() {
+            tracing::error!(
+                "client hello unavailable after successful handshake: {:?}",
+                conn.client_hello().err()
+            );
+            self.internal_failure.fetch_add(1, Ordering::Relaxed);
+            return;
+        }
+
         self.security_policies.record(event.security_policy_label());
 
         if let Some(client_hello) = client_hello {
-            if conn.client_hello_is_sslv2()? {
-                self.sslv2_client_hello.fetch_add(1, Ordering::Relaxed);
-            } else {
-                let supported_parameter = ClientHelloSupportedParameters::new(client_hello)?;
-
-                supported_parameter
-                    .supported_versions()
-                    .iter()
-                    .for_each(|version| self.supported_protocols.increment(version));
-
-                supported_parameter
-                    .supported_ciphers()
-                    .iter()
-                    .for_each(|cipher| self.supported_ciphers.increment(cipher));
-
-                supported_parameter
-                    .supported_groups()
-                    .iter()
-                    .flat_map(|groups| groups.iter())
-                    .for_each(|group| self.supported_groups.increment(group));
-
-                supported_parameter
-                    .supported_signatures()
-                    .iter()
-                    .flat_map(|sigs| sigs.iter())
-                    .for_each(|signature| self.supported_signatures.increment(signature));
-
-                if General20251201::supported(&supported_parameter) {
-                    self.compatibility_general20251201
-                        .fetch_add(1, Ordering::Relaxed);
+            match (
+                conn.client_hello_is_sslv2(),
+                ClientHelloSupportedParameters::new(client_hello),
+            ) {
+                (Ok(true), _) => {
+                    // we don't support parsing supported parameters from SSLv2
+                    // client hellos because they have a different structure
+                    self.sslv2_client_hello.fetch_add(1, Ordering::Relaxed);
                 }
-                if Fips20251201::supported(&supported_parameter) {
-                    self.compatibility_fips20251201
-                        .fetch_add(1, Ordering::Relaxed);
+                (Ok(false), Ok(supported_parameter)) => {
+                    supported_parameter
+                        .supported_versions()
+                        .iter()
+                        .for_each(|version| self.supported_protocols.increment(version));
+
+                    supported_parameter
+                        .supported_ciphers()
+                        .iter()
+                        .for_each(|cipher| self.supported_ciphers.increment(cipher));
+
+                    supported_parameter
+                        .supported_groups()
+                        .iter()
+                        .flat_map(|groups| groups.iter())
+                        .for_each(|group| self.supported_groups.increment(group));
+
+                    supported_parameter
+                        .supported_signatures()
+                        .iter()
+                        .flat_map(|sigs| sigs.iter())
+                        .for_each(|signature| self.supported_signatures.increment(signature));
+
+                    if General20251201::supported(&supported_parameter) {
+                        self.compatibility_general20251201
+                            .fetch_add(1, Ordering::Relaxed);
+                    }
+                    if Fips20251201::supported(&supported_parameter) {
+                        self.compatibility_fips20251201
+                            .fetch_add(1, Ordering::Relaxed);
+                    }
+                    if Cnsa1::supported(&supported_parameter) {
+                        self.compatibility_cnsa1.fetch_add(1, Ordering::Relaxed);
+                    }
+                    if Cnsa2::supported(&supported_parameter) {
+                        self.compatibility_cnsa2.fetch_add(1, Ordering::Relaxed);
+                    }
                 }
-                if Cnsa1::supported(&supported_parameter) {
-                    self.compatibility_cnsa1.fetch_add(1, Ordering::Relaxed);
+                (Err(e), _) => {
+                    // never expected to fail: a failure means the handshake
+                    // succeeded without s2n-tls knowing whether or not it was
+                    // an SSLv2 client hello
+                    tracing::error!("failed to determine sslv2 client hello status: {e}");
+                    self.internal_failure.fetch_add(1, Ordering::Relaxed);
+                    return;
                 }
-                if Cnsa2::supported(&supported_parameter) {
-                    self.compatibility_cnsa2.fetch_add(1, Ordering::Relaxed);
+                (_, Err(e)) => {
+                    // never expected to fail: a failure means that s2n-tls 
+                    // considered the client hello well-formed, but our parser
+                    // didn't
+                    tracing::error!("failed to parse client hello supported parameters: {e}");
+                    self.internal_failure.fetch_add(1, Ordering::Relaxed);
+                    return;
                 }
             }
         }
@@ -327,8 +371,6 @@ impl HandshakeRecordInProgress {
         );
         self.handshake_duration_us
             .fetch_add(event.duration().as_micros() as u64, Ordering::Relaxed);
-
-        Ok(())
     }
 
     /// make a copy of this record to be exported.
@@ -379,6 +421,9 @@ impl HandshakeRecordInProgress {
             handshake_duration_us: self.handshake_duration_us.load(Ordering::Relaxed),
             handshake_compute_us: self.handshake_compute_us.load(Ordering::Relaxed),
             synthetic_traffic_count: self.synthetic_traffic_count.load(Ordering::Relaxed),
+            internal_failure: self
+                .internal_failure
+                .load(Ordering::Relaxed),
             security_policies: self.security_policies.freeze(),
         }
     }
@@ -984,5 +1029,56 @@ mod tests {
         // No RSA in client fields, no ECDSA in server fields
         assert_eq!(record.client_leaf_cert_key.get(&CertKeyType::Rsa4096), 0);
         assert_eq!(record.server_leaf_cert_key.get(&CertKeyType::Secp384r1), 0);
+    }
+
+    /// After a Hello Retry Request, the server's client_hello may not be
+    /// available. This test documents that behavior by asserting that an
+    /// internal_failure is recorded for the server-side HRR handshake.
+    #[test]
+    fn hello_retry_request_internal_failure() {
+        use s2n_tls::security::Policy;
+
+        let sink = crate::test_utils::VecSink::new();
+        let attribution = crate::Attribution {
+            service: "test_server".to_owned(),
+            resource: "test_resource".to_owned(),
+            component: "test_component".to_owned(),
+        };
+        let subscriber = crate::AggregatedMetricsSubscriber::new(sink.clone(), attribution);
+
+        // Use a server policy with strongly preferred groups to force HRR.
+        // "20251117" strongly prefers secp384r1, so a client that sends a
+        // secp256r1 key share will trigger a HelloRetryRequest.
+        let hrr_policy = Policy::from_version("20251117").unwrap();
+        let server_config = {
+            let mut config = s2n_tls::testing::config_builder(&hrr_policy).unwrap();
+            config.set_event_subscriber(subscriber.clone()).unwrap();
+            config.build().unwrap()
+        };
+
+        // Client uses default_tls13 which sends secp256r1 as its initial key share
+        let client_config =
+            s2n_tls::testing::build_config(&s2n_tls::security::DEFAULT_TLS13).unwrap();
+        let mut pair =
+            s2n_tls::testing::TestPair::from_configs(&client_config, &server_config);
+        pair.handshake().unwrap();
+
+        subscriber.finish_record();
+        let records = sink.records.lock().unwrap();
+        let record = &records[0].as_schema().handshake;
+
+        // The handshake succeeded
+        assert_eq!(record.handshake_success_count, 1);
+
+        // Check if HRR actually happened by looking at the negotiated group.
+        // If HRR happened, the server should have negotiated secp384r1 even
+        // though the client initially offered secp256r1.
+        let negotiated_group = pair.server.selected_key_exchange_group();
+        eprintln!("negotiated group: {:?}", negotiated_group);
+        eprintln!("internal_failure: {}", record.internal_failure);
+        eprintln!("handshake_success_count: {}", record.handshake_success_count);
+
+        // But the client hello was unavailable after HRR, causing an internal failure
+        assert_eq!(record.internal_failure, 1);
     }
 }

--- a/bindings/rust/standard/s2n-tls-metrics-subscriber/src/record.rs
+++ b/bindings/rust/standard/s2n-tls-metrics-subscriber/src/record.rs
@@ -1056,8 +1056,6 @@ mod tests {
         let mut pair = s2n_tls::testing::TestPair::from_configs(&client_config, &server_config);
 
         // Write garbage that looks like a TLS record but with invalid content.
-        // Record header: content_type(1) | version(2) | length(2) | payload
-        // Use content_type 0xFF (invalid) to trigger an immediate error.
         let garbage_record: &[u8] = &[
             0x16, // content_type: handshake
             0x03, 0x01, // version: TLS 1.0
@@ -1075,6 +1073,8 @@ mod tests {
             Poll::Ready(Err(_)) => {}
             other => panic!("expected server error, got {:?}", other),
         }
+        // confirm that the "client hello" was not available
+        assert!(pair.server.client_hello().is_err());
 
         subscriber.finish_record();
         let records = sink.records.lock().unwrap();

--- a/bindings/rust/standard/s2n-tls-metrics-subscriber/src/subscriber.rs
+++ b/bindings/rust/standard/s2n-tls-metrics-subscriber/src/subscriber.rs
@@ -205,13 +205,7 @@ impl<S: TelemetrySink> EventSubscriber for AggregatedMetricsSubscriber<S> {
             .synthetic_detector
             .get()
             .map(|boxed| boxed.as_ref());
-        let res = current_record.update(connection, event, detector);
-        // we never expect this to fail, but if it fails in production there is
-        // no meaningful way to handle the failure
-        debug_assert!(res.is_ok());
-        if let Err(e) = res {
-            tracing::error!("failed to update handshake record: {e}");
-        }
+        current_record.update(connection, event, detector);
         // Drop the Arc before attempting export so that finish_record can
         // observe the final reference count drop.
         drop(current_record);

--- a/bindings/rust/standard/s2n-tls-metrics-subscriber/tests/snapshots/entry_emf.json
+++ b/bindings/rust/standard/s2n-tls-metrics-subscriber/tests/snapshots/entry_emf.json
@@ -165,6 +165,9 @@
           },
           {
             "Name": "synthetic_traffic_count"
+          },
+          {
+            "Name": "internal_failure"
           }
         ],
         "Namespace": "TlsMetrics"
@@ -206,6 +209,7 @@
   "handshake_duration_us": "<DURATION>",
   "handshake_failure_count": 1,
   "handshake_success_count": 1,
+  "internal_failure": 0,
   "resource": "arn:aws:elasticloadbalancing:us-east-1:123:listener/abc",
   "service": "my-service",
   "signature_scheme.negotiated.rsa_pss_rsae_sha256": 1,


### PR DESCRIPTION
# Goal
tolerate mismatches between expected library state and the metrics subscriber APIs

## Why
In general, the debug asserts were getting really noisy, especially for customers that are using the external build feature of the bindings, where there isn't any coherency to versioning.

## How
We make the record update infallible, and add a specific internal failure metric for visibility into these failures

## Testing
I added a test ensuing that we gracefully report failures even when there is no retrievable client hello

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
