### PR TITLE
refactor: export trait owns MetricRecord

### DIFF
--- a/bindings/rust/standard/s2n-tls-metrics-subscriber/Cargo.toml
+++ b/bindings/rust/standard/s2n-tls-metrics-subscriber/Cargo.toml
@@ -22,7 +22,7 @@ serde = { version = "1.0.225", features = ["derive"] }
 # a future, incompatible revision of the unstable event API (see PR #5913).
 # s2n-tls and s2n-tls-sys must stay on the same version: parsing/mod.rs casts
 # between their types and guards it with a static_assertions size check.
-s2n-tls = { version = "=0.3.39", path = "../../extended/s2n-tls", features = ["unstable-events", "unstable-testing"] }
+s2n-tls = { version = "0.3.39", path = "../../extended/s2n-tls", default-features = false, features = ["unstable-events", "unstable-testing"] }
 s2n-tls-sys = { version = "=0.3.39", path = "../../extended/s2n-tls-sys"}
 const-oid = "0.10.2"
 
@@ -34,6 +34,8 @@ fuzzing = []
 memory-test = []
 
 [dev-dependencies]
+# enable default features, because this application is responsible for calling init
+s2n-tls = { version = "0.3.39", path = "../../extended/s2n-tls", default-features = true}
 s2n-tls-sys-internal = { path = "../s2n-tls-sys-internal" }
 serde_json = "1.0.141"
 ciborium = "0.2"

--- a/bindings/rust/standard/s2n-tls-metrics-subscriber/examples/metrics_export.rs
+++ b/bindings/rust/standard/s2n-tls-metrics-subscriber/examples/metrics_export.rs
@@ -31,11 +31,11 @@ use s2n_tls_metrics_subscriber::{
 struct StdoutJsonSink;
 
 impl TelemetrySink for StdoutJsonSink {
-    fn export_record(&self, record: &MetricRecord) {
+    fn export_record(&self, record: MetricRecord) {
         let stdout = io::stdout();
         let mut handle = stdout.lock();
         // MetricRecord implements serde::Serialize, so we can use serde_json
-        if let Err(e) = serde_json::to_writer(&mut handle, record) {
+        if let Err(e) = serde_json::to_writer(&mut handle, &record) {
             eprintln!("failed to serialize metric record: {e}");
             return;
         }

--- a/bindings/rust/standard/s2n-tls-metrics-subscriber/src/subscriber.rs
+++ b/bindings/rust/standard/s2n-tls-metrics-subscriber/src/subscriber.rs
@@ -159,7 +159,7 @@ impl<S: TelemetrySink> AggregatedMetricsSubscriber<S> {
             attribution: self.inner.attribution.clone().into_schema(),
             handshake,
         });
-        export_pipeline.sink.export_record(&record);
+        export_pipeline.sink.export_record(record);
         self.inner
             .last_export_epoch_ms
             .store(epoch_ms_now(), Ordering::Relaxed);

--- a/bindings/rust/standard/s2n-tls-metrics-subscriber/src/telemetry_sink.rs
+++ b/bindings/rust/standard/s2n-tls-metrics-subscriber/src/telemetry_sink.rs
@@ -21,7 +21,7 @@ use crate::MetricRecord;
 /// bytes. That crate carries no stability guarantees.
 pub trait TelemetrySink: Send + Sync + 'static {
     /// Export a single metric record.
-    fn export_record(&self, record: &MetricRecord);
+    fn export_record(&self, record: MetricRecord);
 }
 
 /// Blanket impl so that callers can pass an `Arc<T>` directly as a sink.
@@ -29,7 +29,7 @@ pub trait TelemetrySink: Send + Sync + 'static {
 /// across multiple subscribers — they wrap it in an `Arc` and pass clones
 /// without the underlying sink type needing to implement `Clone`.
 impl<T: TelemetrySink> TelemetrySink for Arc<T> {
-    fn export_record(&self, record: &MetricRecord) {
+    fn export_record(&self, record: MetricRecord) {
         (**self).export_record(record)
     }
 }

--- a/bindings/rust/standard/s2n-tls-metrics-subscriber/src/test_utils.rs
+++ b/bindings/rust/standard/s2n-tls-metrics-subscriber/src/test_utils.rs
@@ -30,7 +30,7 @@ impl VecSink {
 }
 
 impl TelemetrySink for VecSink {
-    fn export_record(&self, record: &MetricRecord) {
+    fn export_record(&self, record: MetricRecord) {
         self.records.lock().unwrap().push(record.clone());
     }
 }

--- a/bindings/rust/standard/s2n-tls-metrics-subscriber/tests/entry_snapshot.rs
+++ b/bindings/rust/standard/s2n-tls-metrics-subscriber/tests/entry_snapshot.rs
@@ -16,8 +16,8 @@ use std::sync::{Arc, Mutex};
 #[derive(Clone)]
 struct CaptureSink(Arc<Mutex<Vec<MetricRecord>>>);
 impl TelemetrySink for CaptureSink {
-    fn export_record(&self, record: &MetricRecord) {
-        self.0.lock().unwrap().push(record.clone());
+    fn export_record(&self, record: MetricRecord) {
+        self.0.lock().unwrap().push(record);
     }
 }
 

--- a/bindings/rust/standard/s2n-tls-metrics-subscriber/tests/public_api.rs
+++ b/bindings/rust/standard/s2n-tls-metrics-subscriber/tests/public_api.rs
@@ -16,8 +16,8 @@ fn opaque_serialize_then_schema_deserialize() {
     #[derive(Clone)]
     struct CaptureSink(Arc<Mutex<Vec<Vec<u8>>>>);
     impl TelemetrySink for CaptureSink {
-        fn export_record(&self, record: &MetricRecord) {
-            let bytes = serde_json::to_vec(record).unwrap();
+        fn export_record(&self, record: MetricRecord) {
+            let bytes = serde_json::to_vec(&record).unwrap();
             self.0.lock().unwrap().push(bytes);
         }
     }

--- a/bindings/rust/standard/s2n-tls-metrics-subscriber/tests/subscriber_memory.rs
+++ b/bindings/rust/standard/s2n-tls-metrics-subscriber/tests/subscriber_memory.rs
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! Allocation regression gate for [`AggregatedMetricsSubscriber`].
+//! 
+//! Run with cargo test --features memory-test
 //!
 //! Same shape as `bindings/rust/standard/integration/tests/memory.rs`:
 //! `dhat::Alloc` as the global allocator, hardcoded expected values, and
@@ -34,7 +36,7 @@ fn fuzzy_equals(actual: i64, expected: i64) -> bool {
 struct NullSink;
 
 impl TelemetrySink for NullSink {
-    fn export_record(&self, _record: &MetricRecord) {}
+    fn export_record(&self, _record: MetricRecord) {}
 }
 
 fn attribution() -> Attribution {

--- a/bindings/rust/standard/s2n-tls-metrics-subscriber/tests/subscriber_memory.rs
+++ b/bindings/rust/standard/s2n-tls-metrics-subscriber/tests/subscriber_memory.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! Allocation regression gate for [`AggregatedMetricsSubscriber`].
-//! 
+//!
 //! Run with cargo test --features memory-test
 //!
 //! Same shape as `bindings/rust/standard/integration/tests/memory.rs`:


### PR DESCRIPTION
# Goal
Allow export owners to own the Telemetry Record

Also remove the s2n-tls pin and allow customers to use it in an FFI context (don't use the default s2n-tls feature set)

## Why
It is generally more efficient (instead of forcing a clone)

## How
Update the trait

## Testing
All existing CI should pass

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
