### PR TITLE
chore: version bump

### DIFF
--- a/bindings/rust/extended/s2n-tls-sys/Cargo.toml
+++ b/bindings/rust/extended/s2n-tls-sys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "s2n-tls-sys"
 description = "A C99 implementation of the TLS/SSL protocols"
-version = "0.3.39"
+version = "0.3.40"
 authors = ["AWS s2n"]
 edition = "2021"
 rust-version = "1.91"

--- a/bindings/rust/extended/s2n-tls-sys/templates/Cargo.template
+++ b/bindings/rust/extended/s2n-tls-sys/templates/Cargo.template
@@ -1,7 +1,7 @@
 [package]
 name = "s2n-tls-sys"
 description = "A C99 implementation of the TLS/SSL protocols"
-version = "0.3.39"
+version = "0.3.40"
 authors = ["AWS s2n"]
 edition = "2021"
 rust-version = "1.91"

--- a/bindings/rust/extended/s2n-tls-tokio/Cargo.toml
+++ b/bindings/rust/extended/s2n-tls-tokio/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "s2n-tls-tokio"
 description = "An implementation of TLS streams for Tokio built on top of s2n-tls"
-version = "0.3.39"
+version = "0.3.40"
 authors = ["AWS s2n"]
 edition = "2021"
 rust-version = "1.91"
@@ -16,7 +16,7 @@ errno = { version = "0.3" }
 # A minimum libc version of 0.2.121 is required by aws-lc-sys 0.14.0.
 libc = { version = "0.2.121" }
 pin-project-lite = { version = "0.2" }
-s2n-tls = { version = "=0.3.39", path = "../s2n-tls" }
+s2n-tls = { version = "=0.3.40", path = "../s2n-tls" }
 tokio = { version = "1", features = ["net", "time"] }
 
 [dev-dependencies]

--- a/bindings/rust/extended/s2n-tls/Cargo.toml
+++ b/bindings/rust/extended/s2n-tls/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "s2n-tls"
 description = "A C99 implementation of the TLS/SSL protocols"
-version = "0.3.39"
+version = "0.3.40"
 authors = ["AWS s2n"]
 edition = "2021"
 rust-version = "1.91"
@@ -27,7 +27,7 @@ unstable-testing = []
 errno = { version = "0.3" }
 # A minimum libc version of 0.2.121 is required by aws-lc-sys 0.14.0.
 libc = "0.2.121"
-s2n-tls-sys = { version = "=0.3.39", path = "../s2n-tls-sys", features = ["internal"] }
+s2n-tls-sys = { version = "=0.3.40", path = "../s2n-tls-sys", features = ["internal"] }
 pin-project-lite = "0.2"
 hex = "0.4"
 

--- a/bindings/rust/standard/s2n-tls-metrics-schema/Cargo.toml
+++ b/bindings/rust/standard/s2n-tls-metrics-schema/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "s2n-tls-metrics-schema"
-version = "0.0.1"
+version = "0.0.2"
 edition = "2024"
 description = "Serialization schema types for s2n-tls metrics. No stability guarantees."
 authors = ["AWS s2n"]

--- a/bindings/rust/standard/s2n-tls-metrics-subscriber/Cargo.toml
+++ b/bindings/rust/standard/s2n-tls-metrics-subscriber/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "s2n-tls-metrics-subscriber"
-version = "0.0.4"
+version = "0.0.5"
 edition = "2024"
 description = "Telemetry provider for s2n-tls"
 authors = ["AWS s2n"]
@@ -8,7 +8,7 @@ repository = "https://github.com/aws/s2n-tls"
 license = "Apache-2.0"
 
 [dependencies]
-s2n-tls-metrics-schema = { version = "0.0.1", path = "../s2n-tls-metrics-schema" }
+s2n-tls-metrics-schema = { version = "0.0.2", path = "../s2n-tls-metrics-schema" }
 s2n-codec.workspace = true
 static_assertions = "1.1.0"
 tracing = "0.1.43"
@@ -18,12 +18,10 @@ metrique-writer = "0.1.19"
 arc-swap = "1.8.0"
 # minimum versions set for workspace-wide cargo minimal-versions compatibility
 serde = { version = "1.0.225", features = ["derive"] }
-# Pinned to an exact bindings version so the subscriber cannot roll forward onto
-# a future, incompatible revision of the unstable event API (see PR #5913).
-# s2n-tls and s2n-tls-sys must stay on the same version: parsing/mod.rs casts
-# between their types and guards it with a static_assertions size check.
-s2n-tls = { version = "0.3.39", path = "../../extended/s2n-tls", default-features = false, features = ["unstable-events", "unstable-testing"] }
-s2n-tls-sys = { version = "=0.3.39", path = "../../extended/s2n-tls-sys"}
+# the event APIs are not stable, but we rely on the test introduced in
+# https://github.com/aws/s2n-tls/pull/5949 to ensure stability
+s2n-tls = { version = "0.3.40", path = "../../extended/s2n-tls", default-features = false, features = ["unstable-events", "unstable-testing"] }
+s2n-tls-sys = { version = "0.3.40", path = "../../extended/s2n-tls-sys"}
 const-oid = "0.10.2"
 
 [features]
@@ -35,7 +33,7 @@ memory-test = []
 
 [dev-dependencies]
 # enable default features, because this application is responsible for calling init
-s2n-tls = { version = "0.3.39", path = "../../extended/s2n-tls", default-features = true}
+s2n-tls = { version = "0.3.40", path = "../../extended/s2n-tls", default-features = true}
 s2n-tls-sys-internal = { path = "../s2n-tls-sys-internal" }
 serde_json = "1.0.141"
 ciborium = "0.2"


### PR DESCRIPTION
# Goal
version bump for release

## Why
we want more more metrics

## How
bump the number

## Callouts
We haven't added any new C APIs since the last release, so it's find to just do the bindings release.

## Testing
All existing CI should pass.

related: https://github.com/aws/s2n-tls/issues/4018

Also I double checked that the init feature worked on my local project that needs it.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
