### PR TITLE
feat: store the original clinet hello during hello retry request

### DIFF
--- a/api/s2n.h
+++ b/api/s2n.h
@@ -1493,6 +1493,23 @@ struct s2n_client_hello;
 S2N_API extern struct s2n_client_hello *s2n_connection_get_client_hello(struct s2n_connection *conn);
 
 /**
+ * Get the first ClientHello sent before a HelloRetryRequest.
+ *
+ * When a server sends a HelloRetryRequest, the client responds with a second
+ * ClientHello. By default s2n_connection_get_client_hello() returns that second
+ * (most recent) ClientHello. This method returns the first ClientHello,
+ * which is useful for inspecting the values the client originally offered.
+ *
+ * This is only available on the server, and only after a HelloRetryRequest has
+ * occurred. If no HelloRetryRequest was sent, there is no previous ClientHello
+ * and NULL is returned.
+ *
+ * @param conn The connection object containing the client hello
+ * @returns A handle to the s2n_client_hello structure holding the first client hello sent before a HelloRetryRequest. NULL is returned if no HelloRetryRequest occurred.
+ */
+S2N_API extern struct s2n_client_hello *s2n_connection_get_previous_client_hello(struct s2n_connection *conn);
+
+/**
  * Creates an s2n_client_hello from bytes representing a ClientHello message.
  *
  * The input bytes should include the message header (message type and length),

--- a/api/s2n.h
+++ b/api/s2n.h
@@ -1493,21 +1493,26 @@ struct s2n_client_hello;
 S2N_API extern struct s2n_client_hello *s2n_connection_get_client_hello(struct s2n_connection *conn);
 
 /**
- * Get the first ClientHello sent before a HelloRetryRequest.
+ * Get the first ClientHello sent by the client.
  *
  * When a server sends a HelloRetryRequest, the client responds with a second
- * ClientHello. By default s2n_connection_get_client_hello() returns that second
- * (most recent) ClientHello. This method returns the first ClientHello,
+ * ClientHello, and s2n_connection_get_client_hello() returns that second
+ * (most recent) ClientHello: the one negotiation actually moved forward with.
+ * This method instead always returns the first ClientHello the client sent,
  * which is useful for inspecting the values the client originally offered.
  *
- * This is only available on the server, and only after a HelloRetryRequest has
- * occurred. If no HelloRetryRequest was sent, there is no previous ClientHello
- * and NULL is returned.
+ * When no HelloRetryRequest occurs, only a single ClientHello is sent, so this
+ * method returns the same ClientHello as s2n_connection_get_client_hello().
+ *
+ * The returned handle is owned by the connection and must not be freed by the
+ * caller. It remains valid for the lifetime of the connection, and is
+ * invalidated by s2n_connection_free(), s2n_connection_wipe(), or
+ * s2n_connection_free_handshake().
  *
  * @param conn The connection object containing the client hello
- * @returns A handle to the s2n_client_hello structure holding the first client hello sent before a HelloRetryRequest. NULL is returned if no HelloRetryRequest occurred.
+ * @returns A handle to the s2n_client_hello structure holding the first client hello sent by the client. NULL is returned if a ClientHello has not yet been received and parsed.
  */
-S2N_API extern struct s2n_client_hello *s2n_connection_get_previous_client_hello(struct s2n_connection *conn);
+S2N_API extern struct s2n_client_hello *s2n_connection_get_initial_client_hello(struct s2n_connection *conn);
 
 /**
  * Creates an s2n_client_hello from bytes representing a ClientHello message.

--- a/bindings/rust/extended/s2n-tls/src/connection.rs
+++ b/bindings/rust/extended/s2n-tls/src/connection.rs
@@ -1030,6 +1030,28 @@ impl Connection {
         }))
     }
 
+    /// Retrieves the first ClientHello sent before a HelloRetryRequest.
+    ///
+    /// When a server sends a HelloRetryRequest, the client responds with a
+    /// second ClientHello. [`Connection::client_hello`] returns that second
+    /// (most recent) ClientHello. This method instead returns the original
+    /// ClientHello sent before the HelloRetryRequest, which is useful for
+    /// inspecting the values the client initially offered.
+    ///
+    /// Returns `None` when no HelloRetryRequest has occurred, since in that
+    /// case there is no earlier ClientHello.
+    ///
+    /// Corresponds to [`s2n_connection_get_previous_client_hello`].
+    pub fn previous_client_hello(&self) -> Option<&crate::client_hello::ClientHello> {
+        let handle = unsafe { s2n_connection_get_previous_client_hello(self.connection.as_ptr()) };
+        // A NULL return indicates that no HelloRetryRequest occurred, which is a
+        // valid (non-error) state, so it maps to None.
+        let handle = NonNull::new(handle)?;
+        Some(crate::client_hello::ClientHello::from_ptr(unsafe {
+            handle.as_ref()
+        }))
+    }
+
     /// Corresponds to [`s2n_client_hello_cb_done`].
     pub(crate) fn mark_client_hello_cb_done(&mut self) -> Result<(), Error> {
         unsafe {

--- a/bindings/rust/extended/s2n-tls/src/connection.rs
+++ b/bindings/rust/extended/s2n-tls/src/connection.rs
@@ -1030,25 +1030,23 @@ impl Connection {
         }))
     }
 
-    /// Retrieves the first ClientHello sent before a HelloRetryRequest.
+    /// Retrieves the first ClientHello sent by the client.
     ///
     /// When a server sends a HelloRetryRequest, the client responds with a
-    /// second ClientHello. [`Connection::client_hello`] returns that second
-    /// (most recent) ClientHello. This method instead returns the original
-    /// ClientHello sent before the HelloRetryRequest, which is useful for
-    /// inspecting the values the client initially offered.
+    /// second ClientHello, and [`Connection::client_hello`] returns that second
+    /// (most recent) ClientHello. This method instead always returns the first ClientHello
+    /// the client sent, which is useful for inspecting the values the client originally offered.
     ///
-    /// Returns `None` when no HelloRetryRequest has occurred, since in that
-    /// case there is no earlier ClientHello.
+    /// When no HelloRetryRequest occurs, only a single ClientHello is sent, so
+    /// this returns the same ClientHello as [`Connection::client_hello`].
     ///
-    /// Corresponds to [`s2n_connection_get_previous_client_hello`].
-    pub fn previous_client_hello(&self) -> Option<&crate::client_hello::ClientHello> {
-        let handle = unsafe { s2n_connection_get_previous_client_hello(self.connection.as_ptr()) };
-        // A NULL return indicates that no HelloRetryRequest occurred, which is a
-        // valid (non-error) state, so it maps to None.
-        let handle = NonNull::new(handle)?;
-        Some(crate::client_hello::ClientHello::from_ptr(unsafe {
-            handle.as_ref()
+    /// Corresponds to [`s2n_connection_get_initial_client_hello`].
+    pub fn initial_client_hello(&self) -> Result<&crate::client_hello::ClientHello, Error> {
+        let mut handle = unsafe {
+            s2n_connection_get_initial_client_hello(self.connection.as_ptr()).into_result()?
+        };
+        Ok(crate::client_hello::ClientHello::from_ptr(unsafe {
+            handle.as_mut()
         }))
     }
 

--- a/bindings/rust/extended/s2n-tls/src/testing/s2n_tls.rs
+++ b/bindings/rust/extended/s2n-tls/src/testing/s2n_tls.rs
@@ -27,25 +27,29 @@ mod tests {
         assert!(TestPair::handshake_with_config(&config).is_ok());
     }
 
-    // After a HelloRetryRequest, the first ClientHello (sent before the HRR) is
-    // retained and accessible via Connection::previous_client_hello, while
-    // Connection::client_hello returns the second ClientHello. Without an HRR,
-    // there is no previous ClientHello.
+    // Connection::initial_client_hello always returns the first ClientHello the
+    // client sent. After a HelloRetryRequest it returns the ClientHello sent
+    // before the HRR, distinct from the second ClientHello returned by
+    // Connection::client_hello. Without an HRR only one ClientHello is sent, so
+    // both accessors return the same message.
     #[test]
-    fn previous_client_hello_after_hrr() -> Result<(), Error> {
+    fn initial_client_hello() -> Result<(), Error> {
         // The server strongly prefers secp384r1.
         let server_policy = Policy::from_version("20251117")?;
         // The default TLS1.3 client offers a different group as its initial key
         // share, forcing the server to request a HelloRetryRequest.
         let client_policy = security::DEFAULT_TLS13;
 
-        // Without an HRR (both sides use the same policy), there is no previous ClientHello.
+        // Without an HRR (both sides use the same policy), the initial ClientHello
+        // is the same message as the current one.
         {
             let config = build_config(&client_policy)?;
             let mut pair = TestPair::from_config(&config);
             pair.handshake()?;
-            assert!(pair.server.client_hello().is_ok());
-            assert!(pair.server.previous_client_hello().is_none());
+
+            let current_raw = pair.server.client_hello()?.raw_message()?;
+            let initial_raw = pair.server.initial_client_hello()?.raw_message()?;
+            assert_eq!(current_raw, initial_raw);
         }
 
         // With an HRR, both ClientHellos are available and they are distinct.
@@ -56,17 +60,14 @@ mod tests {
             pair.handshake()?;
 
             let current = pair.server.client_hello()?;
-            let previous = pair
-                .server
-                .previous_client_hello()
-                .expect("previous client hello should be available after an HRR");
+            let initial = pair.server.initial_client_hello()?;
 
             // The two ClientHellos are genuinely different messages: the client
             // offers a new key share in its second ClientHello, so the raw
             // messages differ.
             let current_raw = current.raw_message()?;
-            let previous_raw = previous.raw_message()?;
-            assert_ne!(current_raw, previous_raw);
+            let initial_raw = initial.raw_message()?;
+            assert_ne!(current_raw, initial_raw);
         }
 
         Ok(())

--- a/bindings/rust/extended/s2n-tls/src/testing/s2n_tls.rs
+++ b/bindings/rust/extended/s2n-tls/src/testing/s2n_tls.rs
@@ -27,6 +27,51 @@ mod tests {
         assert!(TestPair::handshake_with_config(&config).is_ok());
     }
 
+    // After a HelloRetryRequest, the first ClientHello (sent before the HRR) is
+    // retained and accessible via Connection::previous_client_hello, while
+    // Connection::client_hello returns the second ClientHello. Without an HRR,
+    // there is no previous ClientHello.
+    #[test]
+    fn previous_client_hello_after_hrr() -> Result<(), Error> {
+        // The server strongly prefers secp384r1.
+        let server_policy = Policy::from_version("20251117")?;
+        // The default TLS1.3 client offers a different group as its initial key
+        // share, forcing the server to request a HelloRetryRequest.
+        let client_policy = security::DEFAULT_TLS13;
+
+        // Without an HRR (both sides use the same policy), there is no previous ClientHello.
+        {
+            let config = build_config(&client_policy)?;
+            let mut pair = TestPair::from_config(&config);
+            pair.handshake()?;
+            assert!(pair.server.client_hello().is_ok());
+            assert!(pair.server.previous_client_hello().is_none());
+        }
+
+        // With an HRR, both ClientHellos are available and they are distinct.
+        {
+            let client_config = build_config(&client_policy)?;
+            let server_config = build_config(&server_policy)?;
+            let mut pair = TestPair::from_configs(&client_config, &server_config);
+            pair.handshake()?;
+
+            let current = pair.server.client_hello()?;
+            let previous = pair
+                .server
+                .previous_client_hello()
+                .expect("previous client hello should be available after an HRR");
+
+            // The two ClientHellos are genuinely different messages: the client
+            // offers a new key share in its second ClientHello, so the raw
+            // messages differ.
+            let current_raw = current.raw_message()?;
+            let previous_raw = previous.raw_message()?;
+            assert_ne!(current_raw, previous_raw);
+        }
+
+        Ok(())
+    }
+
     #[test]
     fn kem_group_name_retrieval() -> Result<(), Error> {
         // PQ isn't supported

--- a/bindings/rust/standard/integration/src/handshake/hrr_client_hello.rs
+++ b/bindings/rust/standard/integration/src/handshake/hrr_client_hello.rs
@@ -4,7 +4,7 @@
 //! Tests confirming ClientHello retrieval after a Hello Retry Request.
 //!
 //! After an HRR, `client_hello()` returns the *second* client hello, while
-//! `previous_client_hello()` returns the *first* one sent before the HRR.
+//! `initial_client_hello()` returns the *first* one sent before the HRR.
 //!
 //! See: https://github.com/aws/s2n-tls/issues/5961
 
@@ -28,7 +28,7 @@ static STRONGLY_PREFERRED_GROUPS: LazyLock<Policy> =
 
 /// After a Hello Retry Request, s2n-tls exposes both client hellos:
 /// - `client_hello()` returns the second (most recent) client hello.
-/// - `previous_client_hello()` returns the first client hello — which contains
+/// - `initial_client_hello()` returns the first client hello — which contains
 ///   the original key share that triggered the HRR.
 ///
 /// This test:
@@ -38,7 +38,7 @@ static STRONGLY_PREFERRED_GROUPS: LazyLock<Policy> =
 /// 3. Confirms the first client hello has secp256r1, the second has secp384r1.
 /// 4. Gets the raw message bytes from both of s2n-tls's stored client hellos,
 ///    parses them with brass-aphid, and confirms the current client hello has
-///    the second key share (secp384r1) and the previous client hello has the
+///    the second key share (secp384r1) and the initial client hello has the
 ///    first key share (secp256r1).
 #[test]
 fn both_client_hellos_available_after_hrr() {
@@ -90,26 +90,26 @@ fn both_client_hellos_available_after_hrr() {
             vec![iana::constants::secp384r1]
         );
 
-        // --- s2n-tls API: the previous client hello is the first one ---
+        // --- s2n-tls API: the initial client hello is the first one ---
 
-        let previous = pair
+        let initial = pair
             .server
             .connection()
-            .previous_client_hello()
-            .expect("previous client hello should be available after an HRR");
-        let previous_raw = previous.raw_message().unwrap();
-        let (previous_parsed, _) = ClientHello::decode_from(&previous_raw).unwrap();
+            .initial_client_hello()
+            .expect("initial client hello should be available after an HRR");
+        let initial_raw = initial.raw_message().unwrap();
+        let (initial_parsed, _) = ClientHello::decode_from(&initial_raw).unwrap();
         assert_eq!(
-            previous_parsed.key_share().unwrap(),
+            initial_parsed.key_share().unwrap(),
             vec![iana::constants::secp256r1]
         );
     });
 }
 
-/// Without a Hello Retry Request, there is no previous client hello, so
-/// `previous_client_hello()` returns `None`.
+/// Without a Hello Retry Request, only a single client hello is sent, so
+/// `initial_client_hello()` returns the same message as `client_hello()`.
 #[test]
-fn no_previous_client_hello_without_hrr() {
+fn initial_client_hello_matches_current_without_hrr() {
     let mut pair: TlsConnPair<OpenSslConnection, S2NConnection> = {
         let mut configs =
             TlsConfigBuilderPair::<SslContextBuilder, s2n_tls::config::Builder>::default();
@@ -126,7 +126,21 @@ fn no_previous_client_hello_without_hrr() {
     pair.handshake().unwrap();
     pair.shutdown().unwrap();
 
-    // A client hello was received, but no HRR occurred.
-    assert!(pair.server.connection().client_hello().is_ok());
-    assert!(pair.server.connection().previous_client_hello().is_none());
+    // A single client hello was received, so the initial and current client
+    // hellos are the same message.
+    let current_raw = pair
+        .server
+        .connection()
+        .client_hello()
+        .unwrap()
+        .raw_message()
+        .unwrap();
+    let initial_raw = pair
+        .server
+        .connection()
+        .initial_client_hello()
+        .unwrap()
+        .raw_message()
+        .unwrap();
+    assert_eq!(current_raw, initial_raw);
 }

--- a/bindings/rust/standard/integration/src/handshake/hrr_client_hello.rs
+++ b/bindings/rust/standard/integration/src/handshake/hrr_client_hello.rs
@@ -110,25 +110,23 @@ fn both_client_hellos_available_after_hrr() {
 /// `previous_client_hello()` returns `None`.
 #[test]
 fn no_previous_client_hello_without_hrr() {
-    required_capability(&[Capability::Tls13], || {
-        let mut pair: TlsConnPair<OpenSslConnection, S2NConnection> = {
-            let mut configs =
-                TlsConfigBuilderPair::<SslContextBuilder, s2n_tls::config::Builder>::default();
-            configs
-                .server
-                .set_security_policy(&STRONGLY_PREFERRED_GROUPS)
-                .unwrap();
-            // The client offers the server's preferred group directly, so no
-            // HelloRetryRequest is needed.
-            configs.client.set_groups_list("secp384r1").unwrap();
-            configs.connection_pair()
-        };
+    let mut pair: TlsConnPair<OpenSslConnection, S2NConnection> = {
+        let mut configs =
+            TlsConfigBuilderPair::<SslContextBuilder, s2n_tls::config::Builder>::default();
+        configs
+            .server
+            .set_security_policy(&STRONGLY_PREFERRED_GROUPS)
+            .unwrap();
+        // The client offers the server's preferred group directly, so no
+        // HelloRetryRequest is needed.
+        configs.client.set_groups_list("secp384r1").unwrap();
+        configs.connection_pair()
+    };
 
-        pair.handshake().unwrap();
-        pair.shutdown().unwrap();
+    pair.handshake().unwrap();
+    pair.shutdown().unwrap();
 
-        // A client hello was received, but no HRR occurred.
-        assert!(pair.server.connection().client_hello().is_ok());
-        assert!(pair.server.connection().previous_client_hello().is_none());
-    });
+    // A client hello was received, but no HRR occurred.
+    assert!(pair.server.connection().client_hello().is_ok());
+    assert!(pair.server.connection().previous_client_hello().is_none());
 }

--- a/bindings/rust/standard/integration/src/handshake/hrr_client_hello.rs
+++ b/bindings/rust/standard/integration/src/handshake/hrr_client_hello.rs
@@ -1,8 +1,10 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-//! Test confirming that after a Hello Retry Request, `client_hello()` returns
-//! the *second* client hello — the first one is lost.
+//! Tests confirming ClientHello retrieval after a Hello Retry Request.
+//!
+//! After an HRR, `client_hello()` returns the *second* client hello, while
+//! `previous_client_hello()` returns the *first* one sent before the HRR.
 //!
 //! See: https://github.com/aws/s2n-tls/issues/5961
 
@@ -24,20 +26,22 @@ use crate::capability_check::{required_capability, Capability};
 static STRONGLY_PREFERRED_GROUPS: LazyLock<Policy> =
     LazyLock::new(|| Policy::from_version("20251117").unwrap());
 
-/// After a Hello Retry Request, s2n-tls only exposes the second client hello
-/// via `s2n_connection_get_client_hello`. The first client hello — which
-/// contains the original key share that triggered the HRR — is lost.
+/// After a Hello Retry Request, s2n-tls exposes both client hellos:
+/// - `client_hello()` returns the second (most recent) client hello.
+/// - `previous_client_hello()` returns the first client hello — which contains
+///   the original key share that triggered the HRR.
 ///
 /// This test:
 /// 1. Forces an HRR by having the client offer secp256r1 while the server
 ///    strongly prefers secp384r1.
 /// 2. Captures both client hellos from the wire.
 /// 3. Confirms the first client hello has secp256r1, the second has secp384r1.
-/// 4. Gets the raw message bytes from s2n-tls's stored client hello, parses
-///    them with brass-aphid, and confirms the key share matches the second
-///    wire client hello (secp384r1), not the first (secp256r1).
+/// 4. Gets the raw message bytes from both of s2n-tls's stored client hellos,
+///    parses them with brass-aphid, and confirms the current client hello has
+///    the second key share (secp384r1) and the previous client hello has the
+///    first key share (secp256r1).
 #[test]
-fn first_client_hello_not_available_after_hrr() {
+fn both_client_hellos_available_after_hrr() {
     required_capability(&[Capability::Tls13], || {
         let key_manager = KeyManager::new();
         let mut pair: TlsConnPair<OpenSslConnection, S2NConnection> = {
@@ -76,15 +80,55 @@ fn first_client_hello_not_available_after_hrr() {
         let second_ch_key_shares = client_hellos[1].key_share().unwrap();
         assert_eq!(second_ch_key_shares, vec![iana::constants::secp384r1]);
 
-        // --- s2n-tls API: parse the stored client hello and compare key shares ---
+        // --- s2n-tls API: the current client hello is the second one ---
 
-        let s2n_client_hello = pair.server.connection().client_hello().unwrap();
+        let current = pair.server.connection().client_hello().unwrap();
+        let current_raw = current.raw_message().unwrap();
+        let (current_parsed, _) = ClientHello::decode_from(&current_raw).unwrap();
+        assert_eq!(
+            current_parsed.key_share().unwrap(),
+            vec![iana::constants::secp384r1]
+        );
 
-        let raw = s2n_client_hello.raw_message().unwrap();
-        let (parsed, _) = ClientHello::decode_from(&raw).unwrap();
+        // --- s2n-tls API: the previous client hello is the first one ---
 
-        let stored_key_shares = parsed.key_share().unwrap();
+        let previous = pair
+            .server
+            .connection()
+            .previous_client_hello()
+            .expect("previous client hello should be available after an HRR");
+        let previous_raw = previous.raw_message().unwrap();
+        let (previous_parsed, _) = ClientHello::decode_from(&previous_raw).unwrap();
+        assert_eq!(
+            previous_parsed.key_share().unwrap(),
+            vec![iana::constants::secp256r1]
+        );
+    });
+}
 
-        assert_eq!(stored_key_shares, vec![iana::constants::secp384r1]);
+/// Without a Hello Retry Request, there is no previous client hello, so
+/// `previous_client_hello()` returns `None`.
+#[test]
+fn no_previous_client_hello_without_hrr() {
+    required_capability(&[Capability::Tls13], || {
+        let mut pair: TlsConnPair<OpenSslConnection, S2NConnection> = {
+            let mut configs =
+                TlsConfigBuilderPair::<SslContextBuilder, s2n_tls::config::Builder>::default();
+            configs
+                .server
+                .set_security_policy(&STRONGLY_PREFERRED_GROUPS)
+                .unwrap();
+            // The client offers the server's preferred group directly, so no
+            // HelloRetryRequest is needed.
+            configs.client.set_groups_list("secp384r1").unwrap();
+            configs.connection_pair()
+        };
+
+        pair.handshake().unwrap();
+        pair.shutdown().unwrap();
+
+        // A client hello was received, but no HRR occurred.
+        assert!(pair.server.connection().client_hello().is_ok());
+        assert!(pair.server.connection().previous_client_hello().is_none());
     });
 }

--- a/tests/unit/s2n_server_hello_retry_test.c
+++ b/tests/unit/s2n_server_hello_retry_test.c
@@ -519,6 +519,106 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_io_pair_close(&io_pair));
     };
 
+    /* After a HelloRetryRequest, the server retains the first ClientHello and it
+     * can be accessed via s2n_connection_get_previous_client_hello. It is distinct
+     * from the second (current) ClientHello returned by s2n_connection_get_client_hello.
+     */
+    {
+        DEFER_CLEANUP(struct s2n_config *config = s2n_config_new(), s2n_config_ptr_free);
+        EXPECT_NOT_NULL(config);
+        EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "default_tls13"));
+        EXPECT_SUCCESS(s2n_config_set_unsafe_for_testing(config));
+
+        DEFER_CLEANUP(struct s2n_cert_chain_and_key *tls13_chain_and_key = NULL,
+                s2n_cert_chain_and_key_ptr_free);
+        EXPECT_SUCCESS(s2n_test_cert_chain_and_key_new(&tls13_chain_and_key,
+                S2N_ECDSA_P384_PKCS1_CERT_CHAIN, S2N_ECDSA_P384_PKCS1_KEY));
+        EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(config, tls13_chain_and_key));
+
+        DEFER_CLEANUP(struct s2n_connection *server_conn = s2n_connection_new(S2N_SERVER),
+                s2n_connection_ptr_free);
+        DEFER_CLEANUP(struct s2n_connection *client_conn = s2n_connection_new(S2N_CLIENT),
+                s2n_connection_ptr_free);
+        EXPECT_NOT_NULL(server_conn);
+        EXPECT_NOT_NULL(client_conn);
+        EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config));
+        EXPECT_SUCCESS(s2n_connection_set_config(client_conn, config));
+
+        DEFER_CLEANUP(struct s2n_test_io_pair io_pair = { 0 }, s2n_io_pair_close);
+        EXPECT_SUCCESS(s2n_io_pair_init_non_blocking(&io_pair));
+        EXPECT_SUCCESS(s2n_connections_set_io_pair(client_conn, server_conn, &io_pair));
+
+        /* Force the HRR path */
+        client_conn->security_policy_override = &security_policy_test_tls13_retry;
+
+        EXPECT_SUCCESS(s2n_negotiate_test_server_and_client(server_conn, client_conn));
+        EXPECT_TRUE(IS_HELLO_RETRY_HANDSHAKE(server_conn));
+
+        /* The current ClientHello (the second one) is available */
+        struct s2n_client_hello *current = s2n_connection_get_client_hello(server_conn);
+        EXPECT_NOT_NULL(current);
+
+        /* The first ClientHello, sent before the HelloRetryRequest, is retained */
+        struct s2n_client_hello *previous = s2n_connection_get_previous_client_hello(server_conn);
+        EXPECT_NOT_NULL(previous);
+
+        /* The two ClientHellos are genuinely different messages. The client offers
+         * a different key share in its second ClientHello in response to the HRR,
+         * so the raw messages must differ.
+         */
+        ssize_t current_len = s2n_client_hello_get_raw_message_length(current);
+        ssize_t previous_len = s2n_client_hello_get_raw_message_length(previous);
+        EXPECT_TRUE(current_len > 0);
+        EXPECT_TRUE(previous_len > 0);
+
+        DEFER_CLEANUP(struct s2n_blob current_raw = { 0 }, s2n_free);
+        DEFER_CLEANUP(struct s2n_blob previous_raw = { 0 }, s2n_free);
+        EXPECT_SUCCESS(s2n_alloc(&current_raw, current_len));
+        EXPECT_SUCCESS(s2n_alloc(&previous_raw, previous_len));
+        EXPECT_EQUAL(s2n_client_hello_get_raw_message(current, current_raw.data, current_raw.size), current_len);
+        EXPECT_EQUAL(s2n_client_hello_get_raw_message(previous, previous_raw.data, previous_raw.size), previous_len);
+
+        bool identical = (current_len == previous_len)
+                && (memcmp(current_raw.data, previous_raw.data, current_len) == 0);
+        EXPECT_FALSE(identical);
+    };
+
+    /* Without a HelloRetryRequest, there is no previous ClientHello and
+     * s2n_connection_get_previous_client_hello returns NULL.
+     */
+    {
+        DEFER_CLEANUP(struct s2n_config *config = s2n_config_new(), s2n_config_ptr_free);
+        EXPECT_NOT_NULL(config);
+        EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "default_tls13"));
+        EXPECT_SUCCESS(s2n_config_set_unsafe_for_testing(config));
+
+        DEFER_CLEANUP(struct s2n_cert_chain_and_key *tls13_chain_and_key = NULL,
+                s2n_cert_chain_and_key_ptr_free);
+        EXPECT_SUCCESS(s2n_test_cert_chain_and_key_new(&tls13_chain_and_key,
+                S2N_ECDSA_P384_PKCS1_CERT_CHAIN, S2N_ECDSA_P384_PKCS1_KEY));
+        EXPECT_SUCCESS(s2n_config_add_cert_chain_and_key_to_store(config, tls13_chain_and_key));
+
+        DEFER_CLEANUP(struct s2n_connection *server_conn = s2n_connection_new(S2N_SERVER),
+                s2n_connection_ptr_free);
+        DEFER_CLEANUP(struct s2n_connection *client_conn = s2n_connection_new(S2N_CLIENT),
+                s2n_connection_ptr_free);
+        EXPECT_NOT_NULL(server_conn);
+        EXPECT_NOT_NULL(client_conn);
+        EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config));
+        EXPECT_SUCCESS(s2n_connection_set_config(client_conn, config));
+
+        DEFER_CLEANUP(struct s2n_test_io_pair io_pair = { 0 }, s2n_io_pair_close);
+        EXPECT_SUCCESS(s2n_io_pair_init_non_blocking(&io_pair));
+        EXPECT_SUCCESS(s2n_connections_set_io_pair(client_conn, server_conn, &io_pair));
+
+        EXPECT_SUCCESS(s2n_negotiate_test_server_and_client(server_conn, client_conn));
+        EXPECT_FALSE(IS_HELLO_RETRY_HANDSHAKE(server_conn));
+
+        /* A ClientHello was received, but no HelloRetryRequest occurred */
+        EXPECT_NOT_NULL(s2n_connection_get_client_hello(server_conn));
+        EXPECT_NULL(s2n_connection_get_previous_client_hello(server_conn));
+    };
+
     /* Hello Retry Request + (poll and no-poll) client hello callback */
     {
         EXPECT_OK(hello_retry_client_hello_cb_test());

--- a/tests/unit/s2n_server_hello_retry_test.c
+++ b/tests/unit/s2n_server_hello_retry_test.c
@@ -520,7 +520,7 @@ int main(int argc, char **argv)
     };
 
     /* After a HelloRetryRequest, the server retains the first ClientHello and it
-     * can be accessed via s2n_connection_get_previous_client_hello. It is distinct
+     * can be accessed via s2n_connection_get_initial_client_hello. It is distinct
      * from the second (current) ClientHello returned by s2n_connection_get_client_hello.
      */
     {
@@ -558,33 +558,34 @@ int main(int argc, char **argv)
         struct s2n_client_hello *current = s2n_connection_get_client_hello(server_conn);
         EXPECT_NOT_NULL(current);
 
-        /* The first ClientHello, sent before the HelloRetryRequest, is retained */
-        struct s2n_client_hello *previous = s2n_connection_get_previous_client_hello(server_conn);
-        EXPECT_NOT_NULL(previous);
+        /* The initial ClientHello, sent before the HelloRetryRequest, is retained */
+        struct s2n_client_hello *initial = s2n_connection_get_initial_client_hello(server_conn);
+        EXPECT_NOT_NULL(initial);
 
-        /* The two ClientHellos are genuinely different messages. The client offers
-         * a different key share in its second ClientHello in response to the HRR,
-         * so the raw messages must differ.
+        /* The current and initial ClientHellos are genuinely different messages.
+         * The client offers a different key share in its second ClientHello in
+         * response to the HRR, so the raw messages must differ.
          */
         ssize_t current_len = s2n_client_hello_get_raw_message_length(current);
-        ssize_t previous_len = s2n_client_hello_get_raw_message_length(previous);
+        ssize_t initial_len = s2n_client_hello_get_raw_message_length(initial);
         EXPECT_TRUE(current_len > 0);
-        EXPECT_TRUE(previous_len > 0);
+        EXPECT_TRUE(initial_len > 0);
 
         DEFER_CLEANUP(struct s2n_blob current_raw = { 0 }, s2n_free);
-        DEFER_CLEANUP(struct s2n_blob previous_raw = { 0 }, s2n_free);
+        DEFER_CLEANUP(struct s2n_blob initial_raw = { 0 }, s2n_free);
         EXPECT_SUCCESS(s2n_alloc(&current_raw, current_len));
-        EXPECT_SUCCESS(s2n_alloc(&previous_raw, previous_len));
+        EXPECT_SUCCESS(s2n_alloc(&initial_raw, initial_len));
         EXPECT_EQUAL(s2n_client_hello_get_raw_message(current, current_raw.data, current_raw.size), current_len);
-        EXPECT_EQUAL(s2n_client_hello_get_raw_message(previous, previous_raw.data, previous_raw.size), previous_len);
+        EXPECT_EQUAL(s2n_client_hello_get_raw_message(initial, initial_raw.data, initial_raw.size), initial_len);
 
-        bool identical = (current_len == previous_len)
-                && (memcmp(current_raw.data, previous_raw.data, current_len) == 0);
+        bool identical = (current_len == initial_len)
+                && (memcmp(current_raw.data, initial_raw.data, current_len) == 0);
         EXPECT_FALSE(identical);
     };
 
-    /* Without a HelloRetryRequest, there is no previous ClientHello and
-     * s2n_connection_get_previous_client_hello returns NULL.
+    /* Without a HelloRetryRequest, only a single ClientHello is sent, so
+     * s2n_connection_get_initial_client_hello returns the same ClientHello as
+     * s2n_connection_get_client_hello.
      */
     {
         DEFER_CLEANUP(struct s2n_config *config = s2n_config_new(), s2n_config_ptr_free);
@@ -614,9 +615,13 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_negotiate_test_server_and_client(server_conn, client_conn));
         EXPECT_FALSE(IS_HELLO_RETRY_HANDSHAKE(server_conn));
 
-        /* A ClientHello was received, but no HelloRetryRequest occurred */
-        EXPECT_NOT_NULL(s2n_connection_get_client_hello(server_conn));
-        EXPECT_NULL(s2n_connection_get_previous_client_hello(server_conn));
+        /* A single ClientHello was received, so the initial ClientHello is the
+         * same object as the current one.
+         */
+        struct s2n_client_hello *current = s2n_connection_get_client_hello(server_conn);
+        struct s2n_client_hello *initial = s2n_connection_get_initial_client_hello(server_conn);
+        EXPECT_NOT_NULL(current);
+        EXPECT_EQUAL(current, initial);
     };
 
     /* Hello Retry Request + (poll and no-poll) client hello callback */

--- a/tls/s2n_client_hello.c
+++ b/tls/s2n_client_hello.c
@@ -52,14 +52,19 @@ struct s2n_client_hello *s2n_connection_get_client_hello(struct s2n_connection *
     return &conn->client_hello;
 }
 
-struct s2n_client_hello *s2n_connection_get_previous_client_hello(struct s2n_connection *conn)
+struct s2n_client_hello *s2n_connection_get_initial_client_hello(struct s2n_connection *conn)
 {
     PTR_ENSURE_REF(conn);
-    if (conn->previous_client_hello == NULL || conn->previous_client_hello->parsed != 1) {
-        return NULL;
+
+    /* When a HelloRetryRequest occurs, the first ClientHello is preserved
+     * separately from the current (second) ClientHello.
+     */
+    if (conn->previous_client_hello != NULL && conn->previous_client_hello->parsed == 1) {
+        return conn->previous_client_hello;
     }
 
-    return conn->previous_client_hello;
+    /* Otherwise only a single ClientHello was sent, which is the initial one. */
+    return s2n_connection_get_client_hello(conn);
 }
 
 static uint32_t min_size(struct s2n_blob *blob, uint32_t max_length)
@@ -506,7 +511,7 @@ int s2n_parse_client_hello(struct s2n_connection *conn)
             &previous_hello_retry, &conn->client_hello, previous_client_random));
 
     /* On a hello retry handshake, retain the first ClientHello so that applications
-     * can inspect the original values via s2n_connection_get_previous_client_hello.
+     * can inspect the original values via s2n_connection_get_initial_client_hello.
      *
      * The `parsed` flag is set explicitly because s2n_server_hello_retry_send resets
      * it to 0 on the connection's client_hello before the second ClientHello arrives.

--- a/tls/s2n_client_hello.c
+++ b/tls/s2n_client_hello.c
@@ -52,6 +52,16 @@ struct s2n_client_hello *s2n_connection_get_client_hello(struct s2n_connection *
     return &conn->client_hello;
 }
 
+struct s2n_client_hello *s2n_connection_get_previous_client_hello(struct s2n_connection *conn)
+{
+    PTR_ENSURE_REF(conn);
+    if (conn->previous_client_hello.parsed != 1) {
+        return NULL;
+    }
+
+    return &conn->previous_client_hello;
+}
+
 static uint32_t min_size(struct s2n_blob *blob, uint32_t max_length)
 {
     return blob->size < max_length ? blob->size : max_length;
@@ -480,6 +490,20 @@ int s2n_parse_client_hello(struct s2n_connection *conn)
 
     POSIX_GUARD_RESULT(s2n_client_hello_verify_for_retry(conn,
             &previous_hello_retry, &conn->client_hello, previous_client_random));
+
+    /* On a hello retry handshake, retain the first ClientHello so that applications
+     * can inspect the original values via s2n_connection_get_previous_client_hello.
+     *
+     * The `parsed` flag is set explicitly because s2n_server_hello_retry_send resets
+     * it to 0 on the connection's client_hello before the second ClientHello arrives.
+     */
+    if (s2n_is_hello_retry_handshake(conn)) {
+        POSIX_GUARD(s2n_client_hello_free_raw_message(&conn->previous_client_hello));
+        conn->previous_client_hello = previous_hello_retry;
+        conn->previous_client_hello.parsed = 1;
+        previous_hello_retry = (struct s2n_client_hello){ 0 };
+    }
+
     return S2N_SUCCESS;
 }
 

--- a/tls/s2n_client_hello.c
+++ b/tls/s2n_client_hello.c
@@ -55,11 +55,11 @@ struct s2n_client_hello *s2n_connection_get_client_hello(struct s2n_connection *
 struct s2n_client_hello *s2n_connection_get_previous_client_hello(struct s2n_connection *conn)
 {
     PTR_ENSURE_REF(conn);
-    if (conn->previous_client_hello.parsed != 1) {
+    if (conn->previous_client_hello == NULL || conn->previous_client_hello->parsed != 1) {
         return NULL;
     }
 
-    return &conn->previous_client_hello;
+    return conn->previous_client_hello;
 }
 
 static uint32_t min_size(struct s2n_blob *blob, uint32_t max_length)
@@ -201,6 +201,20 @@ int s2n_client_hello_free_raw_message(struct s2n_client_hello *client_hello)
     client_hello->extensions.raw.data = NULL;
 
     return 0;
+}
+
+/* Frees a heap-allocated, connection-owned client_hello and NULLs the pointer. */
+S2N_RESULT s2n_client_hello_free_ptr(struct s2n_client_hello **ch)
+{
+    RESULT_ENSURE_REF(ch);
+    if (*ch == NULL) {
+        return S2N_RESULT_OK;
+    }
+
+    RESULT_GUARD_POSIX(s2n_client_hello_free_raw_message(*ch));
+    RESULT_GUARD_POSIX(s2n_free_object((uint8_t **) ch, sizeof(struct s2n_client_hello)));
+
+    return S2N_RESULT_OK;
 }
 
 int s2n_client_hello_free(struct s2n_client_hello **ch)
@@ -498,9 +512,20 @@ int s2n_parse_client_hello(struct s2n_connection *conn)
      * it to 0 on the connection's client_hello before the second ClientHello arrives.
      */
     if (s2n_is_hello_retry_handshake(conn)) {
-        POSIX_GUARD(s2n_client_hello_free_raw_message(&conn->previous_client_hello));
-        conn->previous_client_hello = previous_hello_retry;
-        conn->previous_client_hello.parsed = 1;
+        /* Only one HelloRetryRequest is allowed per handshake, so this is reached
+         * once and previous_client_hello has not been allocated yet.
+         */
+        POSIX_ENSURE(conn->previous_client_hello == NULL, S2N_ERR_INVALID_STATE);
+
+        DEFER_CLEANUP(struct s2n_blob mem = { 0 }, s2n_free);
+        POSIX_GUARD(s2n_alloc(&mem, sizeof(struct s2n_client_hello)));
+        POSIX_GUARD(s2n_blob_zero(&mem));
+
+        conn->previous_client_hello = (struct s2n_client_hello *) (void *) mem.data;
+        ZERO_TO_DISABLE_DEFER_CLEANUP(mem);
+
+        *conn->previous_client_hello = previous_hello_retry;
+        conn->previous_client_hello->parsed = 1;
         previous_hello_retry = (struct s2n_client_hello){ 0 };
     }
 

--- a/tls/s2n_client_hello.h
+++ b/tls/s2n_client_hello.h
@@ -76,7 +76,7 @@ int s2n_client_hello_free_raw_message(struct s2n_client_hello *client_hello);
 S2N_RESULT s2n_client_hello_free_ptr(struct s2n_client_hello **ch);
 
 struct s2n_client_hello *s2n_connection_get_client_hello(struct s2n_connection *conn);
-struct s2n_client_hello *s2n_connection_get_previous_client_hello(struct s2n_connection *conn);
+struct s2n_client_hello *s2n_connection_get_initial_client_hello(struct s2n_connection *conn);
 
 ssize_t s2n_client_hello_get_raw_message_length(struct s2n_client_hello *ch);
 ssize_t s2n_client_hello_get_raw_message(struct s2n_client_hello *ch, uint8_t *out, uint32_t max_length);

--- a/tls/s2n_client_hello.h
+++ b/tls/s2n_client_hello.h
@@ -73,6 +73,7 @@ struct s2n_client_hello {
 };
 
 int s2n_client_hello_free_raw_message(struct s2n_client_hello *client_hello);
+S2N_RESULT s2n_client_hello_free_ptr(struct s2n_client_hello **ch);
 
 struct s2n_client_hello *s2n_connection_get_client_hello(struct s2n_connection *conn);
 struct s2n_client_hello *s2n_connection_get_previous_client_hello(struct s2n_connection *conn);

--- a/tls/s2n_client_hello.h
+++ b/tls/s2n_client_hello.h
@@ -75,6 +75,7 @@ struct s2n_client_hello {
 int s2n_client_hello_free_raw_message(struct s2n_client_hello *client_hello);
 
 struct s2n_client_hello *s2n_connection_get_client_hello(struct s2n_connection *conn);
+struct s2n_client_hello *s2n_connection_get_previous_client_hello(struct s2n_connection *conn);
 
 ssize_t s2n_client_hello_get_raw_message_length(struct s2n_client_hello *ch);
 ssize_t s2n_client_hello_get_raw_message(struct s2n_client_hello *ch, uint8_t *out, uint32_t max_length);

--- a/tls/s2n_connection.c
+++ b/tls/s2n_connection.c
@@ -283,6 +283,7 @@ int s2n_connection_free(struct s2n_connection *conn)
     s2n_x509_validator_wipe(&conn->x509_validator);
     POSIX_GUARD_RESULT(s2n_async_offload_op_wipe(&conn->async_offload_op));
     POSIX_GUARD(s2n_client_hello_free_raw_message(&conn->client_hello));
+    POSIX_GUARD(s2n_client_hello_free_raw_message(&conn->previous_client_hello));
     POSIX_GUARD(s2n_free(&conn->application_protocols_overridden));
     POSIX_GUARD(s2n_free(&conn->cookie));
     POSIX_GUARD(s2n_free(&conn->cert_authorities));
@@ -453,10 +454,12 @@ int s2n_connection_free_handshake(struct s2n_connection *conn)
     /* Wipe the buffers we are going to free */
     POSIX_GUARD(s2n_stuffer_wipe(&conn->handshake.io));
     POSIX_GUARD(s2n_blob_zero(&conn->client_hello.raw_message));
+    POSIX_GUARD(s2n_blob_zero(&conn->previous_client_hello.raw_message));
 
     /* Truncate buffers to save memory, we are done with the handshake */
     POSIX_GUARD(s2n_stuffer_resize(&conn->handshake.io, 0));
     POSIX_GUARD(s2n_free(&conn->client_hello.raw_message));
+    POSIX_GUARD(s2n_free(&conn->previous_client_hello.raw_message));
 
     /* We can free extension data we no longer need */
     POSIX_GUARD(s2n_free(&conn->client_ticket));
@@ -522,6 +525,7 @@ int s2n_connection_wipe(struct s2n_connection *conn)
     POSIX_GUARD(s2n_stuffer_wipe(&conn->handshake.io));
     POSIX_GUARD(s2n_stuffer_wipe(&conn->post_handshake.in));
     POSIX_GUARD(s2n_blob_zero(&conn->client_hello.raw_message));
+    POSIX_GUARD(s2n_blob_zero(&conn->previous_client_hello.raw_message));
     POSIX_GUARD(s2n_stuffer_wipe(&conn->header_in));
     POSIX_GUARD(s2n_stuffer_wipe(&conn->buffer_in));
     POSIX_GUARD(s2n_stuffer_wipe(&conn->out));
@@ -551,6 +555,7 @@ int s2n_connection_wipe(struct s2n_connection *conn)
 
     /* Truncate the message buffers to save memory, we will dynamically resize it as needed */
     POSIX_GUARD(s2n_free(&conn->client_hello.raw_message));
+    POSIX_GUARD(s2n_free(&conn->previous_client_hello.raw_message));
     POSIX_GUARD(s2n_stuffer_resize(&conn->buffer_in, 0));
     POSIX_GUARD(s2n_stuffer_resize(&conn->out, 0));
 

--- a/tls/s2n_connection.c
+++ b/tls/s2n_connection.c
@@ -283,7 +283,7 @@ int s2n_connection_free(struct s2n_connection *conn)
     s2n_x509_validator_wipe(&conn->x509_validator);
     POSIX_GUARD_RESULT(s2n_async_offload_op_wipe(&conn->async_offload_op));
     POSIX_GUARD(s2n_client_hello_free_raw_message(&conn->client_hello));
-    POSIX_GUARD(s2n_client_hello_free_raw_message(&conn->previous_client_hello));
+    POSIX_GUARD_RESULT(s2n_client_hello_free_ptr(&conn->previous_client_hello));
     POSIX_GUARD(s2n_free(&conn->application_protocols_overridden));
     POSIX_GUARD(s2n_free(&conn->cookie));
     POSIX_GUARD(s2n_free(&conn->cert_authorities));
@@ -454,12 +454,11 @@ int s2n_connection_free_handshake(struct s2n_connection *conn)
     /* Wipe the buffers we are going to free */
     POSIX_GUARD(s2n_stuffer_wipe(&conn->handshake.io));
     POSIX_GUARD(s2n_blob_zero(&conn->client_hello.raw_message));
-    POSIX_GUARD(s2n_blob_zero(&conn->previous_client_hello.raw_message));
 
     /* Truncate buffers to save memory, we are done with the handshake */
     POSIX_GUARD(s2n_stuffer_resize(&conn->handshake.io, 0));
     POSIX_GUARD(s2n_free(&conn->client_hello.raw_message));
-    POSIX_GUARD(s2n_free(&conn->previous_client_hello.raw_message));
+    POSIX_GUARD_RESULT(s2n_client_hello_free_ptr(&conn->previous_client_hello));
 
     /* We can free extension data we no longer need */
     POSIX_GUARD(s2n_free(&conn->client_ticket));
@@ -525,7 +524,7 @@ int s2n_connection_wipe(struct s2n_connection *conn)
     POSIX_GUARD(s2n_stuffer_wipe(&conn->handshake.io));
     POSIX_GUARD(s2n_stuffer_wipe(&conn->post_handshake.in));
     POSIX_GUARD(s2n_blob_zero(&conn->client_hello.raw_message));
-    POSIX_GUARD(s2n_blob_zero(&conn->previous_client_hello.raw_message));
+    POSIX_GUARD_RESULT(s2n_client_hello_free_ptr(&conn->previous_client_hello));
     POSIX_GUARD(s2n_stuffer_wipe(&conn->header_in));
     POSIX_GUARD(s2n_stuffer_wipe(&conn->buffer_in));
     POSIX_GUARD(s2n_stuffer_wipe(&conn->out));
@@ -555,7 +554,6 @@ int s2n_connection_wipe(struct s2n_connection *conn)
 
     /* Truncate the message buffers to save memory, we will dynamically resize it as needed */
     POSIX_GUARD(s2n_free(&conn->client_hello.raw_message));
-    POSIX_GUARD(s2n_free(&conn->previous_client_hello.raw_message));
     POSIX_GUARD(s2n_stuffer_resize(&conn->buffer_in, 0));
     POSIX_GUARD(s2n_stuffer_resize(&conn->out, 0));
 

--- a/tls/s2n_connection.h
+++ b/tls/s2n_connection.h
@@ -350,7 +350,12 @@ struct s2n_connection {
 
     struct s2n_client_hello client_hello;
 
-    struct s2n_client_hello previous_client_hello;
+    /* The first ClientHello sent before a HelloRetryRequest. It is a pointer,
+     * rather than embedded by value, to avoid growing every connection by the
+     * size of an s2n_client_hello. It is only allocated when a HelloRetryRequest
+     * occurs, and is NULL otherwise.
+     */
+    struct s2n_client_hello *previous_client_hello;
 
     struct s2n_x509_validator x509_validator;
 

--- a/tls/s2n_connection.h
+++ b/tls/s2n_connection.h
@@ -350,6 +350,8 @@ struct s2n_connection {
 
     struct s2n_client_hello client_hello;
 
+    struct s2n_client_hello previous_client_hello;
+
     struct s2n_x509_validator x509_validator;
 
     struct s2n_async_offload_op async_offload_op;


### PR DESCRIPTION
# Goal

Store the original client hello in the s2n_connection struct so that it can be later retrieved by applications.

## Why

This feature allows users to inspect what was originally sent.

## How

This PR adds a new field in s2n_connection called previous_client_hello to store the orginal client hello when a Hello Retry Request happened. This PR also expose one more API s2n_connection_get_previous_client_hello along with its corresponding rust bindings to access the original client hello.

## Callouts

I decide that the s2n_connection_get_previous_client_hello API will reuturn NULL if Hello Retry Request hasn't happened instead of erroring.

### Memory Discussion

My approach stores the original ClientHello on the heap and keeps a pointer to it on the connection. This minimizes the memory carried by every `s2n_connection`, since the pointer only costs 8 bytes and the ClientHello itself is allocated lazily. It will only be allocated when a HelloRetryRequest actually occurs.

The alternative was to embed a second ClientHello directly in the `s2n_connection` struct. That would grow every connection by 840 bytes (`sizeof(struct s2n_client_hello)`), even for the majority of handshakes that never trigger a HelloRetryRequest, and it exceeds the upper limit enforced by `s2n_connection_size_test`:
https://github.com/aws/s2n-tls/actions/runs/29447402424/job/87461194156

For that reason, I chose to store the ClientHello on the heap and expose it through a pointer.

## Testing

I added both C and Rust tests for this feature:
1. NULL is returned when no HRR happened.
2. When HRR happens, application (client) can access both the original client hello message and the current client hello message.

### Related

resolves https://github.com/aws/s2n-tls/issues/5961.

Release Summary: Applications can now access both the current and the original Client Hello message on Hello Retry Request.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
