### PR TITLE
fix: prefer clang for libs2n LTO to work under rust-lld

### DIFF
--- a/bindings/rust/extended/s2n-tls-sys/Cargo.toml
+++ b/bindings/rust/extended/s2n-tls-sys/Cargo.toml
@@ -53,6 +53,8 @@ libc = "0.2.121"
 
 [build-dependencies]
 cc = { version = "1.2.26", features = ["parallel"] }
+# Used to detect the active rustc version in build.rs (rust-lld LTO warning).
+rustc_version = "0.4"
 
 [dev-dependencies]
 home = "=0.5.5" # newer versions require rust 1.70, see https://github.com/aws/s2n-tls/issues/4395

--- a/bindings/rust/extended/s2n-tls-sys/README.md
+++ b/bindings/rust/extended/s2n-tls-sys/README.md
@@ -35,3 +35,39 @@ export LD_LIBRARY_PATH=$S2N_TLS_LIB_DIR:$LD_LIBRARY_PATH
 ```
 cargo build
 ```
+
+## Performance note: Rust ≥ 1.90, LTO, and the linker
+
+`s2n-tls-sys`'s build script compiles the vendored `libs2n` C code with link-time optimization (LTO) in release/optimized builds. The two compilers emit different kinds of LTO objects, and the linkers consume them differently:
+
+- **GCC** emits fat-LTO objects (GIMPLE + native code). GNU `bfd` performs LTO on them; other linkers (including `rust-lld`) ignore the LTO and link the embedded native code — the link succeeds, just without LTO.
+- **Clang** emits LLVM bitcode. `rust-lld` consumes it, but a plain GNU `ld` cannot and the link **fails** with "File format not recognized" (this is why an earlier change, [#3968](https://github.com/aws/s2n-tls/pull/3968), restricted LTO to GCC).
+
+Starting with Rust 1.90, the default linker on `x86_64-unknown-linux-gnu` [switched from GNU `bfd` to `rust-lld`](https://blog.rust-lang.org/2025/09/01/rust-lld-on-1.90.0-stable/). Since `rust-lld` can't consume GCC's fat-LTO objects, a GCC build on that target silently drops the LTO pass, costing ~17-22 µs per TLS handshake (~2-4%).
+
+### What the build script does automatically
+
+The build script picks the LTO approach based on the linker:
+
+- **When `rust-lld` is the linker** (the default on `x86_64-unknown-linux-gnu`, Rust ≥ 1.90): it **prefers Clang** — if `CC` is unset and `clang` is on `PATH`, it compiles `libs2n` with Clang so `rust-lld` can perform LTO. Installing `clang` is all most consumers need to do.
+- **Otherwise** (GNU `bfd`, macOS `ld`, aarch64, etc.): it uses GCC fat-LTO objects, which link with any linker. Clang bitcode LTO is deliberately *not* enabled here, to avoid the GNU `ld` link failure above.
+
+### If you must use GCC on Rust ≥ 1.90
+
+If the build falls back to GCC on `x86_64-unknown-linux-gnu` with Rust ≥ 1.90, the build script emits a `cargo:warning` because LTO will be silently dropped. To restore LTO you have two options:
+
+1. **Install `clang`** (recommended) and the build script will pick it up automatically, no flags needed.
+2. **Opt out of `rust-lld`** so the GNU `bfd` linker is used, which can consume GCC's fat-LTO objects:
+
+   ```
+   RUSTFLAGS="-Clinker-features=-lld"
+   ```
+
+   Or in `.cargo/config.toml`:
+
+   ```toml
+   [target.x86_64-unknown-linux-gnu]
+   rustflags = ["-Clinker-features=-lld"]
+   ```
+
+Consumers on aarch64 or non-Linux targets are unaffected because only `x86_64-unknown-linux-gnu` has the `rust-lld` default.

--- a/bindings/rust/extended/s2n-tls-sys/build.rs
+++ b/bindings/rust/extended/s2n-tls-sys/build.rs
@@ -132,14 +132,8 @@ fn build_vendored() {
                 // GCC + rust-lld: the fat-LTO objects are ignored by rust-lld,
                 // so the LTO pass is silently dropped (~2-4% per TLS handshake).
                 println!(
-                    "cargo:warning=s2n-tls-sys: cross-file LTO of the vendored libs2n is \
-                     silently disabled. Clang was not found, so the C code was built with \
-                     GCC fat-LTO objects, which the default rust-lld linker (Rust >= 1.90 on \
-                     x86_64-unknown-linux-gnu) cannot consume, costing ~2-4% per TLS handshake. \
-                     Install clang (preferred, restores LTO automatically) or build with \
-                     RUSTFLAGS=\"-Clinker-features=-lld\" to fall back to the GNU bfd linker. \
-                     For details see: \
-                     https://github.com/aws/s2n-tls/blob/main/bindings/rust/extended/s2n-tls-sys/README.md#performance-note-rust--190-lto-and-the-linker"
+                    "cargo:warning=s2n-tls-sys: unable to find clang, falling back to GCC \
+                    and disabling LTO. Expecting a 2-4% performance regression."
                 );
             }
         }

--- a/bindings/rust/extended/s2n-tls-sys/build.rs
+++ b/bindings/rust/extended/s2n-tls-sys/build.rs
@@ -115,16 +115,20 @@ fn build_vendored() {
         //
         // Since Rust 1.90, rust-lld is the default linker on
         // x86_64-unknown-linux-gnu. rust-lld can't consume GCC's fat-LTO
-        // objects, so on that target we prefer Clang to keep LTO working; if
-        // only GCC is available there, LTO is silently dropped and we warn.
-        if rust_lld_is_default() {
-            if build.get_compiler().is_like_clang() || try_prefer_clang(&mut build) {
-                build.flag_if_supported("-flto");
-            } else if build.get_compiler().is_like_gnu() {
-                build
-                    .flag_if_supported("-flto")
-                    .flag_if_supported("-ffat-lto-objects");
+        // objects, so `builder()` prefers Clang there to keep LTO working; if
+        // only GCC is available, LTO is silently dropped and we warn.
+        let compiler = build.get_compiler();
+        if compiler.is_like_clang() && rust_lld_is_default() {
+            // Clang + rust-lld: Clang's LLVM bitcode LTO objects are what
+            // rust-lld can optimize. We require rust-lld here because that
+            // bitcode fails to link with a plain GNU `ld` (see #3968).
+            build.flag_if_supported("-flto");
+        } else if compiler.is_like_gnu() {
+            build
+                .flag_if_supported("-flto")
+                .flag_if_supported("-ffat-lto-objects");
 
+            if rust_lld_is_default() {
                 // GCC + rust-lld: the fat-LTO objects are ignored by rust-lld,
                 // so the LTO pass is silently dropped (~2-4% per TLS handshake).
                 println!(
@@ -138,14 +142,6 @@ fn build_vendored() {
                      https://github.com/aws/s2n-tls/blob/main/bindings/rust/extended/s2n-tls-sys/README.md#performance-note-rust--190-lto-and-the-linker"
                 );
             }
-        } else if build.get_compiler().is_like_gnu() {
-            // Non-rust-lld linker (e.g. GNU bfd, macOS ld). GCC fat-LTO objects
-            // link everywhere. We deliberately do NOT add `-flto` for Clang
-            // here: its bitcode would fail to link with a plain GNU `ld`
-            // (see #3968), and pre-1.90 this target used bfd by default.
-            build
-                .flag_if_supported("-flto")
-                .flag_if_supported("-ffat-lto-objects");
         }
     }
 
@@ -203,13 +199,14 @@ fn build_vendored() {
     println!("cargo:include={}", include_dir.display());
 }
 
-/// Try to switch `build` to use Clang so that cross-file LTO works under
-/// rust-lld (the default linker on x86_64-unknown-linux-gnu since Rust 1.90).
+/// Returns true if we should compile libs2n with Clang: `clang` is on PATH and
+/// runnable, and the user hasn't pinned a compiler via `CC` / `CC_<target>`.
 ///
-/// Returns true if Clang was selected. This is a no-op (returns false) when:
-///   * the user explicitly set `CC` or
-///   * `clang` isn't on PATH / isn't runnable.
-fn try_prefer_clang(build: &mut cc::Build) -> bool {
+/// This is only a *recommendation*; the caller decides whether to act on it
+/// (we only prefer Clang when rust-lld is the linker). The choice is made once
+/// and applied to both the feature detector and the actual compilation.
+fn clang_available_and_unpinned() -> bool {
+    // Respect an explicitly pinned compiler.
     let target = std::env::var("TARGET").unwrap_or_default();
     if std::env::var("CC").is_ok()
         || std::env::var(format!("CC_{target}")).is_ok()
@@ -218,17 +215,12 @@ fn try_prefer_clang(build: &mut cc::Build) -> bool {
         return false;
     }
 
-    let clang_runs = std::process::Command::new("clang")
+    // Only use Clang if it's actually present and runnable.
+    std::process::Command::new("clang")
         .arg("--version")
         .output()
         .map(|out| out.status.success())
-        .unwrap_or(false);
-    if !clang_runs {
-        return false;
-    }
-
-    build.compiler("clang");
-    true
+        .unwrap_or(false)
 }
 
 /// Returns true if the final linker for this build is (most likely) rust-lld.
@@ -266,6 +258,19 @@ fn rust_lld_is_default() -> bool {
 
 fn builder(libcrypto: &Libcrypto) -> cc::Build {
     let mut build = cc::Build::new();
+
+    // Select the C compiler in one place so that every `cc::Build` produced
+    // here (both the feature detector and the compilation build) agrees on the
+    // compiler. Otherwise feature detection could probe with one compiler while
+    // the code is compiled with another, baking in mismatched #defines.
+    //
+    // Prefer Clang when rust-lld is the linker (the default on
+    // x86_64-unknown-linux-gnu since Rust 1.90): Clang emits LLVM bitcode LTO
+    // objects that rust-lld can optimize, whereas GCC's fat-LTO objects can't
+    // be. We don't override an explicitly pinned `CC`.
+    if rust_lld_is_default() && clang_available_and_unpinned() {
+        build.compiler("clang");
+    }
 
     let includes = [&libcrypto.include, "lib", "lib/api"];
     if let Ok(cflags) = std::env::var("CFLAGS") {

--- a/bindings/rust/extended/s2n-tls-sys/build.rs
+++ b/bindings/rust/extended/s2n-tls-sys/build.rs
@@ -99,20 +99,50 @@ fn build_vendored() {
         build.define("S2N_BUILD_RELEASE", "1");
         build.define("NDEBUG", "1");
 
-        // Enable cross-file LTO of libs2n when the toolchain can actually
-        // perform it.
+        // Enable cross-file LTO of libs2n, choosing an approach that is safe
+        // for the compiler + linker combination in use:
+        //
+        //  * GCC emits fat-LTO objects (`-ffat-lto-objects`) embedding both
+        //    GIMPLE and native code. GNU bfd performs LTO on them; other
+        //    linkers (including rust-lld) ignore the LTO and just link the
+        //    embedded native code with no LTO, but the link succeeds. Safe with
+        //    any linker.
+        //
+        //  * Clang emits LLVM bitcode (`-flto`). rust-lld consumes it, but a
+        //    plain GNU `ld` cannot and the link FAILS with "File format not
+        //    recognized" (this is why #3968 restricted LTO to GCC). So we only
+        //    enable Clang LTO when we know the linker is rust-lld.
         //
         // Since Rust 1.90, rust-lld is the default linker on
-        // x86_64-unknown-linux-gnu. rust-lld can consume Clang's LLVM-bitcode
-        // LTO objects, but NOT GCC's GIMPLE fat-LTO sections, so a GCC +
-        // rust-lld build silently drops the LTO pass (costing ~2-4% per TLS
-        // handshake). Clang + rust-lld works, and GCC + bfd works.
-        //
-        // So: prefer Clang when available (works with every linker), and only
-        // fall back to GCC's fat-LTO objects otherwise (works with bfd).
-        if build.get_compiler().is_like_clang() || try_prefer_clang(&mut build) {
-            build.flag_if_supported("-flto");
+        // x86_64-unknown-linux-gnu. rust-lld can't consume GCC's fat-LTO
+        // objects, so on that target we prefer Clang to keep LTO working; if
+        // only GCC is available there, LTO is silently dropped and we warn.
+        if rust_lld_is_default() {
+            if build.get_compiler().is_like_clang() || try_prefer_clang(&mut build) {
+                build.flag_if_supported("-flto");
+            } else if build.get_compiler().is_like_gnu() {
+                build
+                    .flag_if_supported("-flto")
+                    .flag_if_supported("-ffat-lto-objects");
+
+                // GCC + rust-lld: the fat-LTO objects are ignored by rust-lld,
+                // so the LTO pass is silently dropped (~2-4% per TLS handshake).
+                println!(
+                    "cargo:warning=s2n-tls-sys: cross-file LTO of the vendored libs2n is \
+                     silently disabled. Clang was not found, so the C code was built with \
+                     GCC fat-LTO objects, which the default rust-lld linker (Rust >= 1.90 on \
+                     x86_64-unknown-linux-gnu) cannot consume, costing ~2-4% per TLS handshake. \
+                     Install clang (preferred, restores LTO automatically) or build with \
+                     RUSTFLAGS=\"-Clinker-features=-lld\" to fall back to the GNU bfd linker. \
+                     For details see: \
+                     https://github.com/aws/s2n-tls/blob/main/bindings/rust/extended/s2n-tls-sys/README.md#performance-note-rust--190-and-cross-file-lto"
+                );
+            }
         } else if build.get_compiler().is_like_gnu() {
+            // Non-rust-lld linker (e.g. GNU bfd, macOS ld). GCC fat-LTO objects
+            // link everywhere. We deliberately do NOT add `-flto` for Clang
+            // here: its bitcode would fail to link with a plain GNU `ld`
+            // (see #3968), and pre-1.90 this target used bfd by default.
             build
                 .flag_if_supported("-flto")
                 .flag_if_supported("-ffat-lto-objects");
@@ -199,6 +229,39 @@ fn try_prefer_clang(build: &mut cc::Build) -> bool {
 
     build.compiler("clang");
     true
+}
+
+/// Returns true if the final linker for this build is (most likely) rust-lld.
+///
+/// This gates the LTO strategy: rust-lld can consume Clang's LLVM bitcode but
+/// not GCC's fat-LTO objects, whereas a plain GNU `ld` is the opposite (it
+/// fails on Clang bitcode, see #3968). rust-lld became the default linker on
+/// x86_64-unknown-linux-gnu in Rust 1.90.
+///
+/// Every check fails open: if we can't positively confirm rust-lld is in use,
+/// we return false and take the GCC-fat-LTO path that links with any linker.
+fn rust_lld_is_default() -> bool {
+    // Only x86_64-unknown-linux-gnu defaults to rust-lld.
+    if std::env::var("TARGET").as_deref() != Ok("x86_64-unknown-linux-gnu") {
+        return false;
+    }
+
+    // If the user already opted out of rust-lld, the GNU bfd linker will
+    // consume the fat-LTO objects, so there's nothing to warn about.
+    // CARGO_ENCODED_RUSTFLAGS captures both RUSTFLAGS and build.rustflags /
+    // target.<triple>.rustflags from .cargo/config.toml.
+    if let Ok(flags) = std::env::var("CARGO_ENCODED_RUSTFLAGS") {
+        if flags.contains("linker-features=-lld") {
+            return false;
+        }
+    }
+
+    // rust-lld only became the default on this target in Rust 1.90.
+    // Fail open: if the version can't be determined, stay silent.
+    match rustc_version::version() {
+        Ok(version) => version >= rustc_version::Version::new(1, 90, 0),
+        Err(_) => false,
+    }
 }
 
 fn builder(libcrypto: &Libcrypto) -> cc::Build {

--- a/bindings/rust/extended/s2n-tls-sys/build.rs
+++ b/bindings/rust/extended/s2n-tls-sys/build.rs
@@ -135,7 +135,7 @@ fn build_vendored() {
                      Install clang (preferred, restores LTO automatically) or build with \
                      RUSTFLAGS=\"-Clinker-features=-lld\" to fall back to the GNU bfd linker. \
                      For details see: \
-                     https://github.com/aws/s2n-tls/blob/main/bindings/rust/extended/s2n-tls-sys/README.md#performance-note-rust--190-and-cross-file-lto"
+                     https://github.com/aws/s2n-tls/blob/main/bindings/rust/extended/s2n-tls-sys/README.md#performance-note-rust--190-lto-and-the-linker"
                 );
             }
         } else if build.get_compiler().is_like_gnu() {

--- a/bindings/rust/extended/s2n-tls-sys/build.rs
+++ b/bindings/rust/extended/s2n-tls-sys/build.rs
@@ -99,8 +99,20 @@ fn build_vendored() {
         build.define("S2N_BUILD_RELEASE", "1");
         build.define("NDEBUG", "1");
 
-        // build s2n-tls with LTO if supported
-        if build.get_compiler().is_like_gnu() {
+        // Enable cross-file LTO of libs2n when the toolchain can actually
+        // perform it.
+        //
+        // Since Rust 1.90, rust-lld is the default linker on
+        // x86_64-unknown-linux-gnu. rust-lld can consume Clang's LLVM-bitcode
+        // LTO objects, but NOT GCC's GIMPLE fat-LTO sections, so a GCC +
+        // rust-lld build silently drops the LTO pass (costing ~2-4% per TLS
+        // handshake). Clang + rust-lld works, and GCC + bfd works.
+        //
+        // So: prefer Clang when available (works with every linker), and only
+        // fall back to GCC's fat-LTO objects otherwise (works with bfd).
+        if build.get_compiler().is_like_clang() || try_prefer_clang(&mut build) {
+            build.flag_if_supported("-flto");
+        } else if build.get_compiler().is_like_gnu() {
             build
                 .flag_if_supported("-flto")
                 .flag_if_supported("-ffat-lto-objects");
@@ -159,6 +171,34 @@ fn build_vendored() {
     std::fs::create_dir_all(&include_dir).unwrap();
     std::fs::copy("lib/api/s2n.h", include_dir.join("s2n.h")).unwrap();
     println!("cargo:include={}", include_dir.display());
+}
+
+/// Try to switch `build` to use Clang so that cross-file LTO works under
+/// rust-lld (the default linker on x86_64-unknown-linux-gnu since Rust 1.90).
+///
+/// Returns true if Clang was selected. This is a no-op (returns false) when:
+///   * the user explicitly set `CC` or
+///   * `clang` isn't on PATH / isn't runnable.
+fn try_prefer_clang(build: &mut cc::Build) -> bool {
+    let target = std::env::var("TARGET").unwrap_or_default();
+    if std::env::var("CC").is_ok()
+        || std::env::var(format!("CC_{target}")).is_ok()
+        || std::env::var(format!("CC_{}", target.replace('-', "_"))).is_ok()
+    {
+        return false;
+    }
+
+    let clang_runs = std::process::Command::new("clang")
+        .arg("--version")
+        .output()
+        .map(|out| out.status.success())
+        .unwrap_or(false);
+    if !clang_runs {
+        return false;
+    }
+
+    build.compiler("clang");
+    true
 }
 
 fn builder(libcrypto: &Libcrypto) -> cc::Build {

--- a/bindings/rust/extended/s2n-tls-sys/templates/Cargo.template
+++ b/bindings/rust/extended/s2n-tls-sys/templates/Cargo.template
@@ -43,6 +43,8 @@ libc = "0.2.121"
 
 [build-dependencies]
 cc = { version = "1.2.26", features = ["parallel"] }
+# Used to detect the active rustc version in build.rs (rust-lld LTO warning).
+rustc_version = "0.4"
 
 [dev-dependencies]
 home = "=0.5.5" # newer versions require rust 1.70, see https://github.com/aws/s2n-tls/issues/4395

--- a/codebuild/bin/install_ubuntu_dependencies.sh
+++ b/codebuild/bin/install_ubuntu_dependencies.sh
@@ -40,7 +40,7 @@ base_packages() {
   add-apt-repository ppa:longsleep/golang-backports -y
   apt-get update -o Acquire::CompressionTypes::Order::=gz
 
-  DEPENDENCIES="unzip make indent iproute2 kwstyle libssl-dev net-tools tcpdump valgrind lcov m4 nettle-dev nettle-bin pkg-config psmisc gcc g++ zlib1g-dev python3-pip python3-testresources llvm libclang-dev curl shellcheck git tox cmake libtool ninja-build golang-go quilt jq apache2"
+  DEPENDENCIES="unzip make indent iproute2 kwstyle libssl-dev net-tools tcpdump valgrind lcov m4 nettle-dev nettle-bin pkg-config psmisc gcc g++ clang zlib1g-dev python3-pip python3-testresources llvm libclang-dev curl shellcheck git tox cmake libtool ninja-build golang-go quilt jq apache2"
   if [[ -n "${GCC_VERSION:-}" ]] && [[ "${GCC_VERSION:-}" != "NONE" ]]; then
     DEPENDENCIES+=" gcc-$GCC_VERSION g++-$GCC_VERSION";
   fi


### PR DESCRIPTION
# Goal
Restore cross-file LTO of the vendored `libs2n` on Rust ≥ 1.90, and enable it for Clang where safe.

## Why
[Rust 1.90 made `rust-lld` the default linker on `x86_64-unknown-linux-gnu`](https://blog.rust-lang.org/2025/09/18/Rust-1.90.0/#lld-is-now-the-default-linker-on-x86-64-unknown-linux-gnu). `rust-lld` can't consume GCC's fat-LTO objects, so the GCC-only LTO path silently dropped LTO (~2-4% per handshake), see upstream issue report: https://github.com/rust-lang/rust/issues/159355. Clang never got LTO either: #3968 restricted it to GCC because Clang bitcode fails to link with GNU `ld`. `rust-lld` _can_ link that bitcode, so we can now give Clang LTO on that target.

## How
1. `s2n-tls-sys/build.rs` picks LTO by linker:
   - **rust-lld** (x86_64-linux, Rust ≥ 1.90): prefer Clang (if `CC` unset and `clang` on `PATH`) with `-flto`; if only GCC, fall back to GCC fat-LTO and emit a `cargo:warning`.
   - **Otherwise** (bfd, macOS, aarch64, `-lld` opt-out): GCC fat-LTO, which links anywhere. Clang LTO deliberately not enabled here (avoids the #3968 `ld` failure).
2. Add `clang` to `install_ubuntu_dependencies.sh`; document behavior + `RUSTFLAGS="-Clinker-features=-lld"` fallback in `s2n-tls-sys/README.md`.

## Callouts
- Clang builds are now LTO'd (previously GCC-only), but only on the rust-lld target; Clang elsewhere is unchanged, preserving current behavior.
- Adds a `rustc_version` build-dependency (gates the rust-lld version check).

## Testing
Ran the s2n-tls bench CodeBuild job (x86_64), confirmed Clang is selected and handshakes improve vs. the GCC + rust-lld baseline. Non-rust-lld paths preserve prior GCC-fat-LTO / Clang-no-LTO behavior.

### Related
Supersedes #5991 (disabled `rust-lld` in the bench build); this fixes the root cause for all consumers. Safely reverses #3968's Clang restriction for the rust-lld case.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
