### PR TITLE
fix(duvet): Correct CCS quote attribution to RFC 8446 section 5

### DIFF
--- a/tls/s2n_record_read.c
+++ b/tls/s2n_record_read.c
@@ -216,13 +216,10 @@ static bool s2n_is_tls13_plaintext_content(struct s2n_connection *conn, uint8_t 
     /*
      *= https://www.rfc-editor.org/rfc/rfc8446#section-5
      *# An implementation may receive an unencrypted record of type
-     *# change_cipher_spec
-     *
-     *= https://www.rfc-editor.org/rfc/rfc8446#appendix-D.4
-     *# An implementation may receive an unencrypted record of type
-     *# change_cipher_spec at any time after the first ClientHello
-     *# message has been sent or received and before the peer's
-     *# Finished message has been received.
+     *# change_cipher_spec consisting of the single byte value 0x01
+     *# at any time after the first ClientHello message has been
+     *# sent or received and before the peer's Finished message has
+     *# been received
      *
      * CCS is only valid during the handshake. Once the handshake is
      * complete, a CCS record is a protocol violation and must not be


### PR DESCRIPTION

# Goal

Fix failing duvet CI check on main by correcting an RFC quote attribution.

## Why

The duvet compliance check fails because `tls/s2n_record_read.c:221` attributes a quote to `rfc8446#appendix-D.4`, but that text does not exist in Appendix D.4. Duvet cannot find the quoted substring at that URL.

## How

The quoted text ("An implementation may receive an unencrypted record of type change_cipher_spec at any time after the first ClientHello...") lives in RFC 8446 Section 5, not Appendix D.4. 
## Callouts

No behavioral change. Comment-only fix.

## Testing

Duvet CI will validate the quote matches the RFC text at the referenced URL.

### Related

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
