### PR TITLE
test: add record integrity tests

### DIFF
--- a/bindings/rust/standard/integration/src/handshake/encrypted_record_integrity.rs
+++ b/bindings/rust/standard/integration/src/handshake/encrypted_record_integrity.rs
@@ -1,0 +1,129 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Verify that any bit-flip mutation in an encrypted TLS application data
+//! record causes decryption to fail.
+
+use crate::capability_check::{required_capability, Capability};
+use s2n_tls::{
+    config,
+    security::Policy,
+    testing::{self, TestPair},
+};
+use std::{io::Write, task::Poll};
+
+const APP_DATA: &[u8] = b"hello";
+const APP_DATA_LEN: usize = APP_DATA.len();
+
+/// Perform a handshake, have the server send application data, and return the
+/// pair along with the encrypted record bytes from the wire.
+fn encrypted_record(config: &config::Config) -> (TestPair, Vec<u8>) {
+    let mut pair = TestPair::from_config(config);
+    pair.handshake().unwrap();
+
+    assert!(matches!(
+        pair.server.poll_send(APP_DATA),
+        Poll::Ready(Ok(APP_DATA_LEN))
+    ));
+
+    let record: Vec<u8> = pair.io.server_tx_stream.borrow_mut().drain(..).collect();
+    (pair, record)
+}
+
+/// Assert that flipping any single bit in an encrypted record is rejected.
+fn assert_all_mutations_rejected(config: &config::Config) {
+    // Verify the unmodified record decrypts successfully.
+    let (mut pair, record) = encrypted_record(config);
+    let mut buf = [0u8; 128];
+    pair.io
+        .server_tx_stream
+        .borrow_mut()
+        .write_all(&record)
+        .unwrap();
+    assert!(matches!(
+        pair.client.poll_recv(&mut buf),
+        Poll::Ready(Ok(APP_DATA_LEN))
+    ),);
+
+    let record_len = record.len();
+    for bit in 0..record_len * 8 {
+        let (mut pair, record) = encrypted_record(config);
+        // sanity check: all of the records should be the same length
+        assert_eq!(record.len(), record_len);
+
+        let mut mutated = record;
+        mutated[bit / 8] ^= 1 << (bit % 8);
+
+        pair.io
+            .server_tx_stream
+            .borrow_mut()
+            .write_all(&mutated)
+            .unwrap();
+
+        let mut recv_buf = [0u8; 128];
+        match pair.client.poll_recv(&mut recv_buf) {
+            Poll::Ready(Err(e)) => {
+                const ALLOWED_ERRORS: &[&str] = &[
+                    "S2N_ERR_BAD_MESSAGE",
+                    "S2N_ERR_DECRYPT",
+                    "S2N_ERR_SAFETY",
+                    "S2N_ERR_STUFFER_OUT_OF_DATA",
+                    "S2N_ERR_INTEGER_OVERFLOW",
+                ];
+                let name = e.name();
+                assert!(ALLOWED_ERRORS.contains(&name), "unexpected error {name}");
+            }
+            Poll::Ready(Ok(_)) => panic!("accepted record for bit flip {bit}"),
+            Poll::Pending => {
+                // not ideal, but our support of SSLv2 client hellos means that
+                // we go down a different record parsing path.
+                // https://github.com/aws/s2n-tls/issues/6001
+                // s2n-tls returns poll pending because some of the header bytes
+                // get confused for the record length and it thinks more data is
+                // coming.
+            }
+        };
+    }
+}
+
+// TLS 1.3 aead cipher
+#[test]
+fn tls13_aead() {
+    required_capability(&[Capability::Tls13], || {
+        let config =
+            testing::build_config(&Policy::from_version("default_tls13").unwrap()).unwrap();
+
+        let (pair, _) = encrypted_record(&config);
+        let cipher = pair.server.cipher_suite().unwrap();
+        assert_eq!(cipher, "TLS_AES_128_GCM_SHA256");
+
+        assert_all_mutations_rejected(&config);
+    });
+}
+
+// TLS 1.2 stream cipher
+#[test]
+fn tls12_rc4() {
+    required_capability(&[Capability::Rc4], || {
+        let config =
+            testing::build_config(&Policy::from_version("test_all_tls12").unwrap()).unwrap();
+
+        let (pair, _) = encrypted_record(&config);
+        let cipher = pair.server.cipher_suite().unwrap();
+        assert_eq!(cipher, "RC4-MD5");
+
+        assert_all_mutations_rejected(&config);
+    });
+}
+
+// TLS 1.2 block cipher
+#[test]
+fn tls12_cbc() {
+    let config = testing::build_config(&Policy::from_version("20140601").unwrap()).unwrap();
+
+    let (pair, _) = encrypted_record(&config);
+    let cipher = pair.server.cipher_suite().unwrap();
+    assert_eq!(cipher, "AES128-SHA256");
+
+    assert_all_mutations_rejected(&config);
+}

--- a/bindings/rust/standard/integration/src/handshake/mod.rs
+++ b/bindings/rust/standard/integration/src/handshake/mod.rs
@@ -3,6 +3,7 @@
 
 mod cert_aware_sig_selection;
 mod cert_retrieval;
+mod encrypted_record_integrity;
 mod group_getters;
 mod group_negotiation;
 mod handshake_failure_errors;

--- a/bindings/rust/standard/integration/src/utilities/capability_check.rs
+++ b/bindings/rust/standard/integration/src/utilities/capability_check.rs
@@ -47,6 +47,7 @@ pub enum Capability {
     MLKem,
     MLDsa,
     Chachapoly,
+    Rc4,
 }
 
 impl Capability {
@@ -62,6 +63,8 @@ impl Capability {
             // AWS-LC supports both ML-KEM + ML-DSA but AWSLCFIPS only supports ML-KEM
             Capability::MLKem => matches!(libcrypto, Libcrypto::Awslc | Libcrypto::AwslcFips),
             Capability::MLDsa => matches!(libcrypto, Libcrypto::Awslc),
+            // OpenSSL 3.0 removed RC4 from the default provider
+            Capability::Rc4 => libcrypto != Libcrypto::OpenSsl30,
         }
     }
 }

--- a/crypto/s2n_composite_cipher_aes_sha.c
+++ b/crypto/s2n_composite_cipher_aes_sha.c
@@ -143,8 +143,7 @@ static int s2n_composite_cipher_aes_sha_initial_hmac(struct s2n_session_key *key
 
     POSIX_GUARD(s2n_stuffer_write_bytes(&ctrl_stuffer, sequence_number, S2N_TLS_SEQUENCE_NUM_LEN));
     POSIX_GUARD(s2n_stuffer_write_uint8(&ctrl_stuffer, content_type));
-    POSIX_GUARD(s2n_stuffer_write_uint8(&ctrl_stuffer, protocol_version / 10));
-    POSIX_GUARD(s2n_stuffer_write_uint8(&ctrl_stuffer, protocol_version % 10));
+    POSIX_GUARD(s2n_stuffer_write_uint16(&ctrl_stuffer, protocol_version));
     POSIX_GUARD(s2n_stuffer_write_uint16(&ctrl_stuffer, payload_and_eiv_len));
 
     /* This will unnecessarily mangle the input buffer, which is fine since it's temporary

--- a/crypto/s2n_hmac.c
+++ b/crypto/s2n_hmac.c
@@ -253,6 +253,18 @@ int s2n_hmac_update(struct s2n_hmac_state *state, const void *in, uint32_t size)
     return s2n_hash_update(&state->inner, in, size);
 }
 
+/**
+ * A wrapper around s2n_hmac_update that can be used to write a u16 in network order
+ * to the hmac 
+ */
+int s2n_hmac_update_u16(struct s2n_hmac_state *state, const uint16_t data)
+{
+    uint8_t network_order[2] = { 0 };
+    network_order[0] = data >> 8;
+    network_order[1] = data & 0xFF;
+    return s2n_hmac_update(state, &network_order, 2);
+}
+
 int s2n_hmac_digest(struct s2n_hmac_state *state, void *out, uint32_t size)
 {
     POSIX_PRECONDITION(s2n_hmac_state_validate(state));

--- a/crypto/s2n_hmac.h
+++ b/crypto/s2n_hmac.h
@@ -68,6 +68,7 @@ int s2n_hmac_new(struct s2n_hmac_state *state);
 S2N_RESULT s2n_hmac_state_validate(struct s2n_hmac_state *state);
 int s2n_hmac_init(struct s2n_hmac_state *state, s2n_hmac_algorithm alg, const void *key, uint32_t klen);
 int s2n_hmac_update(struct s2n_hmac_state *state, const void *in, uint32_t size);
+int s2n_hmac_update_u16(struct s2n_hmac_state *state, const uint16_t data);
 int s2n_hmac_digest(struct s2n_hmac_state *state, void *out, uint32_t size);
 int s2n_hmac_digest_two_compression_rounds(struct s2n_hmac_state *state, void *out, uint32_t size);
 int s2n_hmac_digest_verify(const void *a, const void *b, uint32_t len);

--- a/tests/sidetrail/working/s2n-record-read-aead/s2n_record_read_wrapper.c
+++ b/tests/sidetrail/working/s2n-record-read-aead/s2n_record_read_wrapper.c
@@ -34,8 +34,7 @@
 int s2n_record_parse_aead(
     const struct s2n_cipher_suite *cipher_suite,
     struct s2n_connection *conn,
-    uint8_t content_type,
-    uint16_t encrypted_length,
+    struct s2n_record_header *header,
     uint8_t * implicit_iv,
     struct s2n_hmac_state *mac,
     uint8_t * sequence_number,
@@ -144,5 +143,9 @@ int s2n_record_parse_wrapper(int *xor_pad,
   struct s2n_session_key session_key;
   uint8_t implicit_iv[S2N_TLS_MAX_IV_LEN];
 
-  return s2n_record_parse_aead(&cipher_suite, &conn, content_type, encrypted_length, implicit_iv, &hmac, sequence_number, &session_key);
+  struct s2n_record_header record_header = {
+    .content_type = content_type,
+    .length = encrypted_length,
+  };
+  return s2n_record_parse_aead(&cipher_suite, &conn, &record_header, implicit_iv, &hmac, sequence_number, &session_key);
 }

--- a/tests/sidetrail/working/s2n-record-read-aead/s2n_record_read_wrapper.c
+++ b/tests/sidetrail/working/s2n-record-read-aead/s2n_record_read_wrapper.c
@@ -13,139 +13,135 @@
  * permissions and limitations under the License.
  */
 
+#include <smack-contracts.h>
+#include <smack.h>
 #include <stdint.h>
 #include <stdlib.h>
 
+#include "crypto/s2n_cipher.h"
 #include "crypto/s2n_hmac.h"
-
-#include "tls/s2n_record.h"
-#include "tls/s2n_prf.h"
-#include "tls/s2n_connection.h"
-
-#include <smack.h>
-#include <smack-contracts.h>
 #include "ct-verif.h"
 #include "sidetrail.h"
-#include "utils/s2n_safety.h"
 #include "tls/s2n_cipher_suites.h"
+#include "tls/s2n_connection.h"
+#include "tls/s2n_prf.h"
+#include "tls/s2n_record.h"
 #include "utils/s2n_blob.h"
-#include "crypto/s2n_cipher.h"
+#include "utils/s2n_safety.h"
 
 int s2n_record_parse_aead(
-    const struct s2n_cipher_suite *cipher_suite,
-    struct s2n_connection *conn,
-    struct s2n_record_header *header,
-    uint8_t * implicit_iv,
-    struct s2n_hmac_state *mac,
-    uint8_t * sequence_number,
-    struct s2n_session_key *session_key);
-
+        const struct s2n_cipher_suite *cipher_suite,
+        struct s2n_connection *conn,
+        struct s2n_record_header *header,
+        uint8_t *implicit_iv,
+        struct s2n_hmac_state *mac,
+        uint8_t *sequence_number,
+        struct s2n_session_key *session_key);
 
 #define DECRYPT_COST 10
-#define IV_SIZE 16
-#define MAX_SIZE 1024
-#define TAG_SIZE 16
+#define IV_SIZE      16
+#define MAX_SIZE     1024
+#define TAG_SIZE     16
 
 int decrypt_aead(struct s2n_session_key *session_key,
-		struct s2n_blob* iv,
-		struct s2n_blob* aad,
-		struct s2n_blob* in,
-		struct s2n_blob* out)
+        struct s2n_blob *iv,
+        struct s2n_blob *aad,
+        struct s2n_blob *in,
+        struct s2n_blob *out)
 
 {
-  int size = in->size;
-  __VERIFIER_ASSUME_LEAKAGE(size * DECRYPT_COST);
-  out->data = malloc(size);
-  return 0;
+    int size = in->size;
+    __VERIFIER_ASSUME_LEAKAGE(size * DECRYPT_COST);
+    out->data = malloc(size);
+    return 0;
 }
 
-int s2n_increment_sequence_number(uint8_t * sequence_number){
-  __VERIFIER_ASSUME_LEAKAGE(0);
-  return 0;
+int s2n_increment_sequence_number(uint8_t *sequence_number)
+{
+    __VERIFIER_ASSUME_LEAKAGE(0);
+    return 0;
 }
 
 int s2n_record_parse_wrapper(int *xor_pad,
-			     int *digest_pad,
-			     int padding_length,
-			     int encrypted_length,
-			     uint8_t content_type,
-			     int flags
-)
+        int *digest_pad,
+        int padding_length,
+        int encrypted_length,
+        uint8_t content_type,
+        int flags)
 {
-  __VERIFIER_ASSERT_MAX_LEAKAGE(10);
-  __VERIFIER_assume(encrypted_length > 0);
-  public_in(__SMACK_value(padding_length));
-  public_in(__SMACK_value(encrypted_length));
-  public_in(__SMACK_value(flags));
-  
-  struct s2n_hmac_state hmac = {
-    .alg = S2N_HMAC_SHA1,
-    .hash_block_size = BLOCK_SIZE,
-    .currently_in_hash_block = 0,
-    .digest_size = SHA_DIGEST_LENGTH,
-    .xor_pad_size = BLOCK_SIZE,
-    .inner.alg = S2N_HASH_SHA1,
-    .inner.currently_in_hash_block = 0,
-    .inner_just_key.alg = S2N_HASH_SHA1,
-    .inner_just_key.currently_in_hash_block = 0,
-    .outer.alg = S2N_HASH_SHA1,
-    .outer.currently_in_hash_block = 0,
-    .outer_just_key.alg = S2N_HASH_SHA1,
-    .outer_just_key.currently_in_hash_block = 0,
-     .xor_pad = *xor_pad,
-    .digest_pad = *digest_pad
-  };
+    __VERIFIER_ASSERT_MAX_LEAKAGE(10);
+    __VERIFIER_assume(encrypted_length > 0);
+    public_in(__SMACK_value(padding_length));
+    public_in(__SMACK_value(encrypted_length));
+    public_in(__SMACK_value(flags));
 
-  
-  struct s2n_cipher aead_cipher = {
-    .type = S2N_AEAD,
-    .io.aead.decrypt = decrypt_aead,
-    .io.aead.record_iv_size = IV_SIZE,
-    .io.aead.fixed_iv_size = IV_SIZE,
-    .io.aead.tag_size = TAG_SIZE,
-  };
-  
-  struct s2n_record_algorithm record_algorithm = {
-    .cipher = &aead_cipher,
-    .flags = flags
-  };
-  
-  struct s2n_cipher_suite cipher_suite = {
-    .record_alg = &record_algorithm,
-  };
+    struct s2n_hmac_state hmac = {
+        .alg = S2N_HMAC_SHA1,
+        .hash_block_size = BLOCK_SIZE,
+        .currently_in_hash_block = 0,
+        .digest_size = SHA_DIGEST_LENGTH,
+        .xor_pad_size = BLOCK_SIZE,
+        .inner.alg = S2N_HASH_SHA1,
+        .inner.currently_in_hash_block = 0,
+        .inner_just_key.alg = S2N_HASH_SHA1,
+        .inner_just_key.currently_in_hash_block = 0,
+        .outer.alg = S2N_HASH_SHA1,
+        .outer.currently_in_hash_block = 0,
+        .outer_just_key.alg = S2N_HASH_SHA1,
+        .outer_just_key.currently_in_hash_block = 0,
+        .xor_pad = *xor_pad,
+        .digest_pad = *digest_pad
+    };
 
-  /* cppcheck-suppress unassignedVariable */
-  uint8_t data1[MAX_SIZE];
-  /* cppcheck-suppress unassignedVariable */
-  uint8_t data2[MAX_SIZE];
-  
-  struct s2n_connection conn = {
-    .actual_protocol_version = S2N_TLS10,
-    .in = {
-      .read_cursor = 0,
-      .write_cursor = MAX_SIZE,
-      .blob = {
-	.data = data1,
-	.size = MAX_SIZE,
-      },
-    },
-    .header_in = {
-      .read_cursor = 0,
-      .write_cursor = S2N_TLS_RECORD_HEADER_LENGTH,
-      .blob = {
-	.data = data2,
-	.size = MAX_SIZE,
-      },
-    },
-  };
+    struct s2n_cipher aead_cipher = {
+        .type = S2N_AEAD,
+        .io.aead.decrypt = decrypt_aead,
+        .io.aead.record_iv_size = IV_SIZE,
+        .io.aead.fixed_iv_size = IV_SIZE,
+        .io.aead.tag_size = TAG_SIZE,
+    };
 
-  uint8_t sequence_number[S2N_TLS_SEQUENCE_NUM_LEN];
-  struct s2n_session_key session_key;
-  uint8_t implicit_iv[S2N_TLS_MAX_IV_LEN];
+    struct s2n_record_algorithm record_algorithm = {
+        .cipher = &aead_cipher,
+        .flags = flags
+    };
 
-  struct s2n_record_header record_header = {
-    .content_type = content_type,
-    .length = encrypted_length,
-  };
-  return s2n_record_parse_aead(&cipher_suite, &conn, &record_header, implicit_iv, &hmac, sequence_number, &session_key);
+    struct s2n_cipher_suite cipher_suite = {
+        .record_alg = &record_algorithm,
+    };
+
+    /* cppcheck-suppress unassignedVariable */
+    uint8_t data1[MAX_SIZE];
+    /* cppcheck-suppress unassignedVariable */
+    uint8_t data2[MAX_SIZE];
+
+    struct s2n_connection conn = {
+        .actual_protocol_version = S2N_TLS10,
+        .in = {
+                .read_cursor = 0,
+                .write_cursor = MAX_SIZE,
+                .blob = {
+                        .data = data1,
+                        .size = MAX_SIZE,
+                },
+        },
+        .header_in = {
+                .read_cursor = 0,
+                .write_cursor = S2N_TLS_RECORD_HEADER_LENGTH,
+                .blob = {
+                        .data = data2,
+                        .size = MAX_SIZE,
+                },
+        },
+    };
+
+    uint8_t sequence_number[S2N_TLS_SEQUENCE_NUM_LEN];
+    struct s2n_session_key session_key;
+    uint8_t implicit_iv[S2N_TLS_MAX_IV_LEN];
+
+    struct s2n_record_header record_header = {
+        .content_type = content_type,
+        .length = encrypted_length,
+    };
+    return s2n_record_parse_aead(&cipher_suite, &conn, &record_header, implicit_iv, &hmac, sequence_number, &session_key);
 }

--- a/tests/sidetrail/working/s2n-record-read-cbc-negative-test/record_read_cbc.patch
+++ b/tests/sidetrail/working/s2n-record-read-cbc-negative-test/record_read_cbc.patch
@@ -1,5 +1,5 @@
 diff --git a/tls/s2n_record_read_cbc.c b/tls/s2n_record_read_cbc.c
-index 346e6571..0f2527e9 100644
+index 0d6944246..patched 100644
 --- a/tls/s2n_record_read_cbc.c
 +++ b/tls/s2n_record_read_cbc.c
 @@ -26,6 +26,8 @@
@@ -11,7 +11,7 @@ index 346e6571..0f2527e9 100644
  int s2n_record_parse_cbc(
          const struct s2n_cipher_suite *cipher_suite,
          struct s2n_connection *conn,
-@@ -82,6 +84,8 @@ int s2n_record_parse_cbc(
+@@ -79,6 +81,8 @@ int s2n_record_parse_cbc(
  
      /* Subtract the padding length */
      POSIX_ENSURE_GT(en.size, 0);
@@ -20,7 +20,7 @@ index 346e6571..0f2527e9 100644
      uint32_t out = 0;
      POSIX_GUARD(s2n_sub_overflow(payload_length, en.data[en.size - 1] + 1, &out));
      payload_length = out;
-@@ -103,6 +107,7 @@ int s2n_record_parse_cbc(
+@@ -99,6 +103,7 @@ int s2n_record_parse_cbc(
  
      /* Padding. This finalizes the provided HMAC. */
      if (s2n_verify_cbc(conn, mac, &en) < 0) {

--- a/tests/sidetrail/working/s2n-record-read-cbc-negative-test/s2n_record_read_wrapper.c
+++ b/tests/sidetrail/working/s2n-record-read-cbc-negative-test/s2n_record_read_wrapper.c
@@ -13,137 +13,133 @@
  * permissions and limitations under the License.
  */
 
+#include <smack-contracts.h>
+#include <smack.h>
 #include <stdint.h>
 #include <stdlib.h>
 
+#include "crypto/s2n_cipher.h"
 #include "crypto/s2n_hmac.h"
-
-#include "tls/s2n_record.h"
-#include "tls/s2n_prf.h"
-#include "tls/s2n_connection.h"
-
-#include <smack.h>
-#include <smack-contracts.h>
 #include "ct-verif.h"
 #include "sidetrail.h"
-#include "utils/s2n_safety.h"
 #include "tls/s2n_cipher_suites.h"
+#include "tls/s2n_connection.h"
+#include "tls/s2n_prf.h"
+#include "tls/s2n_record.h"
 #include "utils/s2n_blob.h"
-#include "crypto/s2n_cipher.h"
+#include "utils/s2n_safety.h"
 
 int s2n_record_parse_cbc(
-    const struct s2n_cipher_suite *cipher_suite,
-    struct s2n_connection *conn,
-    struct s2n_record_header *header,
-    uint8_t * implicit_iv,
-    struct s2n_hmac_state *mac,
-    uint8_t * sequence_number,
-    struct s2n_session_key *session_key);
-
+        const struct s2n_cipher_suite *cipher_suite,
+        struct s2n_connection *conn,
+        struct s2n_record_header *header,
+        uint8_t *implicit_iv,
+        struct s2n_hmac_state *mac,
+        uint8_t *sequence_number,
+        struct s2n_session_key *session_key);
 
 #define DECRYPT_COST 10
-#define IV_SIZE 16
-#define MAX_SIZE 1024
+#define IV_SIZE      16
+#define MAX_SIZE     1024
 int decrypt_cbc(struct s2n_session_key *session_key,
-		struct s2n_blob* iv,
-		struct s2n_blob* in,
-		struct s2n_blob* out)
+        struct s2n_blob *iv,
+        struct s2n_blob *in,
+        struct s2n_blob *out)
 
 {
-  int size = in->size;
-  __VERIFIER_ASSUME_LEAKAGE(size * DECRYPT_COST);
-  out->data = malloc(size);
-  return 0;
+    int size = in->size;
+    __VERIFIER_ASSUME_LEAKAGE(size * DECRYPT_COST);
+    out->data = malloc(size);
+    return 0;
 }
 
-int s2n_increment_sequence_number(uint8_t * sequence_number){
-  __VERIFIER_ASSUME_LEAKAGE(0);
-  return 0;
+int s2n_increment_sequence_number(uint8_t *sequence_number)
+{
+    __VERIFIER_ASSUME_LEAKAGE(0);
+    return 0;
 }
 
 int g_padding_length;
 
 int s2n_record_parse_wrapper(int *xor_pad,
-			     int *digest_pad,
-			     int padding_length,
-			     int encrypted_length,
-			     uint8_t content_type
-)
+        int *digest_pad,
+        int padding_length,
+        int encrypted_length,
+        uint8_t content_type)
 {
-  __VERIFIER_ASSERT_MAX_LEAKAGE(1);
-  __VERIFIER_assume(encrypted_length > 0);
-  __VERIFIER_assume(padding_length >= 0);
-  __VERIFIER_assume(padding_length < 256);
-  public_in(__SMACK_value(padding_length));
-  public_in(__SMACK_value(encrypted_length));
-  
-  struct s2n_hmac_state hmac = {
-    .alg = S2N_HMAC_SHA1,
-    .hash_block_size = BLOCK_SIZE,
-    .currently_in_hash_block = 0,
-    .digest_size = SHA_DIGEST_LENGTH,
-    .xor_pad_size = BLOCK_SIZE,
-    .inner.alg = S2N_HASH_SHA1,
-    .inner.currently_in_hash_block = 0,
-    .inner_just_key.alg = S2N_HASH_SHA1,
-    .inner_just_key.currently_in_hash_block = 0,
-    .outer.alg = S2N_HASH_SHA1,
-    .outer.currently_in_hash_block = 0,
-    .outer_just_key.alg = S2N_HASH_SHA1,
-    .outer_just_key.currently_in_hash_block = 0,
-     .xor_pad = *xor_pad,
-    .digest_pad = *digest_pad
-  };
+    __VERIFIER_ASSERT_MAX_LEAKAGE(1);
+    __VERIFIER_assume(encrypted_length > 0);
+    __VERIFIER_assume(padding_length >= 0);
+    __VERIFIER_assume(padding_length < 256);
+    public_in(__SMACK_value(padding_length));
+    public_in(__SMACK_value(encrypted_length));
 
-  
-  struct s2n_cipher cbc_cipher = {
-    .type = S2N_CBC,
-    .io.cbc.decrypt = decrypt_cbc,
-  };
-  
-  struct s2n_record_algorithm record_algorithm = {
-    .cipher = &cbc_cipher,
-  };
-  
-  struct s2n_cipher_suite cipher_suite = {
-    .record_alg = &record_algorithm,
-  };
-  
-  /* cppcheck-suppress unassignedVariable */
-  uint8_t data1[MAX_SIZE];
-  /* cppcheck-suppress unassignedVariable */
-  uint8_t data2[MAX_SIZE];
-  
-  struct s2n_connection conn = {
-    .actual_protocol_version = S2N_TLS10,
-    .in = {
-      .read_cursor = 0,
-      .write_cursor = MAX_SIZE,
-      .high_water_mark = MAX_SIZE,
-      .blob = {
-	.data = data1,
-	.size = MAX_SIZE,
-      },
-    },
-    .header_in = {
-      .read_cursor = 0,
-      .write_cursor = S2N_TLS_RECORD_HEADER_LENGTH,
-      .high_water_mark = S2N_TLS_RECORD_HEADER_LENGTH,
-      .blob = {
-	.data = data2,
-	.size = MAX_SIZE,
-      },
-    },
-  };
+    struct s2n_hmac_state hmac = {
+        .alg = S2N_HMAC_SHA1,
+        .hash_block_size = BLOCK_SIZE,
+        .currently_in_hash_block = 0,
+        .digest_size = SHA_DIGEST_LENGTH,
+        .xor_pad_size = BLOCK_SIZE,
+        .inner.alg = S2N_HASH_SHA1,
+        .inner.currently_in_hash_block = 0,
+        .inner_just_key.alg = S2N_HASH_SHA1,
+        .inner_just_key.currently_in_hash_block = 0,
+        .outer.alg = S2N_HASH_SHA1,
+        .outer.currently_in_hash_block = 0,
+        .outer_just_key.alg = S2N_HASH_SHA1,
+        .outer_just_key.currently_in_hash_block = 0,
+        .xor_pad = *xor_pad,
+        .digest_pad = *digest_pad
+    };
 
-  uint8_t sequence_number[S2N_TLS_SEQUENCE_NUM_LEN];
-  struct s2n_session_key session_key;
-  uint8_t implicit_iv[S2N_TLS_MAX_IV_LEN];
+    struct s2n_cipher cbc_cipher = {
+        .type = S2N_CBC,
+        .io.cbc.decrypt = decrypt_cbc,
+    };
 
-  g_padding_length = padding_length;
-  struct s2n_record_header record_header = {
-    .content_type = content_type,
-    .length = encrypted_length,
-  };
-  return s2n_record_parse_cbc(&cipher_suite, &conn, &record_header, implicit_iv, &hmac, sequence_number, &session_key);
+    struct s2n_record_algorithm record_algorithm = {
+        .cipher = &cbc_cipher,
+    };
+
+    struct s2n_cipher_suite cipher_suite = {
+        .record_alg = &record_algorithm,
+    };
+
+    /* cppcheck-suppress unassignedVariable */
+    uint8_t data1[MAX_SIZE];
+    /* cppcheck-suppress unassignedVariable */
+    uint8_t data2[MAX_SIZE];
+
+    struct s2n_connection conn = {
+        .actual_protocol_version = S2N_TLS10,
+        .in = {
+                .read_cursor = 0,
+                .write_cursor = MAX_SIZE,
+                .high_water_mark = MAX_SIZE,
+                .blob = {
+                        .data = data1,
+                        .size = MAX_SIZE,
+                },
+        },
+        .header_in = {
+                .read_cursor = 0,
+                .write_cursor = S2N_TLS_RECORD_HEADER_LENGTH,
+                .high_water_mark = S2N_TLS_RECORD_HEADER_LENGTH,
+                .blob = {
+                        .data = data2,
+                        .size = MAX_SIZE,
+                },
+        },
+    };
+
+    uint8_t sequence_number[S2N_TLS_SEQUENCE_NUM_LEN];
+    struct s2n_session_key session_key;
+    uint8_t implicit_iv[S2N_TLS_MAX_IV_LEN];
+
+    g_padding_length = padding_length;
+    struct s2n_record_header record_header = {
+        .content_type = content_type,
+        .length = encrypted_length,
+    };
+    return s2n_record_parse_cbc(&cipher_suite, &conn, &record_header, implicit_iv, &hmac, sequence_number, &session_key);
 }

--- a/tests/sidetrail/working/s2n-record-read-cbc-negative-test/s2n_record_read_wrapper.c
+++ b/tests/sidetrail/working/s2n-record-read-cbc-negative-test/s2n_record_read_wrapper.c
@@ -34,8 +34,7 @@
 int s2n_record_parse_cbc(
     const struct s2n_cipher_suite *cipher_suite,
     struct s2n_connection *conn,
-    uint8_t content_type,
-    uint16_t encrypted_length,
+    struct s2n_record_header *header,
     uint8_t * implicit_iv,
     struct s2n_hmac_state *mac,
     uint8_t * sequence_number,
@@ -142,5 +141,9 @@ int s2n_record_parse_wrapper(int *xor_pad,
   uint8_t implicit_iv[S2N_TLS_MAX_IV_LEN];
 
   g_padding_length = padding_length;
-  return s2n_record_parse_cbc(&cipher_suite, &conn, content_type, encrypted_length, implicit_iv, &hmac, sequence_number, &session_key);
+  struct s2n_record_header record_header = {
+    .content_type = content_type,
+    .length = encrypted_length,
+  };
+  return s2n_record_parse_cbc(&cipher_suite, &conn, &record_header, implicit_iv, &hmac, sequence_number, &session_key);
 }

--- a/tests/sidetrail/working/s2n-record-read-cbc/record_read_cbc.patch
+++ b/tests/sidetrail/working/s2n-record-read-cbc/record_read_cbc.patch
@@ -1,5 +1,5 @@
 diff --git a/tls/s2n_record_read_cbc.c b/tls/s2n_record_read_cbc.c
-index 346e6571..0f2527e9 100644
+index 0d6944246..patched 100644
 --- a/tls/s2n_record_read_cbc.c
 +++ b/tls/s2n_record_read_cbc.c
 @@ -26,6 +26,8 @@
@@ -11,7 +11,7 @@ index 346e6571..0f2527e9 100644
  int s2n_record_parse_cbc(
          const struct s2n_cipher_suite *cipher_suite,
          struct s2n_connection *conn,
-@@ -82,6 +84,8 @@ int s2n_record_parse_cbc(
+@@ -79,6 +81,8 @@ int s2n_record_parse_cbc(
  
      /* Subtract the padding length */
      POSIX_ENSURE_GT(en.size, 0);
@@ -20,7 +20,7 @@ index 346e6571..0f2527e9 100644
      uint32_t out = 0;
      POSIX_GUARD(s2n_sub_overflow(payload_length, en.data[en.size - 1] + 1, &out));
      payload_length = out;
-@@ -103,6 +107,7 @@ int s2n_record_parse_cbc(
+@@ -99,6 +103,7 @@ int s2n_record_parse_cbc(
  
      /* Padding. This finalizes the provided HMAC. */
      if (s2n_verify_cbc(conn, mac, &en) < 0) {

--- a/tests/sidetrail/working/s2n-record-read-cbc/s2n_record_read_wrapper.c
+++ b/tests/sidetrail/working/s2n-record-read-cbc/s2n_record_read_wrapper.c
@@ -13,137 +13,133 @@
  * permissions and limitations under the License.
  */
 
+#include <smack-contracts.h>
+#include <smack.h>
 #include <stdint.h>
 #include <stdlib.h>
 
+#include "crypto/s2n_cipher.h"
 #include "crypto/s2n_hmac.h"
-
-#include "tls/s2n_record.h"
-#include "tls/s2n_prf.h"
-#include "tls/s2n_connection.h"
-
-#include <smack.h>
-#include <smack-contracts.h>
 #include "ct-verif.h"
 #include "sidetrail.h"
-#include "utils/s2n_safety.h"
 #include "tls/s2n_cipher_suites.h"
+#include "tls/s2n_connection.h"
+#include "tls/s2n_prf.h"
+#include "tls/s2n_record.h"
 #include "utils/s2n_blob.h"
-#include "crypto/s2n_cipher.h"
+#include "utils/s2n_safety.h"
 
 int s2n_record_parse_cbc(
-    const struct s2n_cipher_suite *cipher_suite,
-    struct s2n_connection *conn,
-    struct s2n_record_header *header,
-    uint8_t * implicit_iv,
-    struct s2n_hmac_state *mac,
-    uint8_t * sequence_number,
-    struct s2n_session_key *session_key);
-
+        const struct s2n_cipher_suite *cipher_suite,
+        struct s2n_connection *conn,
+        struct s2n_record_header *header,
+        uint8_t *implicit_iv,
+        struct s2n_hmac_state *mac,
+        uint8_t *sequence_number,
+        struct s2n_session_key *session_key);
 
 #define DECRYPT_COST 10
-#define IV_SIZE 16
-#define MAX_SIZE 1024
+#define IV_SIZE      16
+#define MAX_SIZE     1024
 int decrypt_cbc(struct s2n_session_key *session_key,
-		struct s2n_blob* iv,
-		struct s2n_blob* in,
-		struct s2n_blob* out)
+        struct s2n_blob *iv,
+        struct s2n_blob *in,
+        struct s2n_blob *out)
 
 {
-  int size = in->size;
-  __VERIFIER_ASSUME_LEAKAGE(size * DECRYPT_COST);
-  out->data = malloc(size);
-  return 0;
+    int size = in->size;
+    __VERIFIER_ASSUME_LEAKAGE(size * DECRYPT_COST);
+    out->data = malloc(size);
+    return 0;
 }
 
-int s2n_increment_sequence_number(uint8_t * sequence_number){
-  __VERIFIER_ASSUME_LEAKAGE(0);
-  return 0;
+int s2n_increment_sequence_number(uint8_t *sequence_number)
+{
+    __VERIFIER_ASSUME_LEAKAGE(0);
+    return 0;
 }
 
 int g_padding_length;
 
 int s2n_record_parse_wrapper(int *xor_pad,
-			     int *digest_pad,
-			     int padding_length,
-			     int encrypted_length,
-			     uint8_t content_type
-)
+        int *digest_pad,
+        int padding_length,
+        int encrypted_length,
+        uint8_t content_type)
 {
-  __VERIFIER_ASSERT_MAX_LEAKAGE(100);
-  __VERIFIER_assume(encrypted_length > 0);
-  __VERIFIER_assume(padding_length >= 0);
-  __VERIFIER_assume(padding_length < 256);
-  public_in(__SMACK_value(padding_length));
-  public_in(__SMACK_value(encrypted_length));
-  
-  struct s2n_hmac_state hmac = {
-    .alg = S2N_HMAC_SHA1,
-    .hash_block_size = BLOCK_SIZE,
-    .currently_in_hash_block = 0,
-    .digest_size = SHA_DIGEST_LENGTH,
-    .xor_pad_size = BLOCK_SIZE,
-    .inner.alg = S2N_HASH_SHA1,
-    .inner.currently_in_hash_block = 0,
-    .inner_just_key.alg = S2N_HASH_SHA1,
-    .inner_just_key.currently_in_hash_block = 0,
-    .outer.alg = S2N_HASH_SHA1,
-    .outer.currently_in_hash_block = 0,
-    .outer_just_key.alg = S2N_HASH_SHA1,
-    .outer_just_key.currently_in_hash_block = 0,
-     .xor_pad = *xor_pad,
-    .digest_pad = *digest_pad
-  };
+    __VERIFIER_ASSERT_MAX_LEAKAGE(100);
+    __VERIFIER_assume(encrypted_length > 0);
+    __VERIFIER_assume(padding_length >= 0);
+    __VERIFIER_assume(padding_length < 256);
+    public_in(__SMACK_value(padding_length));
+    public_in(__SMACK_value(encrypted_length));
 
-  
-  struct s2n_cipher cbc_cipher = {
-    .type = S2N_CBC,
-    .io.cbc.decrypt = decrypt_cbc,
-  };
-  
-  struct s2n_record_algorithm record_algorithm = {
-    .cipher = &cbc_cipher,
-  };
-  
-  struct s2n_cipher_suite cipher_suite = {
-    .record_alg = &record_algorithm,
-  };
-  
-  /* cppcheck-suppress unassignedVariable */
-  uint8_t data1[MAX_SIZE];
-  /* cppcheck-suppress unassignedVariable */
-  uint8_t data2[MAX_SIZE];
-  
-  struct s2n_connection conn = {
-    .actual_protocol_version = S2N_TLS10,
-    .in = {
-      .read_cursor = 0,
-      .write_cursor = MAX_SIZE,
-      .high_water_mark = MAX_SIZE,
-      .blob = {
-	.data = data1,
-	.size = MAX_SIZE,
-      },
-    },
-    .header_in = {
-      .read_cursor = 0,
-      .write_cursor = S2N_TLS_RECORD_HEADER_LENGTH,
-      .high_water_mark = S2N_TLS_RECORD_HEADER_LENGTH,
-      .blob = {
-	.data = data2,
-	.size = MAX_SIZE,
-      },
-    },
-  };
+    struct s2n_hmac_state hmac = {
+        .alg = S2N_HMAC_SHA1,
+        .hash_block_size = BLOCK_SIZE,
+        .currently_in_hash_block = 0,
+        .digest_size = SHA_DIGEST_LENGTH,
+        .xor_pad_size = BLOCK_SIZE,
+        .inner.alg = S2N_HASH_SHA1,
+        .inner.currently_in_hash_block = 0,
+        .inner_just_key.alg = S2N_HASH_SHA1,
+        .inner_just_key.currently_in_hash_block = 0,
+        .outer.alg = S2N_HASH_SHA1,
+        .outer.currently_in_hash_block = 0,
+        .outer_just_key.alg = S2N_HASH_SHA1,
+        .outer_just_key.currently_in_hash_block = 0,
+        .xor_pad = *xor_pad,
+        .digest_pad = *digest_pad
+    };
 
-  uint8_t sequence_number[S2N_TLS_SEQUENCE_NUM_LEN];
-  struct s2n_session_key session_key;
-  uint8_t implicit_iv[S2N_TLS_MAX_IV_LEN];
+    struct s2n_cipher cbc_cipher = {
+        .type = S2N_CBC,
+        .io.cbc.decrypt = decrypt_cbc,
+    };
 
-  g_padding_length = padding_length;
-  struct s2n_record_header record_header = {
-    .content_type = content_type,
-    .length = encrypted_length,
-  };
-  return s2n_record_parse_cbc(&cipher_suite, &conn, &record_header, implicit_iv, &hmac, sequence_number, &session_key);
+    struct s2n_record_algorithm record_algorithm = {
+        .cipher = &cbc_cipher,
+    };
+
+    struct s2n_cipher_suite cipher_suite = {
+        .record_alg = &record_algorithm,
+    };
+
+    /* cppcheck-suppress unassignedVariable */
+    uint8_t data1[MAX_SIZE];
+    /* cppcheck-suppress unassignedVariable */
+    uint8_t data2[MAX_SIZE];
+
+    struct s2n_connection conn = {
+        .actual_protocol_version = S2N_TLS10,
+        .in = {
+                .read_cursor = 0,
+                .write_cursor = MAX_SIZE,
+                .high_water_mark = MAX_SIZE,
+                .blob = {
+                        .data = data1,
+                        .size = MAX_SIZE,
+                },
+        },
+        .header_in = {
+                .read_cursor = 0,
+                .write_cursor = S2N_TLS_RECORD_HEADER_LENGTH,
+                .high_water_mark = S2N_TLS_RECORD_HEADER_LENGTH,
+                .blob = {
+                        .data = data2,
+                        .size = MAX_SIZE,
+                },
+        },
+    };
+
+    uint8_t sequence_number[S2N_TLS_SEQUENCE_NUM_LEN];
+    struct s2n_session_key session_key;
+    uint8_t implicit_iv[S2N_TLS_MAX_IV_LEN];
+
+    g_padding_length = padding_length;
+    struct s2n_record_header record_header = {
+        .content_type = content_type,
+        .length = encrypted_length,
+    };
+    return s2n_record_parse_cbc(&cipher_suite, &conn, &record_header, implicit_iv, &hmac, sequence_number, &session_key);
 }

--- a/tests/sidetrail/working/s2n-record-read-cbc/s2n_record_read_wrapper.c
+++ b/tests/sidetrail/working/s2n-record-read-cbc/s2n_record_read_wrapper.c
@@ -34,8 +34,7 @@
 int s2n_record_parse_cbc(
     const struct s2n_cipher_suite *cipher_suite,
     struct s2n_connection *conn,
-    uint8_t content_type,
-    uint16_t encrypted_length,
+    struct s2n_record_header *header,
     uint8_t * implicit_iv,
     struct s2n_hmac_state *mac,
     uint8_t * sequence_number,
@@ -142,5 +141,9 @@ int s2n_record_parse_wrapper(int *xor_pad,
   uint8_t implicit_iv[S2N_TLS_MAX_IV_LEN];
 
   g_padding_length = padding_length;
-  return s2n_record_parse_cbc(&cipher_suite, &conn, content_type, encrypted_length, implicit_iv, &hmac, sequence_number, &session_key);
+  struct s2n_record_header record_header = {
+    .content_type = content_type,
+    .length = encrypted_length,
+  };
+  return s2n_record_parse_cbc(&cipher_suite, &conn, &record_header, implicit_iv, &hmac, sequence_number, &session_key);
 }

--- a/tests/sidetrail/working/s2n-record-read-composite/record_read.patch
+++ b/tests/sidetrail/working/s2n-record-read-composite/record_read.patch
@@ -1,17 +1,17 @@
 diff --git a/tls/s2n_record_read_composite.c b/tls/s2n_record_read_composite.c
-index b57207a0..5109c47f 100644
+index 4389b88c4..patched 100644
 --- a/tls/s2n_record_read_composite.c
 +++ b/tls/s2n_record_read_composite.c
-@@ -29,6 +29,8 @@
- #include "utils/s2n_safety.h"
+@@ -26,6 +26,8 @@
  #include "utils/s2n_blob.h"
+ #include "utils/s2n_safety.h"
  
 +extern int g_padding_length;
 +
  int s2n_record_parse_composite(
-     const struct s2n_cipher_suite *cipher_suite,
-     struct s2n_connection *conn,
-@@ -88,6 +90,8 @@ int s2n_record_parse_composite(
+         const struct s2n_cipher_suite *cipher_suite,
+         struct s2n_connection *conn,
+@@ -80,6 +82,8 @@ int s2n_record_parse_composite(
  
      /* Subtract the padding length */
      POSIX_ENSURE_GT(en.size, 0);

--- a/tests/sidetrail/working/s2n-record-read-composite/s2n_record_read_wrapper.c
+++ b/tests/sidetrail/working/s2n-record-read-composite/s2n_record_read_wrapper.c
@@ -34,8 +34,7 @@
 int s2n_record_parse_composite(
     const struct s2n_cipher_suite *cipher_suite,
     struct s2n_connection *conn,
-    uint8_t content_type,
-    uint16_t encrypted_length,
+    struct s2n_record_header *header,
     uint8_t * implicit_iv,
     struct s2n_hmac_state *mac,
     uint8_t * sequence_number,
@@ -152,5 +151,9 @@ int s2n_record_parse_wrapper(int *xor_pad,
   uint8_t implicit_iv[S2N_TLS_MAX_IV_LEN];
 
   g_padding_length = padding_length;
-  return s2n_record_parse_composite(&cipher_suite, &conn, content_type, encrypted_length, implicit_iv, &hmac, sequence_number, &session_key);
+  struct s2n_record_header record_header = {
+    .content_type = content_type,
+    .length = encrypted_length,
+  };
+  return s2n_record_parse_composite(&cipher_suite, &conn, &record_header, implicit_iv, &hmac, sequence_number, &session_key);
 }

--- a/tests/sidetrail/working/s2n-record-read-composite/s2n_record_read_wrapper.c
+++ b/tests/sidetrail/working/s2n-record-read-composite/s2n_record_read_wrapper.c
@@ -13,147 +13,144 @@
  * permissions and limitations under the License.
  */
 
+#include <smack-contracts.h>
+#include <smack.h>
 #include <stdint.h>
 #include <stdlib.h>
 
+#include "crypto/s2n_cipher.h"
 #include "crypto/s2n_hmac.h"
-
-#include "tls/s2n_record.h"
-#include "tls/s2n_prf.h"
-#include "tls/s2n_connection.h"
-
-#include <smack.h>
-#include <smack-contracts.h>
 #include "ct-verif.h"
 #include "sidetrail.h"
-#include "utils/s2n_safety.h"
 #include "tls/s2n_cipher_suites.h"
+#include "tls/s2n_connection.h"
+#include "tls/s2n_prf.h"
+#include "tls/s2n_record.h"
 #include "utils/s2n_blob.h"
-#include "crypto/s2n_cipher.h"
+#include "utils/s2n_safety.h"
 
 int s2n_record_parse_composite(
-    const struct s2n_cipher_suite *cipher_suite,
-    struct s2n_connection *conn,
-    struct s2n_record_header *header,
-    uint8_t * implicit_iv,
-    struct s2n_hmac_state *mac,
-    uint8_t * sequence_number,
-    struct s2n_session_key *session_key);
-
+        const struct s2n_cipher_suite *cipher_suite,
+        struct s2n_connection *conn,
+        struct s2n_record_header *header,
+        uint8_t *implicit_iv,
+        struct s2n_hmac_state *mac,
+        uint8_t *sequence_number,
+        struct s2n_session_key *session_key);
 
 #define DECRYPT_COST 10
-#define IV_SIZE 16
-#define MAX_SIZE 1024
+#define IV_SIZE      16
+#define MAX_SIZE     1024
 
 /* Extra is actually mac_size */
 int initial_hmac(struct s2n_session_key *key, uint8_t *sequence_number, uint8_t content_type, uint16_t protocol_version,
-		 uint16_t payload_and_eiv_len, int *extra)
+        uint16_t payload_and_eiv_len, int *extra)
 {
-  *extra = DIGEST_SIZE;
-  return 0;
+    *extra = DIGEST_SIZE;
+    return 0;
 }
 
 int decrypt_comp(struct s2n_session_key *session_key,
-		struct s2n_blob* iv,
-		struct s2n_blob* in,
-		struct s2n_blob* out)
+        struct s2n_blob *iv,
+        struct s2n_blob *in,
+        struct s2n_blob *out)
 
 {
-  int size = in->size;
-  __VERIFIER_ASSUME_LEAKAGE(size * DECRYPT_COST);
-  out->data = malloc(size);
-  return 0;
+    int size = in->size;
+    __VERIFIER_ASSUME_LEAKAGE(size * DECRYPT_COST);
+    out->data = malloc(size);
+    return 0;
 }
 
-int s2n_increment_sequence_number(uint8_t * sequence_number){
-  __VERIFIER_ASSUME_LEAKAGE(0);
-  return 0;
+int s2n_increment_sequence_number(uint8_t *sequence_number)
+{
+    __VERIFIER_ASSUME_LEAKAGE(0);
+    return 0;
 }
 
 int g_padding_length;
 
 int s2n_record_parse_wrapper(int *xor_pad,
-			     int *digest_pad,
-			     int padding_length,
-			     int encrypted_length,
-			     uint8_t content_type
-)
+        int *digest_pad,
+        int padding_length,
+        int encrypted_length,
+        uint8_t content_type)
 {
-  __VERIFIER_ASSERT_MAX_LEAKAGE(0);
-  __VERIFIER_assume(encrypted_length > 0);
-  __VERIFIER_assume(padding_length >= 0);
-  __VERIFIER_assume(padding_length < 256);
-  public_in(__SMACK_value(padding_length));
-  public_in(__SMACK_value(encrypted_length));
-  
-  struct s2n_hmac_state hmac = {
-    .alg = S2N_HMAC_SHA1,
-    .hash_block_size = BLOCK_SIZE,
-    .currently_in_hash_block = 0,
-    .digest_size = SHA_DIGEST_LENGTH,
-    .xor_pad_size = BLOCK_SIZE,
-    .inner.alg = S2N_HASH_SHA1,
-    .inner.currently_in_hash_block = 0,
-    .inner_just_key.alg = S2N_HASH_SHA1,
-    .inner_just_key.currently_in_hash_block = 0,
-    .outer.alg = S2N_HASH_SHA1,
-    .outer.currently_in_hash_block = 0,
-    .outer_just_key.alg = S2N_HASH_SHA1,
-    .outer_just_key.currently_in_hash_block = 0,
-    .xor_pad = *xor_pad,
-    .digest_pad = *digest_pad
-  };
+    __VERIFIER_ASSERT_MAX_LEAKAGE(0);
+    __VERIFIER_assume(encrypted_length > 0);
+    __VERIFIER_assume(padding_length >= 0);
+    __VERIFIER_assume(padding_length < 256);
+    public_in(__SMACK_value(padding_length));
+    public_in(__SMACK_value(encrypted_length));
 
-  struct s2n_cipher comp_cipher = {
-    .type = S2N_COMPOSITE,
-    .io.comp.decrypt = decrypt_comp,
-    .io.comp.record_iv_size = IV_SIZE,
-    .io.comp.initial_hmac = initial_hmac,
-  };
-  
-  struct s2n_record_algorithm record_algorithm = {
-    .cipher = &comp_cipher,
-  };
-  
-  struct s2n_cipher_suite cipher_suite = {
-    .record_alg = &record_algorithm,
-  };
+    struct s2n_hmac_state hmac = {
+        .alg = S2N_HMAC_SHA1,
+        .hash_block_size = BLOCK_SIZE,
+        .currently_in_hash_block = 0,
+        .digest_size = SHA_DIGEST_LENGTH,
+        .xor_pad_size = BLOCK_SIZE,
+        .inner.alg = S2N_HASH_SHA1,
+        .inner.currently_in_hash_block = 0,
+        .inner_just_key.alg = S2N_HASH_SHA1,
+        .inner_just_key.currently_in_hash_block = 0,
+        .outer.alg = S2N_HASH_SHA1,
+        .outer.currently_in_hash_block = 0,
+        .outer_just_key.alg = S2N_HASH_SHA1,
+        .outer_just_key.currently_in_hash_block = 0,
+        .xor_pad = *xor_pad,
+        .digest_pad = *digest_pad
+    };
 
-  /* cppcheck-suppress unassignedVariable */
-  uint8_t data1[MAX_SIZE];
-  /* cppcheck-suppress unassignedVariable */
-  uint8_t data2[MAX_SIZE];
-  
-  struct s2n_connection conn = {
-    .actual_protocol_version = S2N_TLS10,
-    .in = {
-      .read_cursor = 0,
-      .write_cursor = MAX_SIZE,
-      .high_water_mark = MAX_SIZE,
-      .blob = {
-	.data = data1,
-	.size = MAX_SIZE,
-      },
-    },
-    .header_in = {
-      .read_cursor = 0,
-      .write_cursor = S2N_TLS_RECORD_HEADER_LENGTH,
-      .high_water_mark = S2N_TLS_RECORD_HEADER_LENGTH,
-      .blob = {
-	.data = data2,
-	.size = MAX_SIZE,
-      },
-    },
-  };
+    struct s2n_cipher comp_cipher = {
+        .type = S2N_COMPOSITE,
+        .io.comp.decrypt = decrypt_comp,
+        .io.comp.record_iv_size = IV_SIZE,
+        .io.comp.initial_hmac = initial_hmac,
+    };
 
-  uint8_t sequence_number[S2N_TLS_SEQUENCE_NUM_LEN];
-  struct s2n_session_key session_key;
-  uint8_t implicit_iv[S2N_TLS_MAX_IV_LEN];
+    struct s2n_record_algorithm record_algorithm = {
+        .cipher = &comp_cipher,
+    };
 
-  g_padding_length = padding_length;
-  struct s2n_record_header record_header = {
-    .content_type = content_type,
-    .length = encrypted_length,
-  };
-  return s2n_record_parse_composite(&cipher_suite, &conn, &record_header, implicit_iv, &hmac, sequence_number, &session_key);
+    struct s2n_cipher_suite cipher_suite = {
+        .record_alg = &record_algorithm,
+    };
+
+    /* cppcheck-suppress unassignedVariable */
+    uint8_t data1[MAX_SIZE];
+    /* cppcheck-suppress unassignedVariable */
+    uint8_t data2[MAX_SIZE];
+
+    struct s2n_connection conn = {
+        .actual_protocol_version = S2N_TLS10,
+        .in = {
+                .read_cursor = 0,
+                .write_cursor = MAX_SIZE,
+                .high_water_mark = MAX_SIZE,
+                .blob = {
+                        .data = data1,
+                        .size = MAX_SIZE,
+                },
+        },
+        .header_in = {
+                .read_cursor = 0,
+                .write_cursor = S2N_TLS_RECORD_HEADER_LENGTH,
+                .high_water_mark = S2N_TLS_RECORD_HEADER_LENGTH,
+                .blob = {
+                        .data = data2,
+                        .size = MAX_SIZE,
+                },
+        },
+    };
+
+    uint8_t sequence_number[S2N_TLS_SEQUENCE_NUM_LEN];
+    struct s2n_session_key session_key;
+    uint8_t implicit_iv[S2N_TLS_MAX_IV_LEN];
+
+    g_padding_length = padding_length;
+    struct s2n_record_header record_header = {
+        .content_type = content_type,
+        .length = encrypted_length,
+    };
+    return s2n_record_parse_composite(&cipher_suite, &conn, &record_header, implicit_iv, &hmac, sequence_number, &session_key);
 }

--- a/tests/sidetrail/working/s2n-record-read-stream/s2n_record_read_stream.patch
+++ b/tests/sidetrail/working/s2n-record-read-stream/s2n_record_read_stream.patch
@@ -1,11 +1,11 @@
 diff --git a/tls/s2n_record_read_stream.c b/tls/s2n_record_read_stream.c
-index 927ab00f..3846cc4b 100644
+index 4e0ddaf0d..patched 100644
 --- a/tls/s2n_record_read_stream.c
 +++ b/tls/s2n_record_read_stream.c
-@@ -79,17 +79,22 @@ int s2n_record_parse_stream(
+@@ -75,15 +75,20 @@ int s2n_record_parse_stream(
          POSIX_BAIL(S2N_ERR_BAD_MESSAGE);
      }
-
+ 
 +    /* All information is declassified after the MAC is successfully verified since the record is
 +     * decrypted and authenticated. Code that's executed post MAC validation need not be constant
 +     * time, so it's removed from the scope of SideTrail's analysis.
@@ -15,10 +15,8 @@ index 927ab00f..3846cc4b 100644
       * for reading the plaintext data.
       */
 -    POSIX_GUARD(s2n_stuffer_reread(&conn->in));
--    POSIX_GUARD(s2n_stuffer_reread(&conn->header_in));
 +//    POSIX_GUARD(s2n_stuffer_reread(&conn->in));
-+//    POSIX_GUARD(s2n_stuffer_reread(&conn->header_in));
-
+ 
      /* Truncate and wipe the MAC and any padding */
 -    uint32_t mac_len = 0;
 -    POSIX_GUARD(s2n_sub_overflow(s2n_stuffer_data_available(&conn->in), payload_length, &mac_len));
@@ -28,6 +26,6 @@ index 927ab00f..3846cc4b 100644
 +//    POSIX_GUARD(s2n_sub_overflow(s2n_stuffer_data_available(&conn->in), payload_length, &mac_len));
 +//    POSIX_GUARD(s2n_stuffer_wipe_n(&conn->in, mac_len));
 +//    conn->in_status = PLAINTEXT;
-
+ 
      return 0;
  }

--- a/tests/sidetrail/working/s2n-record-read-stream/s2n_record_read_wrapper.c
+++ b/tests/sidetrail/working/s2n-record-read-stream/s2n_record_read_wrapper.c
@@ -13,136 +13,133 @@
  * permissions and limitations under the License.
  */
 
+#include <smack-contracts.h>
+#include <smack.h>
 #include <stdint.h>
 #include <stdlib.h>
 
+#include "crypto/s2n_cipher.h"
 #include "crypto/s2n_hmac.h"
-
-#include "tls/s2n_record.h"
-#include "tls/s2n_prf.h"
-#include "tls/s2n_connection.h"
-
-#include <smack.h>
-#include <smack-contracts.h>
 #include "ct-verif.h"
 #include "sidetrail.h"
-#include "utils/s2n_safety.h"
 #include "tls/s2n_cipher_suites.h"
+#include "tls/s2n_connection.h"
+#include "tls/s2n_prf.h"
+#include "tls/s2n_record.h"
 #include "utils/s2n_blob.h"
-#include "crypto/s2n_cipher.h"
+#include "utils/s2n_safety.h"
 
 int s2n_record_parse_stream(
-    const struct s2n_cipher_suite *cipher_suite,
-    struct s2n_connection *conn,
-    struct s2n_record_header *header,
-    uint8_t * implicit_iv,
-    struct s2n_hmac_state *mac,
-    uint8_t * sequence_number,
-    struct s2n_session_key *session_key);
+        const struct s2n_cipher_suite *cipher_suite,
+        struct s2n_connection *conn,
+        struct s2n_record_header *header,
+        uint8_t *implicit_iv,
+        struct s2n_hmac_state *mac,
+        uint8_t *sequence_number,
+        struct s2n_session_key *session_key);
 
 #define DECRYPT_COST 10
-#define IV_SIZE 16
-#define MAX_SIZE 1024
+#define IV_SIZE      16
+#define MAX_SIZE     1024
 
 int decrypt_stream(struct s2n_session_key *session_key,
-		   struct s2n_blob* in,
-		   struct s2n_blob* out)
+        struct s2n_blob *in,
+        struct s2n_blob *out)
 
 {
-  int size = in->size;
-  __VERIFIER_ASSUME_LEAKAGE(size * DECRYPT_COST);
-  out->data = malloc(size);
-  return 0;
+    int size = in->size;
+    __VERIFIER_ASSUME_LEAKAGE(size * DECRYPT_COST);
+    out->data = malloc(size);
+    return 0;
 }
 
-int s2n_increment_sequence_number(uint8_t * sequence_number){
-  __VERIFIER_ASSUME_LEAKAGE(0);
-  return 0;
+int s2n_increment_sequence_number(uint8_t *sequence_number)
+{
+    __VERIFIER_ASSUME_LEAKAGE(0);
+    return 0;
 }
 
 int g_padding_length;
 
 int s2n_record_parse_wrapper(int *xor_pad,
-			     int * digest_pad,
-			     int padding_length,
-			     int encrypted_length,
-			     uint8_t content_type
-)
+        int *digest_pad,
+        int padding_length,
+        int encrypted_length,
+        uint8_t content_type)
 {
-  __VERIFIER_ASSERT_MAX_LEAKAGE(5);
-  __VERIFIER_assume(encrypted_length > 0);
-  __VERIFIER_assume(padding_length >= 0);
-  __VERIFIER_assume(padding_length < 256);
-  public_in(__SMACK_value(padding_length));
-  public_in(__SMACK_value(encrypted_length));
-  
-  struct s2n_hmac_state hmac = {
-    .alg = S2N_HMAC_SHA1,
-    .hash_block_size = BLOCK_SIZE,
-    .currently_in_hash_block = 0,
-    .digest_size = SHA_DIGEST_LENGTH,
-    .xor_pad_size = BLOCK_SIZE,
-    .inner.alg = S2N_HASH_SHA1,
-    .inner.currently_in_hash_block = 0,
-    .inner_just_key.alg = S2N_HASH_SHA1,
-    .inner_just_key.currently_in_hash_block = 0,
-    .outer.alg = S2N_HASH_SHA1,
-    .outer.currently_in_hash_block = 0,
-    .outer_just_key.alg = S2N_HASH_SHA1,
-    .outer_just_key.currently_in_hash_block = 0,
-    .xor_pad = *xor_pad,
-    .digest_pad = *digest_pad
-  };
+    __VERIFIER_ASSERT_MAX_LEAKAGE(5);
+    __VERIFIER_assume(encrypted_length > 0);
+    __VERIFIER_assume(padding_length >= 0);
+    __VERIFIER_assume(padding_length < 256);
+    public_in(__SMACK_value(padding_length));
+    public_in(__SMACK_value(encrypted_length));
 
-  
-  struct s2n_cipher stream_cipher = {
-    .type = S2N_STREAM,
-    .io.stream.decrypt = decrypt_stream,
-  };
-  
-  struct s2n_record_algorithm record_algorithm = {
-    .cipher = &stream_cipher,
-  };
-  
-  struct s2n_cipher_suite cipher_suite = {
-    .record_alg = &record_algorithm,
-  };
+    struct s2n_hmac_state hmac = {
+        .alg = S2N_HMAC_SHA1,
+        .hash_block_size = BLOCK_SIZE,
+        .currently_in_hash_block = 0,
+        .digest_size = SHA_DIGEST_LENGTH,
+        .xor_pad_size = BLOCK_SIZE,
+        .inner.alg = S2N_HASH_SHA1,
+        .inner.currently_in_hash_block = 0,
+        .inner_just_key.alg = S2N_HASH_SHA1,
+        .inner_just_key.currently_in_hash_block = 0,
+        .outer.alg = S2N_HASH_SHA1,
+        .outer.currently_in_hash_block = 0,
+        .outer_just_key.alg = S2N_HASH_SHA1,
+        .outer_just_key.currently_in_hash_block = 0,
+        .xor_pad = *xor_pad,
+        .digest_pad = *digest_pad
+    };
 
-  /* cppcheck-suppress unassignedVariable */
-  uint8_t data1[MAX_SIZE];
-  /* cppcheck-suppress unassignedVariable */
-  uint8_t data2[MAX_SIZE];
-  
-  struct s2n_connection conn = {
-    .actual_protocol_version = S2N_TLS10,
-    .in = {
-      .read_cursor = 0,
-      .write_cursor = MAX_SIZE,
-      .high_water_mark = MAX_SIZE,
-      .blob = {
-	.data = data1,
-	.size = MAX_SIZE,
-      },
-    },
-    .header_in = {
-      .read_cursor = 0,
-      .write_cursor = S2N_TLS_RECORD_HEADER_LENGTH,
-      .high_water_mark = S2N_TLS_RECORD_HEADER_LENGTH,
-      .blob = {
-	.data = data2,
-	.size = MAX_SIZE,
-      },
-    },
-  };
+    struct s2n_cipher stream_cipher = {
+        .type = S2N_STREAM,
+        .io.stream.decrypt = decrypt_stream,
+    };
 
-  uint8_t sequence_number[S2N_TLS_SEQUENCE_NUM_LEN];
-  struct s2n_session_key session_key;
-  uint8_t implicit_iv[S2N_TLS_MAX_IV_LEN];
+    struct s2n_record_algorithm record_algorithm = {
+        .cipher = &stream_cipher,
+    };
 
-  g_padding_length = padding_length;
-  struct s2n_record_header record_header = {
-    .content_type = content_type,
-    .length = encrypted_length,
-  };
-  return s2n_record_parse_stream(&cipher_suite, &conn, &record_header, implicit_iv, &hmac, sequence_number, &session_key);
+    struct s2n_cipher_suite cipher_suite = {
+        .record_alg = &record_algorithm,
+    };
+
+    /* cppcheck-suppress unassignedVariable */
+    uint8_t data1[MAX_SIZE];
+    /* cppcheck-suppress unassignedVariable */
+    uint8_t data2[MAX_SIZE];
+
+    struct s2n_connection conn = {
+        .actual_protocol_version = S2N_TLS10,
+        .in = {
+                .read_cursor = 0,
+                .write_cursor = MAX_SIZE,
+                .high_water_mark = MAX_SIZE,
+                .blob = {
+                        .data = data1,
+                        .size = MAX_SIZE,
+                },
+        },
+        .header_in = {
+                .read_cursor = 0,
+                .write_cursor = S2N_TLS_RECORD_HEADER_LENGTH,
+                .high_water_mark = S2N_TLS_RECORD_HEADER_LENGTH,
+                .blob = {
+                        .data = data2,
+                        .size = MAX_SIZE,
+                },
+        },
+    };
+
+    uint8_t sequence_number[S2N_TLS_SEQUENCE_NUM_LEN];
+    struct s2n_session_key session_key;
+    uint8_t implicit_iv[S2N_TLS_MAX_IV_LEN];
+
+    g_padding_length = padding_length;
+    struct s2n_record_header record_header = {
+        .content_type = content_type,
+        .length = encrypted_length,
+    };
+    return s2n_record_parse_stream(&cipher_suite, &conn, &record_header, implicit_iv, &hmac, sequence_number, &session_key);
 }

--- a/tests/sidetrail/working/s2n-record-read-stream/s2n_record_read_wrapper.c
+++ b/tests/sidetrail/working/s2n-record-read-stream/s2n_record_read_wrapper.c
@@ -34,8 +34,7 @@
 int s2n_record_parse_stream(
     const struct s2n_cipher_suite *cipher_suite,
     struct s2n_connection *conn,
-    uint8_t content_type,
-    uint16_t encrypted_length,
+    struct s2n_record_header *header,
     uint8_t * implicit_iv,
     struct s2n_hmac_state *mac,
     uint8_t * sequence_number,
@@ -141,5 +140,9 @@ int s2n_record_parse_wrapper(int *xor_pad,
   uint8_t implicit_iv[S2N_TLS_MAX_IV_LEN];
 
   g_padding_length = padding_length;
-  return s2n_record_parse_stream(&cipher_suite, &conn, content_type, encrypted_length, implicit_iv, &hmac, sequence_number, &session_key);
+  struct s2n_record_header record_header = {
+    .content_type = content_type,
+    .length = encrypted_length,
+  };
+  return s2n_record_parse_stream(&cipher_suite, &conn, &record_header, implicit_iv, &hmac, sequence_number, &session_key);
 }

--- a/tests/unit/s2n_3des_test.c
+++ b/tests/unit/s2n_3des_test.c
@@ -97,12 +97,11 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_stuffer_copy(&conn->out, &conn->in, s2n_stuffer_data_available(&conn->out)));
 
         /* Let's decrypt it */
-        uint8_t content_type = 0;
-        uint16_t fragment_length = 0;
-        EXPECT_SUCCESS(s2n_record_header_parse(conn, &content_type, &fragment_length));
+        struct s2n_record_header header = { 0 };
+        EXPECT_SUCCESS(s2n_record_header_parse(conn, &header));
         EXPECT_SUCCESS(s2n_record_parse(conn));
-        EXPECT_EQUAL(content_type, TLS_APPLICATION_DATA);
-        EXPECT_EQUAL(fragment_length, predicted_length);
+        EXPECT_EQUAL(header.content_type, TLS_APPLICATION_DATA);
+        EXPECT_EQUAL(header.length, predicted_length);
 
         EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->header_in));
         EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->in));

--- a/tests/unit/s2n_aead_aes_test.c
+++ b/tests/unit/s2n_aead_aes_test.c
@@ -135,12 +135,11 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_stuffer_copy(&conn->out, &conn->in, s2n_stuffer_data_available(&conn->out)));
 
         /* Let's decrypt it */
-        uint8_t content_type = 0;
-        uint16_t fragment_length = 0;
-        EXPECT_SUCCESS(s2n_record_header_parse(conn, &content_type, &fragment_length));
+        struct s2n_record_header header = { 0 };
+        EXPECT_SUCCESS(s2n_record_header_parse(conn, &header));
         EXPECT_SUCCESS(s2n_record_parse(conn));
-        EXPECT_EQUAL(content_type, TLS_APPLICATION_DATA);
-        EXPECT_EQUAL(fragment_length, predicted_length);
+        EXPECT_EQUAL(header.content_type, TLS_APPLICATION_DATA);
+        EXPECT_EQUAL(header.length, predicted_length);
 
         EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->header_in));
         EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->in));
@@ -167,8 +166,8 @@ int main(int argc, char **argv)
         EXPECT_EQUAL(conn->header_in.blob.data[0], TLS_APPLICATION_DATA);
         conn->header_in.blob.data[0] ^= 1; /* Flip a bit in the content_type of the TLS Record Header */
 
-        EXPECT_SUCCESS(s2n_record_header_parse(conn, &content_type, &fragment_length));
-        EXPECT_EQUAL(content_type, TLS_APPLICATION_DATA ^ 1);
+        EXPECT_SUCCESS(s2n_record_header_parse(conn, &header));
+        EXPECT_EQUAL(header.content_type, TLS_APPLICATION_DATA ^ 1);
 
         /**
          * We are trying to test the case when the Additional Authenticated Data in AEAD ciphers is tampered with.
@@ -202,9 +201,9 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_stuffer_copy(&conn->out, &conn->header_in, S2N_TLS_RECORD_HEADER_LENGTH));
             EXPECT_SUCCESS(s2n_stuffer_copy(&conn->out, &conn->in, s2n_stuffer_data_available(&conn->out)));
             conn->in.blob.data[j]++;
-            EXPECT_SUCCESS(s2n_record_header_parse(conn, &content_type, &fragment_length));
+            EXPECT_SUCCESS(s2n_record_header_parse(conn, &header));
             EXPECT_FAILURE(s2n_record_parse(conn));
-            EXPECT_EQUAL(content_type, TLS_APPLICATION_DATA);
+            EXPECT_EQUAL(header.content_type, TLS_APPLICATION_DATA);
 
             EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->header_in));
             EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->in));
@@ -228,9 +227,9 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_stuffer_copy(&conn->out, &conn->header_in, S2N_TLS_RECORD_HEADER_LENGTH));
             EXPECT_SUCCESS(s2n_stuffer_copy(&conn->out, &conn->in, s2n_stuffer_data_available(&conn->out)));
             conn->in.blob.data[s2n_stuffer_data_available(&conn->in) - j - 1]++;
-            EXPECT_SUCCESS(s2n_record_header_parse(conn, &content_type, &fragment_length));
+            EXPECT_SUCCESS(s2n_record_header_parse(conn, &header));
             EXPECT_FAILURE(s2n_record_parse(conn));
-            EXPECT_EQUAL(content_type, TLS_APPLICATION_DATA);
+            EXPECT_EQUAL(header.content_type, TLS_APPLICATION_DATA);
 
             EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->header_in));
             EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->in));
@@ -254,9 +253,9 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_stuffer_copy(&conn->out, &conn->header_in, S2N_TLS_RECORD_HEADER_LENGTH));
             EXPECT_SUCCESS(s2n_stuffer_copy(&conn->out, &conn->in, s2n_stuffer_data_available(&conn->out)));
             conn->in.blob.data[S2N_TLS_GCM_EXPLICIT_IV_LEN + j]++;
-            EXPECT_SUCCESS(s2n_record_header_parse(conn, &content_type, &fragment_length));
+            EXPECT_SUCCESS(s2n_record_header_parse(conn, &header));
             EXPECT_FAILURE(s2n_record_parse(conn));
-            EXPECT_EQUAL(content_type, TLS_APPLICATION_DATA);
+            EXPECT_EQUAL(header.content_type, TLS_APPLICATION_DATA);
 
             EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->header_in));
             EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->in));
@@ -323,12 +322,11 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_stuffer_copy(&conn->out, &conn->in, s2n_stuffer_data_available(&conn->out)));
 
         /* Let's decrypt it */
-        uint8_t content_type = 0;
-        uint16_t fragment_length = 0;
-        EXPECT_SUCCESS(s2n_record_header_parse(conn, &content_type, &fragment_length));
+        struct s2n_record_header header = { 0 };
+        EXPECT_SUCCESS(s2n_record_header_parse(conn, &header));
         EXPECT_SUCCESS(s2n_record_parse(conn));
-        EXPECT_EQUAL(content_type, TLS_APPLICATION_DATA);
-        EXPECT_EQUAL(fragment_length, predicted_length);
+        EXPECT_EQUAL(header.content_type, TLS_APPLICATION_DATA);
+        EXPECT_EQUAL(header.length, predicted_length);
 
         EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->header_in));
         EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->in));
@@ -352,9 +350,9 @@ int main(int argc, char **argv)
 
         /* Tamper with the protocol version in the header, and ensure decryption fails, as we use this in the AAD */
         conn->in.blob.data[2] = 2;
-        EXPECT_SUCCESS(s2n_record_header_parse(conn, &content_type, &fragment_length));
+        EXPECT_SUCCESS(s2n_record_header_parse(conn, &header));
         EXPECT_FAILURE(s2n_record_parse(conn));
-        EXPECT_EQUAL(content_type, TLS_APPLICATION_DATA);
+        EXPECT_EQUAL(header.content_type, TLS_APPLICATION_DATA);
 
         EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->header_in));
         EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->in));
@@ -378,9 +376,9 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_stuffer_copy(&conn->out, &conn->header_in, S2N_TLS_RECORD_HEADER_LENGTH));
             EXPECT_SUCCESS(s2n_stuffer_copy(&conn->out, &conn->in, s2n_stuffer_data_available(&conn->out)));
             conn->in.blob.data[j]++;
-            EXPECT_SUCCESS(s2n_record_header_parse(conn, &content_type, &fragment_length));
+            EXPECT_SUCCESS(s2n_record_header_parse(conn, &header));
             EXPECT_FAILURE(s2n_record_parse(conn));
-            EXPECT_EQUAL(content_type, TLS_APPLICATION_DATA);
+            EXPECT_EQUAL(header.content_type, TLS_APPLICATION_DATA);
 
             EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->header_in));
             EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->in));
@@ -405,9 +403,9 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_stuffer_copy(&conn->out, &conn->header_in, S2N_TLS_RECORD_HEADER_LENGTH));
             EXPECT_SUCCESS(s2n_stuffer_copy(&conn->out, &conn->in, s2n_stuffer_data_available(&conn->out)));
             conn->in.blob.data[s2n_stuffer_data_available(&conn->in) - j - 1]++;
-            EXPECT_SUCCESS(s2n_record_header_parse(conn, &content_type, &fragment_length));
+            EXPECT_SUCCESS(s2n_record_header_parse(conn, &header));
             EXPECT_FAILURE(s2n_record_parse(conn));
-            EXPECT_EQUAL(content_type, TLS_APPLICATION_DATA);
+            EXPECT_EQUAL(header.content_type, TLS_APPLICATION_DATA);
 
             EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->header_in));
             EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->in));
@@ -432,9 +430,9 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_stuffer_copy(&conn->out, &conn->header_in, S2N_TLS_RECORD_HEADER_LENGTH));
             EXPECT_SUCCESS(s2n_stuffer_copy(&conn->out, &conn->in, s2n_stuffer_data_available(&conn->out)));
             conn->in.blob.data[S2N_TLS_GCM_EXPLICIT_IV_LEN + j]++;
-            EXPECT_SUCCESS(s2n_record_header_parse(conn, &content_type, &fragment_length));
+            EXPECT_SUCCESS(s2n_record_header_parse(conn, &header));
             EXPECT_FAILURE(s2n_record_parse(conn));
-            EXPECT_EQUAL(content_type, TLS_APPLICATION_DATA);
+            EXPECT_EQUAL(header.content_type, TLS_APPLICATION_DATA);
 
             EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->header_in));
             EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->in));

--- a/tests/unit/s2n_aead_chacha20_poly1305_test.c
+++ b/tests/unit/s2n_aead_chacha20_poly1305_test.c
@@ -135,12 +135,11 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_stuffer_copy(&conn->out, &conn->in, s2n_stuffer_data_available(&conn->out)));
 
         /* Let's decrypt it */
-        uint8_t content_type = 0;
-        uint16_t fragment_length = 0;
-        EXPECT_SUCCESS(s2n_record_header_parse(conn, &content_type, &fragment_length));
+        struct s2n_record_header header = { 0 };
+        EXPECT_SUCCESS(s2n_record_header_parse(conn, &header));
         EXPECT_SUCCESS(s2n_record_parse(conn));
-        EXPECT_EQUAL(content_type, TLS_APPLICATION_DATA);
-        EXPECT_EQUAL(fragment_length, predicted_length);
+        EXPECT_EQUAL(header.content_type, TLS_APPLICATION_DATA);
+        EXPECT_EQUAL(header.length, predicted_length);
 
         EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->header_in));
         EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->in));
@@ -166,8 +165,8 @@ int main(int argc, char **argv)
         EXPECT_EQUAL(conn->header_in.blob.data[0], TLS_APPLICATION_DATA);
         conn->header_in.blob.data[0] ^= 1; /* Flip a bit in the content_type of the TLS Record Header */
 
-        EXPECT_SUCCESS(s2n_record_header_parse(conn, &content_type, &fragment_length));
-        EXPECT_EQUAL(content_type, TLS_APPLICATION_DATA ^ 1);
+        EXPECT_SUCCESS(s2n_record_header_parse(conn, &header));
+        EXPECT_EQUAL(header.content_type, TLS_APPLICATION_DATA ^ 1);
 
         /**
          * We are trying to test the case when the Additional Authenticated Data in AEAD ciphers is tampered with.
@@ -202,9 +201,9 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_stuffer_copy(&conn->out, &conn->header_in, 5));
             EXPECT_SUCCESS(s2n_stuffer_copy(&conn->out, &conn->in, s2n_stuffer_data_available(&conn->out)));
             conn->in.blob.data[s2n_stuffer_data_available(&conn->in) - j - 1]++;
-            EXPECT_SUCCESS(s2n_record_header_parse(conn, &content_type, &fragment_length));
+            EXPECT_SUCCESS(s2n_record_header_parse(conn, &header));
             EXPECT_FAILURE(s2n_record_parse(conn));
-            EXPECT_EQUAL(content_type, TLS_APPLICATION_DATA);
+            EXPECT_EQUAL(header.content_type, TLS_APPLICATION_DATA);
 
             EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->header_in));
             EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->in));
@@ -229,9 +228,9 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_stuffer_copy(&conn->out, &conn->header_in, 5));
             EXPECT_SUCCESS(s2n_stuffer_copy(&conn->out, &conn->in, s2n_stuffer_data_available(&conn->out)));
             conn->in.blob.data[j]++;
-            EXPECT_SUCCESS(s2n_record_header_parse(conn, &content_type, &fragment_length));
+            EXPECT_SUCCESS(s2n_record_header_parse(conn, &header));
             EXPECT_FAILURE(s2n_record_parse(conn));
-            EXPECT_EQUAL(content_type, TLS_APPLICATION_DATA);
+            EXPECT_EQUAL(header.content_type, TLS_APPLICATION_DATA);
 
             EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->header_in));
             EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->in));

--- a/tests/unit/s2n_aes_sha_composite_test.c
+++ b/tests/unit/s2n_aes_sha_composite_test.c
@@ -151,12 +151,11 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_stuffer_copy(&conn->out, &conn->in, s2n_stuffer_data_available(&conn->out)));
 
             /* Let's decrypt it */
-            uint8_t content_type = 0;
-            uint16_t fragment_length = 0;
-            EXPECT_SUCCESS(s2n_record_header_parse(conn, &content_type, &fragment_length));
+            struct s2n_record_header header = { 0 };
+            EXPECT_SUCCESS(s2n_record_header_parse(conn, &header));
             EXPECT_SUCCESS(s2n_record_parse(conn));
-            EXPECT_EQUAL(content_type, TLS_APPLICATION_DATA);
-            EXPECT_EQUAL(fragment_length, predicted_length);
+            EXPECT_EQUAL(header.content_type, TLS_APPLICATION_DATA);
+            EXPECT_EQUAL(header.length, predicted_length);
 
             EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->header_in));
             EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->in));
@@ -227,12 +226,11 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_stuffer_copy(&conn->out, &conn->in, s2n_stuffer_data_available(&conn->out)));
 
             /* Let's decrypt it */
-            uint8_t content_type = 0;
-            uint16_t fragment_length = 0;
-            EXPECT_SUCCESS(s2n_record_header_parse(conn, &content_type, &fragment_length));
+            struct s2n_record_header header = { 0 };
+            EXPECT_SUCCESS(s2n_record_header_parse(conn, &header));
             EXPECT_SUCCESS(s2n_record_parse(conn));
-            EXPECT_EQUAL(content_type, TLS_APPLICATION_DATA);
-            EXPECT_EQUAL(fragment_length, predicted_length);
+            EXPECT_EQUAL(header.content_type, TLS_APPLICATION_DATA);
+            EXPECT_EQUAL(header.length, predicted_length);
 
             EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->header_in));
             EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->in));
@@ -303,12 +301,11 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_stuffer_copy(&conn->out, &conn->in, s2n_stuffer_data_available(&conn->out)));
 
             /* Let's decrypt it */
-            uint8_t content_type = 0;
-            uint16_t fragment_length = 0;
-            EXPECT_SUCCESS(s2n_record_header_parse(conn, &content_type, &fragment_length));
+            struct s2n_record_header header = { 0 };
+            EXPECT_SUCCESS(s2n_record_header_parse(conn, &header));
             EXPECT_SUCCESS(s2n_record_parse(conn));
-            EXPECT_EQUAL(content_type, TLS_APPLICATION_DATA);
-            EXPECT_EQUAL(fragment_length, predicted_length);
+            EXPECT_EQUAL(header.content_type, TLS_APPLICATION_DATA);
+            EXPECT_EQUAL(header.length, predicted_length);
 
             EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->header_in));
             EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->in));
@@ -379,12 +376,11 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_stuffer_copy(&conn->out, &conn->in, s2n_stuffer_data_available(&conn->out)));
 
             /* Let's decrypt it */
-            uint8_t content_type = 0;
-            uint16_t fragment_length = 0;
-            EXPECT_SUCCESS(s2n_record_header_parse(conn, &content_type, &fragment_length));
+            struct s2n_record_header header = { 0 };
+            EXPECT_SUCCESS(s2n_record_header_parse(conn, &header));
             EXPECT_SUCCESS(s2n_record_parse(conn));
-            EXPECT_EQUAL(content_type, TLS_APPLICATION_DATA);
-            EXPECT_EQUAL(fragment_length, predicted_length);
+            EXPECT_EQUAL(header.content_type, TLS_APPLICATION_DATA);
+            EXPECT_EQUAL(header.length, predicted_length);
 
             EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->header_in));
             EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->in));

--- a/tests/unit/s2n_aes_test.c
+++ b/tests/unit/s2n_aes_test.c
@@ -99,12 +99,11 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_stuffer_copy(&conn->out, &conn->in, s2n_stuffer_data_available(&conn->out)));
 
         /* Let's decrypt it */
-        uint8_t content_type = 0;
-        uint16_t fragment_length = 0;
-        EXPECT_SUCCESS(s2n_record_header_parse(conn, &content_type, &fragment_length));
+        struct s2n_record_header header = { 0 };
+        EXPECT_SUCCESS(s2n_record_header_parse(conn, &header));
         EXPECT_SUCCESS(s2n_record_parse(conn));
-        EXPECT_EQUAL(content_type, TLS_APPLICATION_DATA);
-        EXPECT_EQUAL(fragment_length, predicted_length);
+        EXPECT_EQUAL(header.content_type, TLS_APPLICATION_DATA);
+        EXPECT_EQUAL(header.length, predicted_length);
 
         EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->header_in));
         EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->in));
@@ -165,12 +164,11 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_stuffer_copy(&conn->out, &conn->in, s2n_stuffer_data_available(&conn->out)));
 
         /* Let's decrypt it */
-        uint8_t content_type = 0;
-        uint16_t fragment_length = 0;
-        EXPECT_SUCCESS(s2n_record_header_parse(conn, &content_type, &fragment_length));
+        struct s2n_record_header header = { 0 };
+        EXPECT_SUCCESS(s2n_record_header_parse(conn, &header));
         EXPECT_SUCCESS(s2n_record_parse(conn));
-        EXPECT_EQUAL(content_type, TLS_APPLICATION_DATA);
-        EXPECT_EQUAL(fragment_length, predicted_length);
+        EXPECT_EQUAL(header.content_type, TLS_APPLICATION_DATA);
+        EXPECT_EQUAL(header.length, predicted_length);
 
         EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->header_in));
         EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->in));

--- a/tests/unit/s2n_handshake_io_errors_test.c
+++ b/tests/unit/s2n_handshake_io_errors_test.c
@@ -111,7 +111,18 @@ int main(int argc, char **argv)
         /* Set up encryption on the server */
         EXPECT_OK(s2n_connection_set_secrets(server_conn));
 
-        /* Read the ClientHello */
+        /* Rewrite the record header to look like a valid TLS 1.3 encrypted
+         * record (APPLICATION_DATA, version 0x0303) so that the AAD is
+         * correctly constructed. The payload is still the unencrypted
+         * ClientHello, so AEAD decryption will fail. */
+        uint32_t record_size = s2n_stuffer_data_available(&io_stuffer);
+        EXPECT_TRUE(record_size > S2N_TLS_RECORD_HEADER_LENGTH);
+        uint8_t *wire = io_stuffer.blob.data + io_stuffer.read_cursor;
+        wire[0] = TLS_APPLICATION_DATA;
+        wire[1] = 0x03;
+        wire[2] = 0x03;
+
+        /* Read the record — decryption should fail */
         EXPECT_ERROR_WITH_ERRNO(s2n_negotiate_until_message(server_conn, &blocked, SERVER_HELLO),
                 S2N_ERR_DECRYPT);
 

--- a/tests/unit/s2n_rc4_test.c
+++ b/tests/unit/s2n_rc4_test.c
@@ -111,12 +111,11 @@ int main(int argc, char **argv)
             EXPECT_EQUAL(bytes_written + 20, s2n_stuffer_data_available(&conn->in));
 
             /* Let's decrypt it */
-            uint8_t content_type = 0;
-            uint16_t fragment_length = 0;
-            EXPECT_SUCCESS(s2n_record_header_parse(conn, &content_type, &fragment_length));
+            struct s2n_record_header header = { 0 };
+            EXPECT_SUCCESS(s2n_record_header_parse(conn, &header));
             EXPECT_SUCCESS(s2n_record_parse(conn));
-            EXPECT_EQUAL(content_type, TLS_APPLICATION_DATA);
-            EXPECT_EQUAL(fragment_length, predicted_length);
+            EXPECT_EQUAL(header.content_type, TLS_APPLICATION_DATA);
+            EXPECT_EQUAL(header.length, predicted_length);
 
             EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->header_in));
             EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->in));

--- a/tests/unit/s2n_record_test.c
+++ b/tests/unit/s2n_record_test.c
@@ -123,12 +123,12 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_stuffer_copy(&conn->out, &conn->header_in, 5));
         EXPECT_SUCCESS(s2n_stuffer_copy(&conn->out, &conn->in, s2n_stuffer_data_available(&conn->out)));
 
-        uint8_t content_type = 0;
-        uint16_t fragment_length = 0;
-        EXPECT_SUCCESS(s2n_record_header_parse(conn, &content_type, &fragment_length));
+        struct s2n_record_header header = { 0 };
+        EXPECT_SUCCESS(s2n_record_header_parse(conn, &header));
         EXPECT_SUCCESS(s2n_record_parse(conn));
-        EXPECT_EQUAL(content_type, TLS_ALERT);
-        EXPECT_EQUAL(fragment_length, bytes_written);
+        EXPECT_EQUAL(header.content_type, TLS_ALERT);
+        EXPECT_EQUAL(header.version, 0x0302);
+        EXPECT_EQUAL(header.length, bytes_written);
     }
 
     /* test a fake streaming cipher with a MAC */
@@ -184,12 +184,12 @@ int main(int argc, char **argv)
         uint8_t original_seq_num[8];
         EXPECT_MEMCPY_SUCCESS(original_seq_num, conn->server->client_sequence_number, 8);
 
-        uint8_t content_type = 0;
-        uint16_t fragment_length = 0;
-        EXPECT_SUCCESS(s2n_record_header_parse(conn, &content_type, &fragment_length));
+        struct s2n_record_header header = { 0 };
+        EXPECT_SUCCESS(s2n_record_header_parse(conn, &header));
         EXPECT_SUCCESS(s2n_record_parse(conn));
-        EXPECT_EQUAL(content_type, TLS_ALERT);
-        EXPECT_EQUAL(fragment_length, predicted_length);
+        EXPECT_EQUAL(header.content_type, TLS_ALERT);
+        EXPECT_EQUAL(header.version, 0x0302);
+        EXPECT_EQUAL(header.length, predicted_length);
 
         /* Simulate a replay attack and verify that replaying the same record
          * fails due to the sequence number check */
@@ -205,7 +205,7 @@ int main(int argc, char **argv)
          * won't parse
          */
         uint64_t byte_to_corrupt = 0;
-        EXPECT_OK(s2n_public_random(fragment_length, &byte_to_corrupt));
+        EXPECT_OK(s2n_public_random(header.length, &byte_to_corrupt));
         EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->header_in));
         EXPECT_SUCCESS(s2n_stuffer_wipe(&conn->in));
         EXPECT_SUCCESS(s2n_stuffer_reread(&conn->out));
@@ -278,12 +278,12 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_stuffer_copy(&conn->out, &conn->header_in, 5));
         EXPECT_SUCCESS(s2n_stuffer_copy(&conn->out, &conn->in, s2n_stuffer_data_available(&conn->out)));
 
-        uint8_t content_type = 0;
-        uint16_t fragment_length = 0;
-        EXPECT_SUCCESS(s2n_record_header_parse(conn, &content_type, &fragment_length));
+        struct s2n_record_header header = { 0 };
+        EXPECT_SUCCESS(s2n_record_header_parse(conn, &header));
         EXPECT_SUCCESS(s2n_record_parse(conn));
-        EXPECT_EQUAL(content_type, TLS_APPLICATION_DATA);
-        EXPECT_EQUAL(fragment_length, predicted_length);
+        EXPECT_EQUAL(header.content_type, TLS_APPLICATION_DATA);
+        EXPECT_EQUAL(header.version, 0x0301);
+        EXPECT_EQUAL(header.length, predicted_length);
     }
 
     /* Test a mock block cipher with a mac - in TLS1.1+ mode */
@@ -346,12 +346,12 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_stuffer_copy(&conn->out, &conn->header_in, 5));
         EXPECT_SUCCESS(s2n_stuffer_copy(&conn->out, &conn->in, s2n_stuffer_data_available(&conn->out)));
 
-        uint8_t content_type = 0;
-        uint16_t fragment_length = 0;
-        EXPECT_SUCCESS(s2n_record_header_parse(conn, &content_type, &fragment_length));
+        struct s2n_record_header header = { 0 };
+        EXPECT_SUCCESS(s2n_record_header_parse(conn, &header));
         EXPECT_SUCCESS(s2n_record_parse(conn));
-        EXPECT_EQUAL(content_type, TLS_APPLICATION_DATA);
-        EXPECT_EQUAL(fragment_length, predicted_length);
+        EXPECT_EQUAL(header.content_type, TLS_APPLICATION_DATA);
+        EXPECT_EQUAL(header.version, 0x0302);
+        EXPECT_EQUAL(header.length, predicted_length);
     }
 
     /* Test TLS record limit */
@@ -386,15 +386,14 @@ int main(int argc, char **argv)
 
         /* Trigger condition to check for protocol version */
         conn->actual_protocol_version_established = 1;
-        uint8_t content_type = 0;
-        uint16_t fragment_length = 0;
-        EXPECT_SUCCESS(s2n_record_header_parse(conn, &content_type, &fragment_length));
+        struct s2n_record_header header = { 0 };
+        EXPECT_SUCCESS(s2n_record_header_parse(conn, &header));
 
         /* If record version on wire is TLS 1.3, check s2n_record_header_parse fails */
         EXPECT_SUCCESS(s2n_stuffer_reread(&conn->header_in));
         conn->header_in.blob.data[1] = 3;
         conn->header_in.blob.data[2] = 4;
-        EXPECT_FAILURE_WITH_ERRNO(s2n_record_header_parse(conn, &content_type, &fragment_length), S2N_ERR_BAD_MESSAGE);
+        EXPECT_FAILURE_WITH_ERRNO(s2n_record_header_parse(conn, &header), S2N_ERR_BAD_MESSAGE);
     };
 
     /* Test: ApplicationData MUST be encrypted */
@@ -415,25 +414,24 @@ int main(int argc, char **argv)
     {
         DEFER_CLEANUP(struct s2n_connection *server_conn = s2n_connection_new(S2N_SERVER),
                 s2n_connection_ptr_free);
-        uint8_t content_type = 0;
-        uint16_t fragment_length = 0;
-        uint8_t header[5] = { 0x16, /* Record type */
+        struct s2n_record_header parsed_header = { 0 };
+        uint8_t header_bytes[5] = { 0x16, /* Record type */
             0x03, 0x01,             /* Protocol version: TLS10 */
             0x00, 0x00 };           /* Record size */
 
-        uint8_t altered_header[5] = { 0x16, /* Record type */
+        uint8_t altered_header_bytes[5] = { 0x16, /* Record type */
             0x03, 0x03,                     /* Protocol version: TLS12 */
             0x00, 0x00 };                   /* Record size */
 
-        EXPECT_SUCCESS(s2n_stuffer_write_bytes(&server_conn->header_in, header, sizeof(header)));
-        EXPECT_SUCCESS(s2n_record_header_parse(server_conn, &content_type, &fragment_length));
+        EXPECT_SUCCESS(s2n_stuffer_write_bytes(&server_conn->header_in, header_bytes, sizeof(header_bytes)));
+        EXPECT_SUCCESS(s2n_record_header_parse(server_conn, &parsed_header));
         /* Record TLS version is retrieved as written in the header */
         EXPECT_EQUAL(server_conn->client_hello.legacy_record_version, S2N_TLS10);
 
         EXPECT_SUCCESS(s2n_stuffer_wipe(&server_conn->header_in));
 
-        EXPECT_SUCCESS(s2n_stuffer_write_bytes(&server_conn->header_in, altered_header, sizeof(header)));
-        EXPECT_SUCCESS(s2n_record_header_parse(server_conn, &content_type, &fragment_length));
+        EXPECT_SUCCESS(s2n_stuffer_write_bytes(&server_conn->header_in, altered_header_bytes, sizeof(altered_header_bytes)));
+        EXPECT_SUCCESS(s2n_record_header_parse(server_conn, &parsed_header));
         /* Record TLS version is unchanged even though a different TLS version was in the record header */
         EXPECT_EQUAL(server_conn->client_hello.legacy_record_version, S2N_TLS10);
     }

--- a/tests/unit/s2n_record_test.c
+++ b/tests/unit/s2n_record_test.c
@@ -416,12 +416,12 @@ int main(int argc, char **argv)
                 s2n_connection_ptr_free);
         struct s2n_record_header parsed_header = { 0 };
         uint8_t header_bytes[5] = { 0x16, /* Record type */
-            0x03, 0x01,             /* Protocol version: TLS10 */
-            0x00, 0x00 };           /* Record size */
+            0x03, 0x01,                   /* Protocol version: TLS10 */
+            0x00, 0x00 };                 /* Record size */
 
         uint8_t altered_header_bytes[5] = { 0x16, /* Record type */
-            0x03, 0x03,                     /* Protocol version: TLS12 */
-            0x00, 0x00 };                   /* Record size */
+            0x03, 0x03,                           /* Protocol version: TLS12 */
+            0x00, 0x00 };                         /* Record size */
 
         EXPECT_SUCCESS(s2n_stuffer_write_bytes(&server_conn->header_in, header_bytes, sizeof(header_bytes)));
         EXPECT_SUCCESS(s2n_record_header_parse(server_conn, &parsed_header));

--- a/tests/unit/s2n_tls13_record_aead_test.c
+++ b/tests/unit/s2n_tls13_record_aead_test.c
@@ -101,28 +101,31 @@ int main(int argc, char **argv)
     /* Test s2n_tls13_aead_aad_init() */
     {
         s2n_stack_blob(aad, S2N_TLS13_AAD_LEN, S2N_TLS13_AAD_LEN);
-        EXPECT_OK(s2n_tls13_aead_aad_init(662, 12, &aad));
+        struct s2n_record_header header = {
+            .content_type = TLS_APPLICATION_DATA,
+            .version = 0x0303,
+            .length = 662 + 12,
+        };
+        EXPECT_OK(s2n_tls13_aead_aad_init(&header, &aad));
         S2N_BLOB_FROM_HEX(expected_aad, "17030302a2");
         S2N_BLOB_EXPECT_EQUAL(expected_aad, aad);
 
         /* record length 16640 should be valid */
         EXPECT_SUCCESS(s2n_blob_zero(&aad));
-        EXPECT_OK(s2n_tls13_aead_aad_init(16628, 12, &aad));
+        header.length = 16628 + 12;
+        EXPECT_OK(s2n_tls13_aead_aad_init(&header, &aad));
 
         /* record length 16641 should be invalid */
         EXPECT_SUCCESS(s2n_blob_zero(&aad));
-        EXPECT_ERROR_WITH_ERRNO(s2n_tls13_aead_aad_init(16629, 12, &aad), S2N_ERR_RECORD_LIMIT);
+        header.length = 16629 + 12;
+        EXPECT_ERROR_WITH_ERRNO(s2n_tls13_aead_aad_init(&header, &aad), S2N_ERR_RECORD_LIMIT);
 
         /* Test failure case: No AAD should be invalid */
-        EXPECT_SUCCESS(s2n_blob_zero(&aad));
-        EXPECT_ERROR(s2n_tls13_aead_aad_init(16629, 12, NULL));
-
-        /* Test failure case: 0-length tag should be invalid */
-        EXPECT_SUCCESS(s2n_blob_zero(&aad));
-        EXPECT_ERROR(s2n_tls13_aead_aad_init(16628, 0, &aad));
+        EXPECT_ERROR(s2n_tls13_aead_aad_init(&header, NULL));
 
         /* Test failure case: invalid record length (-1) should be invalid */
-        EXPECT_ERROR(s2n_tls13_aead_aad_init(-1, 0, &aad));
+        header.length = UINT16_MAX;
+        EXPECT_ERROR(s2n_tls13_aead_aad_init(&header, &aad));
     }
 
     /* Test s2n_tls13_aes_128_gcm_sha256 cipher suite with TLS 1.3 test vectors */
@@ -149,6 +152,7 @@ int main(int argc, char **argv)
         /* Test parsing of tls 1.3 aead record */
         struct s2n_record_header record_header = {
             .content_type = TLS_APPLICATION_DATA,
+            .version = 0x0303,
             .length = protected_record.size,
         };
         EXPECT_SUCCESS(s2n_record_parse_aead(
@@ -318,6 +322,7 @@ int main(int argc, char **argv)
         /* Decrypt payload */
         struct s2n_record_header decrypt_header = {
             .content_type = TLS_APPLICATION_DATA,
+            .version = 0x0303,
             .length = encrypted.size,
         };
         EXPECT_SUCCESS(s2n_record_parse_aead(

--- a/tests/unit/s2n_tls13_record_aead_test.c
+++ b/tests/unit/s2n_tls13_record_aead_test.c
@@ -147,11 +147,14 @@ int main(int argc, char **argv)
         S2N_BLOB_FROM_HEX(iv, "5d313eb2671276ee13000b30");
 
         /* Test parsing of tls 1.3 aead record */
+        struct s2n_record_header record_header = {
+            .content_type = TLS_APPLICATION_DATA,
+            .length = protected_record.size,
+        };
         EXPECT_SUCCESS(s2n_record_parse_aead(
                 cipher_suite,
                 conn,
-                0, /* content_type doesn't matter for TLS 1.3 */
-                protected_record.size,
+                &record_header,
                 iv.data, /* implicit_iv */
                 NULL,    /* mac not used for TLS 1.3 */
                 conn->secure->client_sequence_number,
@@ -178,31 +181,31 @@ int main(int argc, char **argv)
 
         /* Repeat the test to prove RESET_TEST works */
         RESET_TEST
-        EXPECT_SUCCESS(s2n_record_parse_aead(cipher_suite, conn, 0, protected_record.size,
+        EXPECT_SUCCESS(s2n_record_parse_aead(cipher_suite, conn, &record_header,
                 iv.data, NULL, conn->secure->client_sequence_number, &session_key));
 
         /* Test record parsing failure from aead tag change */
         RESET_TEST
         conn->in.blob.data[protected_record.size - 2]++;
-        EXPECT_FAILURE(s2n_record_parse_aead(cipher_suite, conn, 0, protected_record.size,
+        EXPECT_FAILURE(s2n_record_parse_aead(cipher_suite, conn, &record_header,
                 iv.data, NULL, conn->secure->client_sequence_number, &session_key));
 
         /* Test incorrect ciphertext changes fails parsing */
         RESET_TEST
         conn->in.blob.data[0]++;
-        EXPECT_FAILURE(s2n_record_parse_aead(cipher_suite, conn, 0, protected_record.size,
+        EXPECT_FAILURE(s2n_record_parse_aead(cipher_suite, conn, &record_header,
                 iv.data, NULL, conn->secure->client_sequence_number, &session_key));
 
         /* Test wrong sequence number fails parsing */
         RESET_TEST
         conn->secure->client_sequence_number[7] = 1;
-        EXPECT_FAILURE(s2n_record_parse_aead(cipher_suite, conn, 0, protected_record.size,
+        EXPECT_FAILURE(s2n_record_parse_aead(cipher_suite, conn, &record_header,
                 iv.data, NULL, conn->secure->client_sequence_number, &session_key));
 
         /* Test IV changes fails parsing */
         RESET_TEST
         iv.data[0]++;
-        EXPECT_FAILURE(s2n_record_parse_aead(cipher_suite, conn, 0, protected_record.size,
+        EXPECT_FAILURE(s2n_record_parse_aead(cipher_suite, conn, &record_header,
                 iv.data, NULL, conn->secure->client_sequence_number, &session_key));
 
         EXPECT_SUCCESS(s2n_connection_free(conn));
@@ -313,11 +316,14 @@ int main(int argc, char **argv)
         };
 
         /* Decrypt payload */
+        struct s2n_record_header decrypt_header = {
+            .content_type = TLS_APPLICATION_DATA,
+            .length = encrypted.size,
+        };
         EXPECT_SUCCESS(s2n_record_parse_aead(
                 cipher_suite,
                 conn,
-                0, /* content_type */
-                encrypted.size,
+                &decrypt_header,
                 iv.data, /* implicit_iv */
                 NULL,    /* mac not used for TLS 1.3 */
                 conn->secure->client_sequence_number,

--- a/tls/s2n_aead.c
+++ b/tls/s2n_aead.c
@@ -47,10 +47,29 @@ S2N_RESULT s2n_aead_aad_init(const struct s2n_connection *conn, uint8_t *sequenc
     return S2N_RESULT_OK;
 }
 
-/* Prepares an AAD (additional authentication data) for a TLS 1.3 AEAD record */
-S2N_RESULT s2n_tls13_aead_aad_init(uint16_t record_length, uint8_t tag_length, struct s2n_blob *additional_data)
+/* Prepares an AAD (additional authentication data) for a TLS 1.3 AEAD record.
+ *
+ * While the outer wire content type and outer wire version are "hard-coded", it
+ * is still necessary to check that they 
+ * - match the expected values
+ * - are correctly included in the AAD
+ * 
+ * This is necessary to ensure the integrity of the record.
+ * 
+ * - `wire_content_type`: the content type from the outer record header of the
+ *   TLS 1.3 record. For an encrypted record, this should always be "application data".
+ * - `wire_version`: the protocol version from the outer record header of the 
+ *   TLS 1.3 record. This is expected to be TLS 1.2. The "real" protocol version
+ *   is decided during the handshake.
+ * - `record_length`: The length of encrypted payload, minus the authentication 
+ *   tag. This is an internal s2n-tls concept, and not connected to any values in
+ *   the RFC.
+ * - `tag_length`: The length of the AEAD authentication tag. Length is determined
+ *   by the negotiated cipher.
+ * - `additional_data`: The AAD construction to be used with the record content
+ */
+S2N_RESULT s2n_tls13_aead_aad_init(struct s2n_record_header* header, struct s2n_blob *additional_data)
 {
-    RESULT_ENSURE_GT(tag_length, 0);
     RESULT_ENSURE_REF(additional_data);
     RESULT_ENSURE_GTE(additional_data->size, S2N_TLS13_AAD_LEN);
 
@@ -67,7 +86,8 @@ S2N_RESULT s2n_tls13_aead_aad_init(uint16_t record_length, uint8_t tag_length, s
      *#    versions of TLS.  The actual content type of the record is found
      *#    in TLSInnerPlaintext.type after decryption.
      **/
-    data[idx++] = TLS_APPLICATION_DATA;
+    RESULT_ENSURE(header->content_type == TLS_APPLICATION_DATA, S2N_ERR_BAD_MESSAGE);
+    data[idx++] = header->content_type;
 
     /**
      *= https://www.rfc-editor.org/rfc/rfc8446#section-5.2
@@ -79,8 +99,10 @@ S2N_RESULT s2n_tls13_aead_aad_init(uint16_t record_length, uint8_t tag_length, s
      *#    ServerHello messages, authenticates the protocol version, so this
      *#    value is redundant.
      */
-    data[idx++] = 0x03;
-    data[idx++] = 0x03;
+    RESULT_ENSURE(header->version == 0x0303, S2N_ERR_BAD_MESSAGE);
+    /* data needs to be network order */
+    data[idx++] = header->version >> 8;
+    data[idx++] = header->version & UINT8_MAX;
 
     /**
      *= https://www.rfc-editor.org/rfc/rfc8446#section-5.2
@@ -92,10 +114,9 @@ S2N_RESULT s2n_tls13_aead_aad_init(uint16_t record_length, uint8_t tag_length, s
      *#    record that exceeds this length MUST terminate the connection with
      *#    a "record_overflow" alert.
      */
-    uint16_t length = record_length + tag_length;
-    RESULT_ENSURE(length <= (1 << 14) + 256, S2N_ERR_RECORD_LIMIT);
-    data[idx++] = length >> 8;
-    data[idx++] = length & UINT8_MAX;
+    RESULT_ENSURE(header->length <= (1 << 14) + 256, S2N_ERR_RECORD_LIMIT);
+    data[idx++] = header->length >> 8;
+    data[idx++] = header->length & UINT8_MAX;
 
     /* Double check no overflow */
     RESULT_ENSURE_LTE(idx, additional_data->size);

--- a/tls/s2n_record.h
+++ b/tls/s2n_record.h
@@ -69,13 +69,19 @@
 #define S2N_TLS_MAX_RECORD_LEN_FOR(frag) S2N_TLS12_MAX_RECORD_LEN_FOR(frag)
 #define S2N_TLS_MAXIMUM_RECORD_LENGTH    S2N_TLS_MAX_RECORD_LEN_FOR(S2N_TLS_MAXIMUM_FRAGMENT_LENGTH)
 
+struct s2n_record_header {
+    uint8_t content_type;
+    uint16_t version;
+    uint16_t length;
+};
+
 S2N_RESULT s2n_record_max_write_size(struct s2n_connection *conn, uint16_t max_fragment_size, uint16_t *max_record_size);
 S2N_RESULT s2n_record_max_write_payload_size(struct s2n_connection *conn, uint16_t *max_fragment_size);
 S2N_RESULT s2n_record_min_write_payload_size(struct s2n_connection *conn, uint16_t *payload_size);
 S2N_RESULT s2n_record_write(struct s2n_connection *conn, uint8_t content_type, struct s2n_blob *in);
 int s2n_record_writev(struct s2n_connection *conn, uint8_t content_type, const struct iovec *in, int in_count, size_t offs, size_t to_write);
 int s2n_record_parse(struct s2n_connection *conn);
-int s2n_record_header_parse(struct s2n_connection *conn, uint8_t *content_type, uint16_t *fragment_length);
+int s2n_record_header_parse(struct s2n_connection *conn, struct s2n_record_header *header);
 int s2n_tls13_parse_record_type(struct s2n_stuffer *stuffer, uint8_t *record_type);
 int s2n_sslv2_record_header_parse(struct s2n_connection *conn, uint8_t *record_type, uint8_t *client_protocol_version, uint16_t *fragment_length);
 int s2n_verify_cbc(struct s2n_connection *conn, struct s2n_hmac_state *hmac, struct s2n_blob *decrypted);

--- a/tls/s2n_record.h
+++ b/tls/s2n_record.h
@@ -86,5 +86,6 @@ int s2n_tls13_parse_record_type(struct s2n_stuffer *stuffer, uint8_t *record_typ
 int s2n_sslv2_record_header_parse(struct s2n_connection *conn, uint8_t *record_type, uint8_t *client_protocol_version, uint16_t *fragment_length);
 int s2n_verify_cbc(struct s2n_connection *conn, struct s2n_hmac_state *hmac, struct s2n_blob *decrypted);
 S2N_RESULT s2n_aead_aad_init(const struct s2n_connection *conn, uint8_t *sequence_number, uint8_t content_type, uint16_t record_length, struct s2n_blob *ad);
-S2N_RESULT s2n_tls13_aead_aad_init(uint16_t record_length, uint8_t tag_length, struct s2n_blob *ad);
+S2N_RESULT s2n_tls13_aead_aad_init(struct s2n_record_header *header, struct s2n_blob *ad);
+S2N_RESULT s2n_record_header_version(const uint8_t (*record_header)[5], uint16_t *out);
 S2N_RESULT s2n_record_wipe(struct s2n_connection *conn);

--- a/tls/s2n_record_read.c
+++ b/tls/s2n_record_read.c
@@ -240,7 +240,7 @@ static bool s2n_is_tls13_plaintext_content(struct s2n_connection *conn, uint8_t 
 
 int s2n_record_parse(struct s2n_connection *conn)
 {
-    struct s2n_record_header header = {0};
+    struct s2n_record_header header = { 0 };
     POSIX_GUARD(s2n_record_header_parse(conn, &header));
 
     struct s2n_crypto_parameters *current_client_crypto = conn->client;

--- a/tls/s2n_record_read.c
+++ b/tls/s2n_record_read.c
@@ -93,16 +93,19 @@ int s2n_sslv2_record_header_parse(
     return 0;
 }
 
+/**
+ * - `conn`: connection with record header available in internal buffers
+ * - `header`: output parameter, populated after the header is parsed
+ */
 int s2n_record_header_parse(
         struct s2n_connection *conn,
-        uint8_t *content_type,
-        uint16_t *fragment_length)
+        struct s2n_record_header *header)
 {
     struct s2n_stuffer *in = &conn->header_in;
 
     S2N_ERROR_IF(s2n_stuffer_data_available(in) < S2N_TLS_RECORD_HEADER_LENGTH, S2N_ERR_BAD_MESSAGE);
 
-    POSIX_GUARD(s2n_stuffer_read_uint8(in, content_type));
+    POSIX_GUARD(s2n_stuffer_read_uint8(in, &header->content_type));
 
     /* Once the protocol version is established, reject records with
      * content_type values outside the valid TLS set {20, 21, 22, 23}.
@@ -118,7 +121,7 @@ int s2n_record_header_parse(
      * the protocol version.
      */
     if (conn->actual_protocol_version_established) {
-        switch (*content_type) {
+        switch (header->content_type) {
             case TLS_CHANGE_CIPHER_SPEC:
             case TLS_ALERT:
             case TLS_HANDSHAKE:
@@ -129,10 +132,12 @@ int s2n_record_header_parse(
         }
     }
 
-    uint8_t protocol_version[S2N_TLS_PROTOCOL_VERSION_LEN];
-    POSIX_GUARD(s2n_stuffer_read_bytes(in, protocol_version, S2N_TLS_PROTOCOL_VERSION_LEN));
+    POSIX_GUARD(s2n_stuffer_read_uint16(in, &header->version));
+    uint8_t major_version = header->version >> 8;
+    uint8_t minor_version = header->version & 0xFF;
 
-    const uint8_t version = (protocol_version[0] * 10) + protocol_version[1];
+    /* s2n has it's own legacy format for storing version numbers */
+    const uint8_t version = (major_version * 10) + minor_version;
     /* We record the protocol version in the first record seen by the server for fingerprinting usecases */
     if (!conn->client_hello.record_version_recorded) {
         conn->client_hello.legacy_record_version = version;
@@ -162,7 +167,7 @@ int s2n_record_header_parse(
      *# endpoint that receives a record that exceeds this length MUST
      *# terminate the connection with a "record_overflow" alert.
      */
-    POSIX_GUARD(s2n_stuffer_read_uint16(in, fragment_length));
+    POSIX_GUARD(s2n_stuffer_read_uint16(in, &header->length));
     POSIX_GUARD(s2n_stuffer_reread(in));
 
     return 0;
@@ -235,13 +240,12 @@ static bool s2n_is_tls13_plaintext_content(struct s2n_connection *conn, uint8_t 
 
 int s2n_record_parse(struct s2n_connection *conn)
 {
-    uint8_t content_type = 0;
-    uint16_t encrypted_length = 0;
-    POSIX_GUARD(s2n_record_header_parse(conn, &content_type, &encrypted_length));
+    struct s2n_record_header header = {0};
+    POSIX_GUARD(s2n_record_header_parse(conn, &header));
 
     struct s2n_crypto_parameters *current_client_crypto = conn->client;
     struct s2n_crypto_parameters *current_server_crypto = conn->server;
-    if (s2n_is_tls13_plaintext_content(conn, content_type)) {
+    if (s2n_is_tls13_plaintext_content(conn, header.content_type)) {
         POSIX_ENSURE_REF(conn->initial);
         conn->client = conn->initial;
         conn->server = conn->initial;
@@ -261,7 +265,7 @@ int s2n_record_parse(struct s2n_connection *conn)
         session_key = &conn->server->server_key;
     }
 
-    if (s2n_is_tls13_plaintext_content(conn, content_type)) {
+    if (s2n_is_tls13_plaintext_content(conn, header.content_type)) {
         conn->client = current_client_crypto;
         conn->server = current_server_crypto;
     }
@@ -269,7 +273,7 @@ int s2n_record_parse(struct s2n_connection *conn)
     /* The NULL stream cipher MUST NEVER be used for ApplicationData.
      * If ApplicationData is unencrypted, we can't trust it. */
     if (cipher_suite->record_alg->cipher == &s2n_null_cipher) {
-        POSIX_ENSURE(content_type != TLS_APPLICATION_DATA, S2N_ERR_DECRYPT);
+        POSIX_ENSURE(header.content_type != TLS_APPLICATION_DATA, S2N_ERR_DECRYPT);
     }
 
     /*
@@ -291,21 +295,21 @@ int s2n_record_parse(struct s2n_connection *conn)
      */
     if (conn->actual_protocol_version == S2N_TLS13
             && cipher_suite->record_alg->cipher != &s2n_null_cipher) {
-        POSIX_ENSURE(content_type == TLS_APPLICATION_DATA, S2N_ERR_BAD_MESSAGE);
+        POSIX_ENSURE(header.content_type == TLS_APPLICATION_DATA, S2N_ERR_BAD_MESSAGE);
     }
 
     switch (cipher_suite->record_alg->cipher->type) {
         case S2N_AEAD:
-            POSIX_GUARD(s2n_record_parse_aead(cipher_suite, conn, content_type, encrypted_length, implicit_iv, mac, sequence_number, session_key));
+            POSIX_GUARD(s2n_record_parse_aead(cipher_suite, conn, &header, implicit_iv, mac, sequence_number, session_key));
             break;
         case S2N_CBC:
-            POSIX_GUARD(s2n_record_parse_cbc(cipher_suite, conn, content_type, encrypted_length, implicit_iv, mac, sequence_number, session_key));
+            POSIX_GUARD(s2n_record_parse_cbc(cipher_suite, conn, &header, implicit_iv, mac, sequence_number, session_key));
             break;
         case S2N_COMPOSITE:
-            POSIX_GUARD(s2n_record_parse_composite(cipher_suite, conn, content_type, encrypted_length, implicit_iv, mac, sequence_number, session_key));
+            POSIX_GUARD(s2n_record_parse_composite(cipher_suite, conn, &header, implicit_iv, mac, sequence_number, session_key));
             break;
         case S2N_STREAM:
-            POSIX_GUARD(s2n_record_parse_stream(cipher_suite, conn, content_type, encrypted_length, implicit_iv, mac, sequence_number, session_key));
+            POSIX_GUARD(s2n_record_parse_stream(cipher_suite, conn, &header, implicit_iv, mac, sequence_number, session_key));
             break;
         default:
             POSIX_BAIL(S2N_ERR_CIPHER_TYPE);

--- a/tls/s2n_record_read.h
+++ b/tls/s2n_record_read.h
@@ -20,8 +20,7 @@
 int s2n_record_parse_aead(
         const struct s2n_cipher_suite *cipher_suite,
         struct s2n_connection *conn,
-        uint8_t content_type,
-        uint16_t encrypted_length,
+        struct s2n_record_header *header,
         uint8_t *implicit_iv,
         struct s2n_hmac_state *mac,
         uint8_t *sequence_number,
@@ -29,8 +28,7 @@ int s2n_record_parse_aead(
 int s2n_record_parse_cbc(
         const struct s2n_cipher_suite *cipher_suite,
         struct s2n_connection *conn,
-        uint8_t content_type,
-        uint16_t encrypted_length,
+        struct s2n_record_header *header,
         uint8_t *implicit_iv,
         struct s2n_hmac_state *mac,
         uint8_t *sequence_number,
@@ -38,8 +36,7 @@ int s2n_record_parse_cbc(
 int s2n_record_parse_composite(
         const struct s2n_cipher_suite *cipher_suite,
         struct s2n_connection *conn,
-        uint8_t content_type,
-        uint16_t encrypted_length,
+        struct s2n_record_header *header,
         uint8_t *implicit_iv,
         struct s2n_hmac_state *mac,
         uint8_t *sequence_number,
@@ -47,8 +44,7 @@ int s2n_record_parse_composite(
 int s2n_record_parse_stream(
         const struct s2n_cipher_suite *cipher_suite,
         struct s2n_connection *conn,
-        uint8_t content_type,
-        uint16_t encrypted_length,
+        struct s2n_record_header *header,
         uint8_t *implicit_iv,
         struct s2n_hmac_state *mac,
         uint8_t *sequence_number,

--- a/tls/s2n_record_read_aead.c
+++ b/tls/s2n_record_read_aead.c
@@ -30,8 +30,7 @@
 int s2n_record_parse_aead(
         const struct s2n_cipher_suite *cipher_suite,
         struct s2n_connection *conn,
-        uint8_t content_type,
-        uint16_t encrypted_length,
+        struct s2n_record_header *header,
         uint8_t *implicit_iv,
         struct s2n_hmac_state *mac,
         uint8_t *sequence_number,
@@ -42,7 +41,7 @@ int s2n_record_parse_aead(
     s2n_stack_blob(aad, is_tls13_record ? S2N_TLS13_AAD_LEN : S2N_TLS_MAX_AAD_LEN, S2N_TLS_MAX_AAD_LEN);
 
     struct s2n_blob en = { 0 };
-    POSIX_GUARD(s2n_blob_init(&en, s2n_stuffer_raw_read(&conn->in, encrypted_length), encrypted_length));
+    POSIX_GUARD(s2n_blob_init(&en, s2n_stuffer_raw_read(&conn->in, header->length), header->length));
     POSIX_ENSURE_REF(en.data);
     /* In AEAD mode, the explicit IV is in the record */
     POSIX_ENSURE_GTE(en.size, cipher_suite->record_alg->cipher->io.aead.record_iv_size);
@@ -79,7 +78,7 @@ int s2n_record_parse_aead(
     /* Set the IV size to the amount of data written */
     iv.size = s2n_stuffer_data_available(&iv_stuffer);
 
-    uint16_t payload_length = encrypted_length;
+    uint16_t payload_length = header->length;
     /* remove the AEAD overhead from the record size */
     POSIX_ENSURE_GTE(payload_length, cipher_suite->record_alg->cipher->io.aead.record_iv_size + cipher_suite->record_alg->cipher->io.aead.tag_size);
     payload_length -= cipher_suite->record_alg->cipher->io.aead.record_iv_size;
@@ -88,7 +87,7 @@ int s2n_record_parse_aead(
     if (is_tls13_record) {
         POSIX_GUARD_RESULT(s2n_tls13_aead_aad_init(payload_length, cipher_suite->record_alg->cipher->io.aead.tag_size, &aad));
     } else {
-        POSIX_GUARD_RESULT(s2n_aead_aad_init(conn, sequence_number, content_type, payload_length, &aad));
+        POSIX_GUARD_RESULT(s2n_aead_aad_init(conn, sequence_number, header->content_type, payload_length, &aad));
     }
 
     /* Decrypt stuff! */
@@ -108,7 +107,6 @@ int s2n_record_parse_aead(
      * for reading the plaintext data.
      */
     POSIX_GUARD(s2n_stuffer_reread(&conn->in));
-    POSIX_GUARD(s2n_stuffer_reread(&conn->header_in));
 
     /* Skip the IV, if any */
     if (conn->actual_protocol_version >= S2N_TLS12) {

--- a/tls/s2n_record_read_aead.c
+++ b/tls/s2n_record_read_aead.c
@@ -85,7 +85,7 @@ int s2n_record_parse_aead(
     payload_length -= cipher_suite->record_alg->cipher->io.aead.tag_size;
 
     if (is_tls13_record) {
-        POSIX_GUARD_RESULT(s2n_tls13_aead_aad_init(payload_length, cipher_suite->record_alg->cipher->io.aead.tag_size, &aad));
+        POSIX_GUARD_RESULT(s2n_tls13_aead_aad_init(header, &aad));
     } else {
         POSIX_GUARD_RESULT(s2n_aead_aad_init(conn, sequence_number, header->content_type, payload_length, &aad));
     }

--- a/tls/s2n_record_read_cbc.c
+++ b/tls/s2n_record_read_cbc.c
@@ -86,11 +86,11 @@ int s2n_record_parse_cbc(
 
     if (conn->actual_protocol_version == S2N_SSLv3) {
         POSIX_GUARD(s2n_hmac_update(mac, &header->content_type, 1));
-        POSIX_GUARD(s2n_hmac_update(mac, &payload_length, sizeof(payload_length)));
+        POSIX_GUARD(s2n_hmac_update_u16(mac, payload_length));
     } else {
         POSIX_GUARD(s2n_hmac_update(mac, &header->content_type, sizeof(header->content_type)));
-        POSIX_GUARD(s2n_hmac_update(mac, &header->version, sizeof(header->version)));
-        POSIX_GUARD(s2n_hmac_update(mac, &payload_length, sizeof(payload_length)));
+        POSIX_GUARD(s2n_hmac_update_u16(mac, header->version));
+        POSIX_GUARD(s2n_hmac_update_u16(mac, payload_length));
     }
 
     struct s2n_blob seq = { .data = sequence_number, .size = S2N_TLS_SEQUENCE_NUM_LEN };

--- a/tls/s2n_record_read_cbc.c
+++ b/tls/s2n_record_read_cbc.c
@@ -29,8 +29,7 @@
 int s2n_record_parse_cbc(
         const struct s2n_cipher_suite *cipher_suite,
         struct s2n_connection *conn,
-        uint8_t content_type,
-        uint16_t encrypted_length,
+        struct s2n_record_header *header,
         uint8_t *implicit_iv,
         struct s2n_hmac_state *mac,
         uint8_t *sequence_number,
@@ -38,10 +37,7 @@ int s2n_record_parse_cbc(
 {
     struct s2n_blob iv = { .data = implicit_iv, .size = cipher_suite->record_alg->cipher->io.cbc.record_iv_size };
     uint8_t ivpad[S2N_TLS_MAX_IV_LEN];
-
-    /* Add the header to the HMAC */
-    uint8_t *header = s2n_stuffer_raw_read(&conn->header_in, S2N_TLS_RECORD_HEADER_LENGTH);
-    POSIX_ENSURE_REF(header);
+    uint16_t encrypted_length = header->length;
 
     POSIX_ENSURE_LTE(cipher_suite->record_alg->cipher->io.cbc.record_iv_size, S2N_TLS_MAX_IV_LEN);
 
@@ -85,17 +81,16 @@ int s2n_record_parse_cbc(
     uint32_t out = 0;
     POSIX_GUARD(s2n_sub_overflow(payload_length, en.data[en.size - 1] + 1, &out));
     payload_length = out;
-    /* Update the MAC */
-    header[3] = (payload_length >> 8);
-    header[4] = payload_length & 0xff;
     POSIX_GUARD(s2n_hmac_reset(mac));
     POSIX_GUARD(s2n_hmac_update(mac, sequence_number, S2N_TLS_SEQUENCE_NUM_LEN));
 
     if (conn->actual_protocol_version == S2N_SSLv3) {
-        POSIX_GUARD(s2n_hmac_update(mac, header, 1));
-        POSIX_GUARD(s2n_hmac_update(mac, header + 3, 2));
+        POSIX_GUARD(s2n_hmac_update(mac, &header->content_type, 1));
+        POSIX_GUARD(s2n_hmac_update(mac, &payload_length, sizeof(payload_length)));
     } else {
-        POSIX_GUARD(s2n_hmac_update(mac, header, S2N_TLS_RECORD_HEADER_LENGTH));
+        POSIX_GUARD(s2n_hmac_update(mac, &header->content_type, sizeof(header->content_type)));
+        POSIX_GUARD(s2n_hmac_update(mac, &header->version, sizeof(header->version)));
+        POSIX_GUARD(s2n_hmac_update(mac, &payload_length, sizeof(payload_length)));
     }
 
     struct s2n_blob seq = { .data = sequence_number, .size = S2N_TLS_SEQUENCE_NUM_LEN };
@@ -110,7 +105,6 @@ int s2n_record_parse_cbc(
      * for reading the plaintext data.
      */
     POSIX_GUARD(s2n_stuffer_reread(&conn->in));
-    POSIX_GUARD(s2n_stuffer_reread(&conn->header_in));
 
     /* Skip the IV, if any */
     if (conn->actual_protocol_version > S2N_TLS10) {

--- a/tls/s2n_record_read_composite.c
+++ b/tls/s2n_record_read_composite.c
@@ -28,8 +28,7 @@
 int s2n_record_parse_composite(
         const struct s2n_cipher_suite *cipher_suite,
         struct s2n_connection *conn,
-        uint8_t content_type,
-        uint16_t encrypted_length,
+        struct s2n_record_header *header,
         uint8_t *implicit_iv,
         struct s2n_hmac_state *mac,
         uint8_t *sequence_number,
@@ -39,14 +38,10 @@ int s2n_record_parse_composite(
     struct s2n_blob iv = { .data = implicit_iv, .size = cipher_suite->record_alg->cipher->io.comp.record_iv_size };
     uint8_t ivpad[S2N_TLS_MAX_IV_LEN];
 
-    /* Add the header to the HMAC */
-    uint8_t *header = s2n_stuffer_raw_read(&conn->header_in, S2N_TLS_RECORD_HEADER_LENGTH);
-    POSIX_ENSURE_REF(header);
-
-    struct s2n_blob en = { .size = encrypted_length, .data = s2n_stuffer_raw_read(&conn->in, encrypted_length) };
+    struct s2n_blob en = { .size = header->length, .data = s2n_stuffer_raw_read(&conn->in, header->length) };
     POSIX_ENSURE_REF(en.data);
 
-    uint16_t payload_length = encrypted_length;
+    uint16_t payload_length = header->length;
     uint8_t mac_digest_size = 0;
     POSIX_GUARD(s2n_hmac_digest_size(mac->alg, &mac_digest_size));
 
@@ -59,7 +54,7 @@ int s2n_record_parse_composite(
     /* In the decrypt case, this outputs the MAC digest length:
      * https://github.com/openssl/openssl/blob/master/crypto/evp/e_aes_cbc_hmac_sha1.c#L842 */
     int mac_size = 0;
-    POSIX_GUARD(cipher_suite->record_alg->cipher->io.comp.initial_hmac(session_key, sequence_number, content_type, conn->actual_protocol_version, payload_length, &mac_size));
+    POSIX_GUARD(cipher_suite->record_alg->cipher->io.comp.initial_hmac(session_key, sequence_number, header->content_type, conn->actual_protocol_version, payload_length, &mac_size));
 
     POSIX_ENSURE_GTE(payload_length, mac_size);
     payload_length -= mac_size;
@@ -95,7 +90,6 @@ int s2n_record_parse_composite(
      * for reading the plaintext data.
      */
     POSIX_GUARD(s2n_stuffer_reread(&conn->in));
-    POSIX_GUARD(s2n_stuffer_reread(&conn->header_in));
 
     /* Skip the IV, if any */
     if (conn->actual_protocol_version > S2N_TLS10) {

--- a/tls/s2n_record_read_stream.c
+++ b/tls/s2n_record_read_stream.c
@@ -28,21 +28,16 @@
 int s2n_record_parse_stream(
         const struct s2n_cipher_suite *cipher_suite,
         struct s2n_connection *conn,
-        uint8_t content_type,
-        uint16_t encrypted_length,
+        struct s2n_record_header *header,
         uint8_t *implicit_iv,
         struct s2n_hmac_state *mac,
         uint8_t *sequence_number,
         struct s2n_session_key *session_key)
 {
-    /* Add the header to the HMAC */
-    uint8_t *header = s2n_stuffer_raw_read(&conn->header_in, S2N_TLS_RECORD_HEADER_LENGTH);
-    POSIX_ENSURE_REF(header);
-
-    struct s2n_blob en = { .size = encrypted_length, .data = s2n_stuffer_raw_read(&conn->in, encrypted_length) };
+    struct s2n_blob en = { .size = header->length, .data = s2n_stuffer_raw_read(&conn->in, header->length) };
     POSIX_ENSURE_REF(en.data);
 
-    uint16_t payload_length = encrypted_length;
+    uint16_t payload_length = header->length;
     uint8_t mac_digest_size = 0;
     POSIX_GUARD(s2n_hmac_digest_size(mac->alg, &mac_digest_size));
 
@@ -53,16 +48,16 @@ int s2n_record_parse_stream(
     POSIX_GUARD(cipher_suite->record_alg->cipher->io.stream.decrypt(session_key, &en, &en));
 
     /* Update the MAC */
-    header[3] = (payload_length >> 8);
-    header[4] = payload_length & 0xff;
     POSIX_GUARD(s2n_hmac_reset(mac));
     POSIX_GUARD(s2n_hmac_update(mac, sequence_number, S2N_TLS_SEQUENCE_NUM_LEN));
 
     if (conn->actual_protocol_version == S2N_SSLv3) {
-        POSIX_GUARD(s2n_hmac_update(mac, header, 1));
-        POSIX_GUARD(s2n_hmac_update(mac, header + 3, 2));
+        POSIX_GUARD(s2n_hmac_update(mac, &header->content_type, 1));
+        POSIX_GUARD(s2n_hmac_update(mac, &payload_length, sizeof(payload_length)));
     } else {
-        POSIX_GUARD(s2n_hmac_update(mac, header, S2N_TLS_RECORD_HEADER_LENGTH));
+        POSIX_GUARD(s2n_hmac_update(mac, &header->content_type, sizeof(header->content_type)));
+        POSIX_GUARD(s2n_hmac_update(mac, &header->version, sizeof(header->version)));
+        POSIX_GUARD(s2n_hmac_update(mac, &payload_length, sizeof(payload_length)));
     }
 
     struct s2n_blob seq = { .data = sequence_number, .size = S2N_TLS_SEQUENCE_NUM_LEN };
@@ -83,7 +78,6 @@ int s2n_record_parse_stream(
      * for reading the plaintext data.
      */
     POSIX_GUARD(s2n_stuffer_reread(&conn->in));
-    POSIX_GUARD(s2n_stuffer_reread(&conn->header_in));
 
     /* Truncate and wipe the MAC and any padding */
     uint32_t mac_len = 0;

--- a/tls/s2n_record_read_stream.c
+++ b/tls/s2n_record_read_stream.c
@@ -53,11 +53,11 @@ int s2n_record_parse_stream(
 
     if (conn->actual_protocol_version == S2N_SSLv3) {
         POSIX_GUARD(s2n_hmac_update(mac, &header->content_type, 1));
-        POSIX_GUARD(s2n_hmac_update(mac, &payload_length, sizeof(payload_length)));
+        POSIX_GUARD(s2n_hmac_update_u16(mac, payload_length));
     } else {
         POSIX_GUARD(s2n_hmac_update(mac, &header->content_type, sizeof(header->content_type)));
-        POSIX_GUARD(s2n_hmac_update(mac, &header->version, sizeof(header->version)));
-        POSIX_GUARD(s2n_hmac_update(mac, &payload_length, sizeof(payload_length)));
+        POSIX_GUARD(s2n_hmac_update_u16(mac, header->version));
+        POSIX_GUARD(s2n_hmac_update_u16(mac, payload_length));
     }
 
     struct s2n_blob seq = { .data = sequence_number, .size = S2N_TLS_SEQUENCE_NUM_LEN };

--- a/tls/s2n_record_write.c
+++ b/tls/s2n_record_write.c
@@ -161,7 +161,16 @@ S2N_RESULT s2n_record_min_write_payload_size(struct s2n_connection *conn, uint16
     return S2N_RESULT_OK;
 }
 
-int s2n_record_write_protocol_version(struct s2n_connection *conn, uint8_t record_type, struct s2n_stuffer *out)
+/**
+ * Return the protocol version that should be written into the record header.
+ * 
+ * This is the IANA version type (u16), not the internal s2n version type (u8).
+ * 
+ * This may not be the actual protocol version that was negotiated. For example
+ * TLS 1.3 records treat the record header protocol as an "opaque" value pinned
+ * to TLS 1.2 (0x0303)
+ */
+S2N_RESULT s2n_record_protocol_version(struct s2n_connection *conn, uint8_t record_type, uint16_t *out)
 {
     uint8_t record_protocol_version = conn->actual_protocol_version;
 
@@ -202,13 +211,9 @@ int s2n_record_write_protocol_version(struct s2n_connection *conn, uint8_t recor
         record_protocol_version = S2N_TLS10;
     }
 
-    uint8_t protocol_version[S2N_TLS_PROTOCOL_VERSION_LEN];
-    protocol_version[0] = record_protocol_version / 10;
-    protocol_version[1] = record_protocol_version % 10;
+    *out = (record_protocol_version / 10 << 8) | record_protocol_version % 10;
 
-    POSIX_GUARD(s2n_stuffer_write_bytes(out, protocol_version, S2N_TLS_PROTOCOL_VERSION_LEN));
-
-    return 0;
+    return S2N_RESULT_OK;
 }
 
 static inline int s2n_record_encrypt(
@@ -454,7 +459,9 @@ int s2n_record_writev(struct s2n_connection *conn, uint8_t content_type, const s
     /* Now that we know the length, start writing the record */
     uint8_t record_type = RECORD_TYPE(is_tls13_record, content_type);
     POSIX_GUARD(s2n_stuffer_write_uint8(&record_stuffer, record_type));
-    POSIX_GUARD(s2n_record_write_protocol_version(conn, record_type, &record_stuffer));
+    uint16_t wire_protocol_version = 0;
+    POSIX_GUARD_RESULT(s2n_record_protocol_version(conn, record_type, &wire_protocol_version));
+    POSIX_GUARD(s2n_stuffer_write_uint16(&record_stuffer, wire_protocol_version));
 
     /* Compute non-payload parts of the MAC(seq num, type, proto vers, fragment length) for composite ciphers.
      * Composite "encrypt" will MAC the payload data and fill in padding.
@@ -468,7 +475,7 @@ int s2n_record_writev(struct s2n_connection *conn, uint8_t content_type, const s
 
         /* Outputs number of extra bytes required for MAC and padding */
         int pad_and_mac_len = 0;
-        POSIX_GUARD(cipher_suite->record_alg->cipher->io.comp.initial_hmac(session_key, sequence_number, content_type, conn->actual_protocol_version,
+        POSIX_GUARD(cipher_suite->record_alg->cipher->io.comp.initial_hmac(session_key, sequence_number, content_type, wire_protocol_version,
                 payload_and_eiv_len, &pad_and_mac_len));
         extra += pad_and_mac_len;
     }
@@ -511,7 +518,12 @@ int s2n_record_writev(struct s2n_connection *conn, uint8_t content_type, const s
         /* Set the IV size to the amount of data written */
         iv.size = s2n_stuffer_data_available(&iv_stuffer);
         if (is_tls13_record) {
-            POSIX_GUARD_RESULT(s2n_tls13_aead_aad_init(data_bytes_to_take + S2N_TLS_CONTENT_TYPE_LENGTH, cipher_suite->record_alg->cipher->io.aead.tag_size, &aad));
+            struct s2n_record_header header = {
+                .content_type = TLS_APPLICATION_DATA,
+                .version = 0x0303,
+                .length = data_bytes_to_take + S2N_TLS_CONTENT_TYPE_LENGTH + cipher_suite->record_alg->cipher->io.aead.tag_size
+            };
+            POSIX_GUARD_RESULT(s2n_tls13_aead_aad_init(&header, &aad));
         } else {
             POSIX_GUARD_RESULT(s2n_aead_aad_init(conn, sequence_number, content_type, data_bytes_to_take, &aad));
         }

--- a/tls/s2n_recv.c
+++ b/tls/s2n_recv.c
@@ -118,7 +118,10 @@ int s2n_read_full_record(struct s2n_connection *conn, uint8_t *record_type, int 
         *isSSLv2 = 1;
         WITH_ERROR_BLINDING(conn, POSIX_GUARD(s2n_sslv2_record_header_parse(conn, record_type, &conn->client_hello.legacy_version, &fragment_length)));
     } else {
-        WITH_ERROR_BLINDING(conn, POSIX_GUARD(s2n_record_header_parse(conn, record_type, &fragment_length)));
+        struct s2n_record_header header = { 0 };
+        WITH_ERROR_BLINDING(conn, POSIX_GUARD(s2n_record_header_parse(conn, &header)));
+        *record_type = header.content_type;
+        fragment_length = header.length;
     }
 
     /* Read enough to have the whole record */


### PR DESCRIPTION
# Goal
Add a simple record integrity property test

## Why
https://github.com/aws/s2n-tls/security/advisories/GHSA-684c-v35q-fvx7

## How
We just iterate over the record and try flipping each bit. Any of these bit flips violate record integrity, so it should fail.

See callouts, but I did also just add the raw wire bytes to the AAD, which is a nice defense-in-depth which protects against a lot of the record tampering.

## Callouts
I actually did find a some small record integrity fixes

1. We were hard-coding the protocol version in the TLS 1.3 AAD. We did make an attempt to check that this was the correct value earlier, but our truncated version (`u8`) representation loses information. We now include the real wire bytes in the AAD.
2. We were using the truncated version for composite cipher HMAC construction. This lost information, meaning that there were cases when we couldn't detect that the record protocol version had been tampered with. We now feed the real wire bytes into the HMAC for composite ciphers, the same as we were previously doing for the software CBC + HMAC construction.

I also _really_ dislike the error hygiene from `s2n_recv`, but fixing that is currently lower priority than getting this test coverage added.

I did look at switching the s2n-version to just use the correct IANA naming scheme, but it has leaked into
- our public APIs
- our session ticket format
- our serialized ticket format

So I think this ended up being the significantly cleaner approach.

## Testing
All existing tests should pass, and the new ones too.

### Related
https://github.com/aws/s2n-tls/issues/6001

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
