### PR TITLE
style(integv2): run latest ruff format & check

### DIFF
--- a/tests/integrationv2/README.md
+++ b/tests/integrationv2/README.md
@@ -94,14 +94,19 @@ Pytest will generate 8 configuration based on the parameterize options below. Th
 test will be run with each of the possible configurations.
 """
 
-@pytest.mark.parametrize("cipher",
-    [Ciphers.AES128_GCM_SHA256, Ciphers.CHACHA20_POLY1305_SHA256], ids=get_parameter_name)
-@pytest.mark.parametrize("provider",
-    [S2N, OpenSSL])
-@pytest.mark.parametrize("protocol",
-    [Protocols.TLS13], ids=get_parameter_name)
-@pytest.mark.parametrize("certificate",
-    [Cert("ECDSA_256", "ecdsa_p256_pkcs1"), Cert("ECDSA_384", "ecdsa_p384_pkcs1")], ids=get_parameter_name)
+
+@pytest.mark.parametrize(
+    "cipher",
+    [Ciphers.AES128_GCM_SHA256, Ciphers.CHACHA20_POLY1305_SHA256],
+    ids=get_parameter_name,
+)
+@pytest.mark.parametrize("provider", [S2N, OpenSSL])
+@pytest.mark.parametrize("protocol", [Protocols.TLS13], ids=get_parameter_name)
+@pytest.mark.parametrize(
+    "certificate",
+    [Cert("ECDSA_256", "ecdsa_p256_pkcs1"), Cert("ECDSA_384", "ecdsa_p384_pkcs1")],
+    ids=get_parameter_name,
+)
 def test_example(managed_process, cipher, provider, protocol, certificate):
     host = "localhost"
     port = next(available_ports)
@@ -112,7 +117,8 @@ def test_example(managed_process, cipher, provider, protocol, certificate):
         port=port,
         cipher=cipher,
         insecure=True,
-        protocol=protocol)
+        protocol=protocol,
+    )
 
     server_options = copy.copy(client_options)
     server_options.mode = Provider.ServerMode
@@ -127,12 +133,16 @@ def test_example(managed_process, cipher, provider, protocol, certificate):
     for results in client.get_results():
         assert results.exception is None
         assert results.exit_code == 0
-        assert bytes("Actual protocol version: {}".format(expected_version).encode('utf-8')) in results.stdout
+        assert (
+            bytes(
+                "Actual protocol version: {}".format(expected_version).encode("utf-8")
+            )
+            in results.stdout
+        )
 
     for results in server.get_results():
         assert results.exception is None
         assert results.exit_code == 0
-
 ```
 
 

--- a/tests/integrationv2/common.py
+++ b/tests/integrationv2/common.py
@@ -1,16 +1,17 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
+import itertools
 import os
+import random
 import re
+import string
 import subprocess
 import threading
-import itertools
-import random
-import string
+
 import pytest
 
 from constants import TEST_CERT_DIRECTORY
-from global_flags import get_flag, S2N_PROVIDER_VERSION
+from global_flags import S2N_PROVIDER_VERSION, get_flag
 
 
 def data_bytes(n_bytes):
@@ -46,7 +47,7 @@ def pq_enabled():
     return "awslc" in get_flag(S2N_PROVIDER_VERSION)
 
 
-class AvailablePorts(object):
+class AvailablePorts:
     """
     This iterator will atomically return the next number.
     This is useful when running multiple tests in parallel
@@ -99,10 +100,10 @@ class TimeoutException(subprocess.SubprocessError):
 
     def __str__(self):
         cmd = " ".join(self.exception.cmd)
-        return "{} {}".format(self.exception, cmd)
+        return f"{self.exception} {cmd}"
 
 
-class Cert(object):
+class Cert:
     def __init__(self, name, prefix, location=TEST_CERT_DIRECTORY):
         self.name = name
         self.cert = location + prefix + "_cert.pem"
@@ -145,15 +146,13 @@ class Cert(object):
         sig_alg_has_curve = (
             sigalg.algorithm == "EC" and sigalg.min_protocol == Protocols.TLS13
         )
-        if sig_alg_has_curve and self.curve not in sigalg.name:
-            return False
-        return True
+        return not (sig_alg_has_curve and self.curve not in sigalg.name)
 
     def __str__(self):
         return self.name
 
 
-class Certificates(object):
+class Certificates:
     """
     When referencing certificates, use these values.
     """
@@ -186,7 +185,7 @@ class Certificates(object):
     OCSP_ECDSA = Cert("OCSP_ECDSA_256", "ocsp/server_ecdsa")
 
 
-class Protocol(object):
+class Protocol:
     def __init__(self, name, value):
         self.name = name
         self.value = value
@@ -210,7 +209,7 @@ class Protocol(object):
         return self.name
 
 
-class Protocols(object):
+class Protocols:
     """
     When referencing protocols, use these protocol values.
     The first argument is the human readable name. The second
@@ -227,7 +226,7 @@ class Protocols(object):
     SSLv2 = Protocol("SSLv2", 20)
 
 
-class Cipher(object):
+class Cipher:
     def __init__(
         self,
         name,
@@ -248,9 +247,7 @@ class Cipher(object):
         self.s2n = s2n
         self.pq = pq
 
-        if self.min_version >= Protocols.TLS13:
-            self.algorithm = "ANY"
-        elif iana_standard_name is None:
+        if self.min_version >= Protocols.TLS13 or iana_standard_name is None:
             self.algorithm = "ANY"
         elif "ECDSA" in iana_standard_name:
             self.algorithm = "EC"
@@ -269,7 +266,7 @@ class Cipher(object):
         return self.name
 
 
-class Ciphers(object):
+class Ciphers:
     """
     When referencing ciphers, use these class values.
     """
@@ -544,7 +541,7 @@ class Ciphers(object):
         return {cipher.iana_standard_name: cipher for cipher in ciphers}.get(iana_name)
 
 
-class Curve(object):
+class Curve:
     def __init__(self, name, min_protocol=Protocols.SSLv3):
         self.name = name
         self.min_protocol = min_protocol
@@ -553,7 +550,7 @@ class Curve(object):
         return self.name
 
 
-class Curves(object):
+class Curves:
     """
     When referencing curves, use these class values.
     Don't hardcode curve names.
@@ -579,7 +576,7 @@ class Curves(object):
         return {curve.name: curve for curve in curves}.get(name)
 
 
-class Signature(object):
+class Signature:
     def __init__(
         self,
         name,
@@ -610,7 +607,7 @@ class Signature(object):
         return self.name
 
 
-class Signatures(object):
+class Signatures:
     NONE = Signature("None+None", max_protocol=Protocols.TLS13)
     RSA_SHA1 = Signature("RSA+SHA1", max_protocol=Protocols.TLS12)
     RSA_SHA224 = Signature("RSA+SHA224", max_protocol=Protocols.TLS12)
@@ -655,7 +652,7 @@ class Signatures(object):
     )
 
 
-class Results(object):
+class Results:
     """
     An instance of this object will be returned to the test by a managed_process'
     get_results() method.
@@ -690,9 +687,7 @@ class Results(object):
         self.expect_nonzero_exit = expect_nonzero_exit
 
     def __str__(self):
-        return "Stdout: {}\nStderr: {}\nExit code: {}\nException: {}".format(
-            self.stdout, self.stderr, self.exit_code, self.exception
-        )
+        return f"Stdout: {self.stdout}\nStderr: {self.stderr}\nExit code: {self.exit_code}\nException: {self.exception}"
 
     def assert_success(self):
         assert self.exception is None, self.exception
@@ -705,7 +700,7 @@ class Results(object):
         return {self.stdout, self.stderr}
 
 
-class ProviderOptions(object):
+class ProviderOptions:
     def __init__(
         self,
         mode=None,
@@ -727,7 +722,7 @@ class ProviderOptions(object):
         server_name=None,
         protocol=None,
         use_mainline_version=None,
-        env_overrides=dict(),
+        env_overrides=None,
         enable_client_ocsp=False,
         ocsp_response=None,
         signature_algorithm=None,
@@ -795,7 +790,7 @@ class ProviderOptions(object):
         self.use_mainline_version = use_mainline_version
 
         # Extra environment parameters
-        self.env_overrides = env_overrides
+        self.env_overrides = env_overrides if env_overrides is not None else {}
 
         # Enable OCSP on the client
         self.enable_client_ocsp = enable_client_ocsp

--- a/tests/integrationv2/configuration.py
+++ b/tests/integrationv2/configuration.py
@@ -2,10 +2,9 @@
 # SPDX-License-Identifier: Apache-2.0
 import collections
 
-from common import Certificates, Ciphers, Curves, Protocols, AvailablePorts
+from common import AvailablePorts, Certificates, Ciphers, Curves, Protocols
 from constants import TEST_SNI_CERT_DIRECTORY
-from providers import S2N, OpenSSL, JavaSSL
-
+from providers import S2N, JavaSSL, OpenSSL
 
 # The boolean configuration will let a test run for True and False
 # for some value. For example, using the insecure flag.

--- a/tests/integrationv2/conftest.py
+++ b/tests/integrationv2/conftest.py
@@ -1,8 +1,10 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 import os
+
 import pytest
-from global_flags import set_flag, S2N_PROVIDER_VERSION, S2N_FIPS_MODE
+
+from global_flags import S2N_FIPS_MODE, S2N_PROVIDER_VERSION, set_flag
 from providers import S2N, JavaSSL, OpenSSL
 
 PATH_CONFIGURATION_KEY = pytest.StashKey()

--- a/tests/integrationv2/fixtures.py
+++ b/tests/integrationv2/fixtures.py
@@ -2,11 +2,10 @@
 # SPDX-License-Identifier: Apache-2.0
 import pytest
 
-from processes import ManagedProcess
-from providers import Provider, S2N
-
 from common import ProviderOptions
 from conftest import PATH_CONFIGURATION_KEY
+from processes import ManagedProcess
+from providers import S2N, Provider
 
 
 @pytest.fixture
@@ -105,15 +104,15 @@ def managed_process(request: pytest.FixtureRequest):
 
                 print(f"Command line:\n\t{' '.join(p.cmd_line)}")
                 print(f"Exit code:\n\t {p.results.exit_code}")
-                print("")
+                print()
 
                 print("  Stdout  ".center(width, padchar))
                 print(p.results.stdout.decode("utf-8", "backslashreplace"))
-                print("")
+                print()
 
                 print("  Stderr  ".center(width, padchar))
                 print(p.results.stderr.decode("utf-8", "backslashreplace"))
-                print("")
+                print()
 
             # Whether the processes succeeded or not, clean them up.
             if aborted:

--- a/tests/integrationv2/processes.py
+++ b/tests/integrationv2/processes.py
@@ -5,17 +5,16 @@ import select
 import selectors
 import subprocess
 import threading
-
-from common import Results, TimeoutException
 from time import monotonic as _time
 
+from common import Results, TimeoutException
 
 _PopenSelector = selectors.PollSelector
 _PIPE_BUF = getattr(select, "PIPE_BUF", 512)
 _DEBUG_LEN = 200
 
 
-class _processCommunicator(object):
+class _processCommunicator:
     """
     This class allows greater control over stdin than using Popen.communicate().
     Popen.communicate() closes stdin as soon as data is written. This causes
@@ -372,7 +371,7 @@ class ManagedProcess(threading.Thread):
         close_marker=None,
         timeout=5,
         data_source=None,
-        env_overrides=dict(),
+        env_overrides=None,
         expect_stderr=False,
         kill_marker=None,
         send_with_newline=False,
@@ -381,6 +380,8 @@ class ManagedProcess(threading.Thread):
 
         proc_env = os.environ.copy()
 
+        if env_overrides is None:
+            env_overrides = {}
         for key in env_overrides:
             proc_env[key] = env_overrides[key]
 
@@ -435,7 +436,7 @@ class ManagedProcess(threading.Thread):
                 self.proc = proc
             except Exception as ex:
                 self.results = Results(None, None, None, ex, self.expect_stderr)
-                raise ex
+                raise
 
             communicator = _processCommunicator(proc, self.name)
 
@@ -487,7 +488,7 @@ class ManagedProcess(threading.Thread):
                     ex,
                     self.expect_stderr,
                 )
-                raise ex
+                raise
 
     def kill(self):
         self.proc.kill()

--- a/tests/integrationv2/providers.py
+++ b/tests/integrationv2/providers.py
@@ -2,23 +2,24 @@
 # SPDX-License-Identifier: Apache-2.0
 import os
 import subprocess
-import pytest
 import threading
+from stat import S_IMODE
+
+import pytest
 
 from common import (
-    ProviderOptions,
+    Cert,
     Certificates,
     Ciphers,
     Curves,
     Protocols,
+    ProviderOptions,
     Signatures,
-    Cert,
 )
-from global_flags import get_flag, S2N_PROVIDER_VERSION, S2N_FIPS_MODE
-from stat import S_IMODE
+from global_flags import S2N_FIPS_MODE, S2N_PROVIDER_VERSION, get_flag
 
 
-class Provider(object):
+class Provider:
     """
     A provider defines a specific provider of TLS. This could be
     S2N, OpenSSL, BoringSSL, etc.
@@ -77,7 +78,7 @@ class Provider(object):
         """
         This should be the last message printed before the client/server can send data.
         """
-        return None
+        return
 
     @classmethod
     def supports_protocol(cls, protocol):
@@ -142,12 +143,10 @@ class S2N(Provider):
         if not cls._pss_supported() and cert.algorithm == "RSAPSS":
             return False
         # https://github.com/aws/s2n-tls/issues/5200
-        if (
+        return not (
             "openssl-3.0-fips" in get_flag(S2N_PROVIDER_VERSION)
             and "RSA_1024" in cert.name
-        ):
-            return False
-        return True
+        )
 
     @classmethod
     def supports_protocol(cls, protocol):
@@ -155,16 +154,13 @@ class S2N(Provider):
             return False
 
         # SSLv3 cannot be negotiated in FIPS mode with libcryptos other than AWS-LC.
-        if all(
+        return not all(
             [
                 protocol == Protocols.SSLv3,
                 get_flag(S2N_FIPS_MODE),
                 "awslc" not in get_flag(S2N_PROVIDER_VERSION),
             ]
-        ):
-            return False
-
-        return True
+        )
 
     @classmethod
     def supports_cipher(cls, cipher, with_curve=None):
@@ -192,18 +188,13 @@ class S2N(Provider):
     @classmethod
     def supports_signature(cls, signature):
         # Disable RSA_PSS_RSAE_SHA256 in unsupported libcryptos
-        if (
+        return not (
             any(
-                [
-                    libcrypto in get_flag(S2N_PROVIDER_VERSION)
-                    for libcrypto in ["openssl-1.0.2", "libressl", "boringssl"]
-                ]
+                libcrypto in get_flag(S2N_PROVIDER_VERSION)
+                for libcrypto in ["openssl-1.0.2", "libressl", "boringssl"]
             )
             and signature == Signatures.RSA_PSS_RSAE_SHA256
-        ):
-            return False
-
-        return True
+        )
 
     def setup_client(self):
         """
@@ -311,9 +302,7 @@ class S2N(Provider):
             cmd_line.append("-T")
 
         if self.options.reconnects_before_exit is not None:
-            cmd_line.append(
-                "--max-conns={}".format(self.options.reconnects_before_exit)
-            )
+            cmd_line.append(f"--max-conns={self.options.reconnects_before_exit}")
 
         if get_flag(S2N_FIPS_MODE):
             cmd_line.append("--enter-fips-mode")
@@ -331,7 +320,7 @@ class S2N(Provider):
 
 class OpenSSL(Provider):
     result = subprocess.run(
-        ["openssl", "version"], shell=False, capture_output=True, text=True
+        ["openssl", "version"], shell=False, capture_output=True, text=True, check=False
     )
     # After splitting, version_str would be: ["OpenSSL", "3.0.8", "7", "Feb", "2023\n"]
     version_str = result.stdout.split(" ")
@@ -366,7 +355,7 @@ class OpenSSL(Provider):
         return ciphers
 
     def _cipher_to_cmdline(self, cipher):
-        cmdline = list()
+        cmdline = []
 
         ciphers = []
         if type(cipher) is list:
@@ -381,9 +370,7 @@ class OpenSSL(Provider):
 
             if len(mismatch) > 0:
                 raise Exception(
-                    "Cannot combine ciphers for TLS1.3 or above with older ciphers: {}".format(
-                        [c.name for c in cipher]
-                    )
+                    f"Cannot combine ciphers for TLS1.3 or above with older ciphers: {[c.name for c in cipher]}"
                 )
 
             ciphers.append(self._join_ciphers(cipher))
@@ -438,9 +425,7 @@ class OpenSSL(Provider):
 
     def setup_client(self):
         cmd_line = ["openssl", "s_client"]
-        cmd_line.extend(
-            ["-connect", "{}:{}".format(self.options.host, self.options.port)]
-        )
+        cmd_line.extend(["-connect", f"{self.options.host}:{self.options.port}"])
 
         # Additional debugging that will be captured incase of failure
         if self.options.verbose:
@@ -506,7 +491,7 @@ class OpenSSL(Provider):
         self.ready_to_test_marker = "ACCEPT"
 
         cmd_line = ["openssl", "s_server"]
-        cmd_line.extend(["-accept", "{}".format(self.options.port)])
+        cmd_line.extend(["-accept", f"{self.options.port}"])
 
         if self.options.reconnects_before_exit is not None:
             # If the user request a specific reconnection count, set it here
@@ -574,16 +559,14 @@ class SSLv3Provider(OpenSSL):
     def _override_libssl(self, options: ProviderOptions):
         install_dir = os.environ["OPENSSL_1_0_2_INSTALL_DIR"]
 
-        override_env_vars = dict()
+        override_env_vars = {}
         override_env_vars["PATH"] = install_dir + "/bin"
         override_env_vars["LD_LIBRARY_PATH"] = install_dir + "/lib"
         options.env_overrides = override_env_vars
 
     @classmethod
     def supports_protocol(cls, protocol):
-        if protocol is Protocols.SSLv3:
-            return True
-        return False
+        return protocol is Protocols.SSLv3
 
 
 class JavaSSL(Provider):
@@ -602,22 +585,16 @@ class JavaSSL(Provider):
     @classmethod
     def supports_protocol(cls, protocol):
         # https://aws.amazon.com/blogs/opensource/tls-1-0-1-1-changes-in-openjdk-and-amazon-corretto/
-        if (
+        return not (
             protocol is Protocols.SSLv3
             or protocol is Protocols.TLS10
             or protocol is Protocols.TLS11
-        ):
-            return False
-
-        return True
+        )
 
     @classmethod
     def supports_cipher(cls, cipher, with_curve=None):
         # Java SSL does not support CHACHA20
-        if "CHACHA20" in cipher.name:
-            return False
-
-        return True
+        return "CHACHA20" not in cipher.name
 
     def setup_server(self):
         pytest.skip("JavaSSL does not support server mode at this time")
@@ -677,9 +654,7 @@ class BoringSSL(Provider):
             elif self.options.curve == Curves.P521:
                 cmd_line.extend(["-curves", "P-521"])
             elif self.options.curve == Curves.X25519:
-                pytest.skip(
-                    "BoringSSL does not support curve {}".format(self.options.curve)
-                )
+                pytest.skip(f"BoringSSL does not support curve {self.options.curve}")
 
         if self.options.extra_flags is not None:
             cmd_line.extend(self.options.extra_flags)
@@ -688,9 +663,7 @@ class BoringSSL(Provider):
 
     def setup_client(self):
         cmd_line = ["bssl", "s_client"]
-        cmd_line.extend(
-            ["-connect", "{}:{}".format(self.options.host, self.options.port)]
-        )
+        cmd_line.extend(["-connect", f"{self.options.host}:{self.options.port}"])
         if self.options.cert is not None:
             cmd_line.extend(["-cert", self.options.cert])
         if self.options.key is not None:
@@ -708,9 +681,7 @@ class BoringSSL(Provider):
             elif self.options.curve == Curves.P521:
                 cmd_line.extend(["-curves", "P-521"])
             elif self.options.curve == Curves.X25519:
-                pytest.skip(
-                    "BoringSSL does not support curve {}".format(self.options.curve)
-                )
+                pytest.skip(f"BoringSSL does not support curve {self.options.curve}")
 
         if self.options.extra_flags is not None:
             cmd_line.extend(self.options.extra_flags)
@@ -912,13 +883,15 @@ class GnuTLS(Provider):
         return GnuTLS.sigalg_to_priority_str(signature) is not None
 
 
-def find_files(file_glob, root_dir=".", modes=[]):
+def find_files(file_glob, root_dir=".", modes=None):
     """
     find util in python form.
     file_glob: a snippet of the filename, e.g. ".py"
     root_dir: starting point for search
     mode is an octal representation of owner/group/other, e.g.: '0o644'
     """
+    if modes is None:
+        modes = []
     result = []
     for root, dirs, files in os.walk(root_dir):
         for file in files:

--- a/tests/integrationv2/pyproject.toml
+++ b/tests/integrationv2/pyproject.toml
@@ -14,3 +14,11 @@ dependencies = [
     "ruff>=0.9.7",
     "sslyze>=6.1.0",
 ]
+
+[tool.ruff.lint]
+ignore = [
+    "BLE001",  # blind exception catch is intentional in test fixtures
+    "S110",    # try-except-pass is intentional in test fixtures
+    "SIM102",  # nested ifs are often clearer with comments between conditions
+    "TRY002",  # custom exceptions are overkill for test utilities
+]

--- a/tests/integrationv2/test_buffered_send.py
+++ b/tests/integrationv2/test_buffered_send.py
@@ -2,16 +2,16 @@
 # SPDX-License-Identifier: Apache-2.0
 import pytest
 
-from configuration import (
-    available_ports,
-    PROTOCOLS,
-    MINIMAL_TEST_CIPHERS,
-    MINIMAL_TEST_CERTS,
-)
 from common import ProviderOptions, data_bytes
+from configuration import (
+    MINIMAL_TEST_CERTS,
+    MINIMAL_TEST_CIPHERS,
+    PROTOCOLS,
+    available_ports,
+)
 from fixtures import managed_process  # noqa: F401
-from providers import Provider, S2N, OpenSSL, GnuTLS
-from utils import invalid_test_parameters, get_parameter_name, to_bytes, to_string
+from providers import S2N, GnuTLS, OpenSSL, Provider
+from utils import get_parameter_name, invalid_test_parameters, to_bytes, to_string
 
 SEND_DATA_SIZE = 2**14
 

--- a/tests/integrationv2/test_client_authentication.py
+++ b/tests/integrationv2/test_client_authentication.py
@@ -1,16 +1,17 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 import copy
+
 import pytest
 
-from configuration import available_ports, ALL_TEST_CIPHERS, PROTOCOLS
-from common import Certificates, ProviderOptions, Protocols, data_bytes, Signatures
+from common import Certificates, Protocols, ProviderOptions, Signatures, data_bytes
+from configuration import ALL_TEST_CIPHERS, PROTOCOLS, available_ports
 from fixtures import managed_process  # noqa: F401
-from providers import Provider, S2N, GnuTLS, OpenSSL
+from providers import S2N, GnuTLS, OpenSSL, Provider
 from utils import (
-    invalid_test_parameters,
-    get_parameter_name,
     get_expected_s2n_version,
+    get_parameter_name,
+    invalid_test_parameters,
     to_bytes,
 )
 
@@ -40,12 +41,11 @@ def assert_s2n_handshake_complete(results, protocol, provider, is_complete=True)
     expected_version = get_expected_s2n_version(protocol, provider)
     if is_complete:
         assert (
-            to_bytes("Actual protocol version: {}".format(expected_version))
-            in results.stdout
+            to_bytes(f"Actual protocol version: {expected_version}") in results.stdout
         )
     else:
         assert (
-            to_bytes("Actual protocol version: {}".format(expected_version))
+            to_bytes(f"Actual protocol version: {expected_version}")
             not in results.stdout
         )
 

--- a/tests/integrationv2/test_cross_compatibility.py
+++ b/tests/integrationv2/test_cross_compatibility.py
@@ -1,20 +1,21 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
-import pytest
 import copy
 import os
 
+import pytest
+
+from common import Protocols, ProviderOptions, data_bytes
 from configuration import (
-    available_ports,
     ALL_TEST_CIPHERS,
     ALL_TEST_CURVES,
     MINIMAL_TEST_CERTS,
     S2N_TEST_POLICIES,
+    available_ports,
 )
-from common import ProviderOptions, Protocols, data_bytes
 from fixtures import managed_process  # noqa: F401
-from providers import Provider, S2N, OpenSSL
-from utils import invalid_test_parameters, get_parameter_name, to_bytes
+from providers import S2N, OpenSSL, Provider
+from utils import get_parameter_name, invalid_test_parameters, to_bytes
 
 S2N_RESUMPTION_MARKER = to_bytes("Resumed session")
 CLOSE_MARKER_BYTES = data_bytes(10)

--- a/tests/integrationv2/test_early_data.py
+++ b/tests/integrationv2/test_early_data.py
@@ -2,20 +2,22 @@
 # SPDX-License-Identifier: Apache-2.0
 import copy
 import os
+
 import pytest
 
+from common import Curves, Protocols, ProviderOptions, data_bytes
 from configuration import (
-    available_ports,
     ALL_TEST_CURVES,
     MINIMAL_TEST_CERTS,
     TLS13_CIPHERS,
+    available_ports,
 )
-from common import ProviderOptions, Protocols, Curves, data_bytes
 from fixtures import managed_process  # noqa: F401
-from providers import Provider, S2N as S2NBase, OpenSSL as OpenSSLBase
-from utils import invalid_test_parameters, get_parameter_name, to_bytes
-
+from providers import S2N as S2NBase
+from providers import OpenSSL as OpenSSLBase
+from providers import Provider
 from test_hello_retry_requests import S2N_HRR_MARKER
+from utils import get_parameter_name, invalid_test_parameters, to_bytes
 
 TICKET_FILE = "ticket"
 EARLY_DATA_FILE = "early_data"
@@ -29,7 +31,7 @@ NUM_CONNECTIONS = NUM_RESUMES + 1  # resumes + initial
 S2N_DEFAULT_CURVE = Curves.X25519
 # We have no plans to support this curve any time soon
 S2N_UNSUPPORTED_CURVE = "X448"
-S2N_HRR_CURVES = list(curve for curve in ALL_TEST_CURVES if curve != S2N_DEFAULT_CURVE)
+S2N_HRR_CURVES = [curve for curve in ALL_TEST_CURVES if curve != S2N_DEFAULT_CURVE]
 
 S2N_EARLY_DATA_MARKER = to_bytes("WITH_EARLY_DATA")
 S2N_EARLY_DATA_RECV_MARKER = "Early Data received: "

--- a/tests/integrationv2/test_external_psk.py
+++ b/tests/integrationv2/test_external_psk.py
@@ -1,18 +1,19 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
+from enum import Enum, auto
+
 import pytest
 
+from common import Protocols, ProviderOptions, data_bytes
 from configuration import (
-    available_ports,
-    TLS13_CIPHERS,
     ALL_TEST_CURVES,
     MINIMAL_TEST_CERTS,
+    TLS13_CIPHERS,
+    available_ports,
 )
-from common import ProviderOptions, Protocols, data_bytes
 from fixtures import managed_process  # noqa: F401
 from providers import S2N, OpenSSL
-from utils import invalid_test_parameters, get_parameter_name, to_bytes
-from enum import Enum, auto
+from utils import get_parameter_name, invalid_test_parameters, to_bytes
 
 # Known value test vectors from https://tools.ietf.org/html/rfc8448#section-4
 known_psk_identity = (
@@ -95,14 +96,10 @@ def skip_invalid_psk_tests(provider, psk_hash_alg):
 
 def validate_negotiated_psk_s2n(outcome, psk_identity, results):
     if outcome == Outcome.psk_connection:
-        assert (
-            to_bytes("Negotiated PSK identity: {}".format(psk_identity))
-            in results.stdout
-        )
+        assert to_bytes(f"Negotiated PSK identity: {psk_identity}") in results.stdout
     elif outcome == Outcome.full_handshake:
         assert (
-            to_bytes("Negotiated PSK identity: {}".format(psk_identity))
-            not in results.stdout
+            to_bytes(f"Negotiated PSK identity: {psk_identity}") not in results.stdout
         )
     else:
         assert results.exit_code != 0

--- a/tests/integrationv2/test_fragmentation.py
+++ b/tests/integrationv2/test_fragmentation.py
@@ -1,19 +1,19 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 import copy
+
 import pytest
 
-from configuration import available_ports, PROTOCOLS
-from common import ProviderOptions, Ciphers, Certificates, data_bytes
+from common import Certificates, Ciphers, ProviderOptions, data_bytes
+from configuration import PROTOCOLS, available_ports
 from fixtures import managed_process  # noqa: F401
-from providers import Provider, S2N, OpenSSL, GnuTLS
+from providers import S2N, GnuTLS, OpenSSL, Provider
 from utils import (
-    invalid_test_parameters,
-    get_parameter_name,
     get_expected_s2n_version,
+    get_parameter_name,
+    invalid_test_parameters,
     to_bytes,
 )
-
 
 CIPHERS_TO_TEST = [
     Ciphers.AES256_SHA,
@@ -55,9 +55,7 @@ def test_s2n_server_framented_data(
     frag_len,
 ):
     if provider is OpenSSL and "openssl-1.0.2" in provider.get_version():
-        pytest.skip(
-            "{} does not allow setting max fragmentation for packets".format(provider)
-        )
+        pytest.skip(f"{provider} does not allow setting max fragmentation for packets")
 
     port = next(available_ports)
 
@@ -91,7 +89,7 @@ def test_s2n_server_framented_data(
     for server_results in server.get_results():
         server_results.assert_success()
         assert (
-            to_bytes("Actual protocol version: {}".format(expected_version))
+            to_bytes(f"Actual protocol version: {expected_version}")
             in server_results.stdout
         )
 

--- a/tests/integrationv2/test_happy_path.py
+++ b/tests/integrationv2/test_happy_path.py
@@ -1,22 +1,23 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 import copy
+
 import pytest
 
+from common import ProviderOptions, data_bytes
 from configuration import (
-    available_ports,
+    ALL_TEST_CERTS,
     ALL_TEST_CIPHERS,
     ALL_TEST_CURVES,
-    ALL_TEST_CERTS,
     PROTOCOLS,
+    available_ports,
 )
-from common import ProviderOptions, data_bytes
 from fixtures import managed_process  # noqa: F401
-from providers import Provider, S2N, OpenSSL, JavaSSL, GnuTLS, SSLv3Provider
+from providers import S2N, GnuTLS, JavaSSL, OpenSSL, Provider, SSLv3Provider
 from utils import (
-    invalid_test_parameters,
-    get_parameter_name,
     get_expected_s2n_version,
+    get_parameter_name,
+    invalid_test_parameters,
     to_bytes,
 )
 
@@ -79,15 +80,14 @@ def test_s2n_server_happy_path(
     for server_results in server.get_results():
         server_results.assert_success()
         assert (
-            to_bytes("Actual protocol version: {}".format(expected_version))
+            to_bytes(f"Actual protocol version: {expected_version}")
             in server_results.stdout
         )
         assert random_bytes in server_results.stdout
 
         if provider is not S2N:
             assert (
-                to_bytes("Cipher negotiated: {}".format(cipher.name))
-                in server_results.stdout
+                to_bytes(f"Cipher negotiated: {cipher.name}") in server_results.stdout
             )
 
 
@@ -149,7 +149,7 @@ def test_s2n_client_happy_path(
     for client_results in client.get_results():
         client_results.assert_success()
         assert (
-            to_bytes("Actual protocol version: {}".format(expected_version))
+            to_bytes(f"Actual protocol version: {expected_version}")
             in client_results.stdout
         )
 
@@ -160,5 +160,5 @@ def test_s2n_client_happy_path(
         server_results.assert_success()
         # Avoid debugging information that sometimes gets inserted after the first character.
         assert any(
-            [random_bytes[1:] in stream for stream in server_results.output_streams()]
+            random_bytes[1:] in stream for stream in server_results.output_streams()
         )

--- a/tests/integrationv2/test_hello_retry_requests.py
+++ b/tests/integrationv2/test_hello_retry_requests.py
@@ -1,19 +1,20 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 import copy
-import pytest
 import re
 
+import pytest
+
+from common import Curves, Protocols, ProviderOptions, data_bytes
 from configuration import (
-    available_ports,
-    TLS13_CIPHERS,
     ALL_TEST_CURVES,
     MINIMAL_TEST_CERTS,
+    TLS13_CIPHERS,
+    available_ports,
 )
-from common import ProviderOptions, Protocols, data_bytes, Curves
 from fixtures import managed_process  # noqa: F401
-from providers import Provider, S2N, OpenSSL
-from utils import invalid_test_parameters, get_parameter_name, to_bytes
+from providers import S2N, OpenSSL, Provider
+from utils import get_parameter_name, invalid_test_parameters, to_bytes
 
 S2N_DEFAULT_CURVE = Curves.X25519
 S2N_HRR_MARKER = to_bytes("HELLO_RETRY_REQUEST")
@@ -86,7 +87,7 @@ def test_hrr_with_s2n_as_client(
     # The client should connect and return without error
     for results in client.get_results():
         results.assert_success()
-        assert to_bytes("Curve: {}".format(CURVE_NAMES[curve.name])) in results.stdout
+        assert to_bytes(f"Curve: {CURVE_NAMES[curve.name]}") in results.stdout
         assert S2N_HRR_MARKER in results.stdout
 
     # These are the special HelloRetryRequest bytes from the Server Random field
@@ -105,7 +106,7 @@ def test_hrr_with_s2n_as_client(
             is not None
         )
         assert (
-            to_bytes("Shared Elliptic groups: {}".format(server_options.curve))
+            to_bytes(f"Shared Elliptic groups: {server_options.curve}")
             in results.stdout
         )
         assert random_bytes in results.stdout
@@ -160,7 +161,7 @@ def test_hrr_with_s2n_as_server(
     for results in server.get_results():
         results.assert_success()
         assert random_bytes in results.stdout
-        assert to_bytes("Curve: {}".format(CURVE_NAMES[curve.name])) in results.stdout
+        assert to_bytes(f"Curve: {CURVE_NAMES[curve.name]}") in results.stdout
         assert random_bytes in results.stdout
         assert S2N_HRR_MARKER in results.stdout
 
@@ -233,7 +234,7 @@ def test_hrr_with_default_keyshare(
     # The client should connect and return without error
     for results in client.get_results():
         results.assert_success()
-        assert to_bytes("Curve: {}".format(CURVE_NAMES[curve.name])) in results.stdout
+        assert to_bytes(f"Curve: {CURVE_NAMES[curve.name]}") in results.stdout
         assert S2N_HRR_MARKER in results.stdout
 
     # These are the special HelloRetryRequest bytes from the Server Random field
@@ -252,7 +253,7 @@ def test_hrr_with_default_keyshare(
             is not None
         )
         assert (
-            to_bytes("Shared Elliptic groups: {}".format(server_options.curve))
+            to_bytes(f"Shared Elliptic groups: {server_options.curve}")
             in results.stdout
         )
         assert random_bytes in results.stdout

--- a/tests/integrationv2/test_key_update.py
+++ b/tests/integrationv2/test_key_update.py
@@ -1,13 +1,14 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 import copy
+
 import pytest
 
-from configuration import available_ports, TLS13_CIPHERS
-from common import ProviderOptions, Protocols, random_str
+from common import Protocols, ProviderOptions, random_str
+from configuration import TLS13_CIPHERS, available_ports
 from fixtures import managed_process  # noqa: F401
-from providers import Provider, S2N, OpenSSL
-from utils import invalid_test_parameters, get_parameter_name
+from providers import S2N, OpenSSL, Provider
+from utils import get_parameter_name, invalid_test_parameters
 
 SERVER_DATA = "Some random data from the server:" + random_str(10)
 CLIENT_DATA = "Some random data from the client:" + random_str(10)

--- a/tests/integrationv2/test_npn.py
+++ b/tests/integrationv2/test_npn.py
@@ -1,20 +1,20 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 import copy
+
 import pytest
 
+from common import Protocols, ProviderOptions
 from configuration import (
-    available_ports,
     ALL_TEST_CIPHERS,
     ALL_TEST_CURVES,
     MINIMAL_TEST_CERTS,
     PROTOCOLS,
+    available_ports,
 )
-from common import ProviderOptions, Protocols
 from fixtures import managed_process  # noqa: F401
-from providers import OpenSSL, S2N, Provider
-from utils import invalid_test_parameters, get_parameter_name, to_bytes
-
+from providers import S2N, OpenSSL, Provider
+from utils import get_parameter_name, invalid_test_parameters, to_bytes
 
 # NPN not supported in TLS1.3
 TLS_PROTOCOLS = [x for x in PROTOCOLS if x.value < Protocols.TLS13.value]

--- a/tests/integrationv2/test_ocsp.py
+++ b/tests/integrationv2/test_ocsp.py
@@ -2,14 +2,13 @@
 # SPDX-License-Identifier: Apache-2.0
 import pytest
 
-from configuration import available_ports, ALL_TEST_CIPHERS, ALL_TEST_CURVES, PROTOCOLS
-from common import ProviderOptions, data_bytes, Certificates
-from fixtures import managed_process  # noqa: F401
+from common import Certificates, ProviderOptions, data_bytes
+from configuration import ALL_TEST_CIPHERS, ALL_TEST_CURVES, PROTOCOLS, available_ports
 from constants import TEST_OCSP_DIRECTORY
-from providers import Provider, S2N, OpenSSL, GnuTLS
-from utils import invalid_test_parameters, get_parameter_name
-from global_flags import get_flag, S2N_PROVIDER_VERSION
-
+from fixtures import managed_process  # noqa: F401
+from global_flags import S2N_PROVIDER_VERSION, get_flag
+from providers import S2N, GnuTLS, OpenSSL, Provider
+from utils import get_parameter_name, invalid_test_parameters
 
 OCSP_CERTS = [Certificates.OCSP, Certificates.OCSP_ECDSA]
 
@@ -140,19 +139,17 @@ def test_s2n_server_ocsp_response(
     for client_results in client.get_results():
         client_results.assert_success()
         assert any(
-            [
-                {
-                    GnuTLS: b"OCSP Response Information:\n\tResponse Status: Successful",
-                    OpenSSL: b"OCSP Response Status: successful",
-                }.get(provider)
-                in stream
-                for stream in client_results.output_streams()
-            ]
+            {
+                GnuTLS: b"OCSP Response Information:\n\tResponse Status: Successful",
+                OpenSSL: b"OCSP Response Status: successful",
+            }.get(provider)
+            in stream
+            for stream in client_results.output_streams()
         )
 
     for server_results in server.get_results():
         server_results.assert_success()
         # Avoid debugging information that sometimes gets inserted after the first character.
         assert any(
-            [random_bytes[1:] in stream for stream in server_results.output_streams()]
+            random_bytes[1:] in stream for stream in server_results.output_streams()
         )

--- a/tests/integrationv2/test_record_padding.py
+++ b/tests/integrationv2/test_record_padding.py
@@ -2,22 +2,23 @@
 # SPDX-License-Identifier: Apache-2.0
 import copy
 import platform
-import pytest
 import re
 
+import pytest
+
+from common import Protocols, ProviderOptions, data_bytes
 from configuration import (
-    available_ports,
-    TLS13_CIPHERS,
     ALL_TEST_CURVES,
     MINIMAL_TEST_CERTS,
+    TLS13_CIPHERS,
+    available_ports,
 )
-from common import ProviderOptions, Protocols, data_bytes
 from fixtures import managed_process  # noqa: F401
-from providers import Provider, S2N, OpenSSL
+from providers import S2N, OpenSSL, Provider
 from utils import (
-    invalid_test_parameters,
-    get_parameter_name,
     get_expected_s2n_version,
+    get_parameter_name,
+    invalid_test_parameters,
     to_bytes,
 )
 
@@ -133,14 +134,11 @@ def test_s2n_server_handles_padded_records(
         assert random_bytes in server_results.stdout
         # verify that the version was correctly negotiated
         assert (
-            to_bytes("Actual protocol version: {}".format(expected_version))
+            to_bytes(f"Actual protocol version: {expected_version}")
             in server_results.stdout
         )
         # verify that the cipher was correctly negotiated
-        assert (
-            to_bytes("Cipher negotiated: {}".format(cipher.name))
-            in server_results.stdout
-        )
+        assert to_bytes(f"Cipher negotiated: {cipher.name}") in server_results.stdout
 
 
 @pytest.mark.flaky(
@@ -213,13 +211,10 @@ def test_s2n_client_handles_padded_records(
         # assert that the client has received server's application payload
         assert server_random_bytes in client_results.stdout
         assert (
-            to_bytes("Actual protocol version: {}".format(expected_version))
+            to_bytes(f"Actual protocol version: {expected_version}")
             in client_results.stdout
         )
-        assert (
-            to_bytes("Cipher negotiated: {}".format(cipher.name))
-            in client_results.stdout
-        )
+        assert to_bytes(f"Cipher negotiated: {cipher.name}") in client_results.stdout
 
     for server_results in openssl.get_results():
         server_results.assert_success()

--- a/tests/integrationv2/test_renegotiate_apache.py
+++ b/tests/integrationv2/test_renegotiate_apache.py
@@ -1,15 +1,16 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
-import pytest
 import tempfile
 
+import pytest
+
+from common import Protocols, ProviderOptions
 from configuration import ALL_TEST_CURVES, PROTOCOLS
-from common import ProviderOptions, Protocols
-from fixtures import managed_process  # noqa: F401
-from global_flags import get_flag, S2N_PROVIDER_VERSION
-from providers import Provider, S2N
-from utils import invalid_test_parameters, get_parameter_name
 from constants import TEST_CERT_DIRECTORY
+from fixtures import managed_process  # noqa: F401
+from global_flags import S2N_PROVIDER_VERSION, get_flag
+from providers import S2N, Provider
+from utils import get_parameter_name, invalid_test_parameters
 
 TEST_PROTOCOLS = [x for x in PROTOCOLS if x.value < Protocols.TLS13.value]
 S2N_RENEG_OPTION = "--renegotiation"

--- a/tests/integrationv2/test_serialization.py
+++ b/tests/integrationv2/test_serialization.py
@@ -1,15 +1,16 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
-import pytest
 import copy
 import os
 from enum import Enum, auto
 
+import pytest
+
+from common import Ciphers, Protocols, ProviderOptions, random_str
 from configuration import available_ports
-from common import Ciphers, ProviderOptions, Protocols, random_str
 from fixtures import managed_process  # noqa: F401
-from providers import Provider, S2N
-from utils import invalid_test_parameters, get_parameter_name, to_bytes
+from providers import S2N, Provider
+from utils import get_parameter_name, invalid_test_parameters, to_bytes
 
 SERVER_STATE_FILE = "server_state"
 CLIENT_STATE_FILE = "client_state"
@@ -95,17 +96,11 @@ def test_server_serialization_backwards_compat(
 
     for results in client.get_results():
         results.assert_success()
-        assert (
-            to_bytes("Actual protocol version: {}".format(protocol.value))
-            in results.stdout
-        )
+        assert to_bytes(f"Actual protocol version: {protocol.value}") in results.stdout
 
     for results in server.get_results():
         results.assert_success()
-        assert (
-            to_bytes("Actual protocol version: {}".format(protocol.value))
-            in results.stdout
-        )
+        assert to_bytes(f"Actual protocol version: {protocol.value}") in results.stdout
 
     assert os.path.exists(server_state_file)
     assert os.path.exists(client_state_file)

--- a/tests/integrationv2/test_signature_algorithms.py
+++ b/tests/integrationv2/test_signature_algorithms.py
@@ -1,16 +1,17 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 import copy
+
 import pytest
 
-from configuration import available_ports, ALL_TEST_CIPHERS, MINIMAL_TEST_CERTS
-from common import ProviderOptions, Protocols, Signatures, data_bytes
+from common import Protocols, ProviderOptions, Signatures, data_bytes
+from configuration import ALL_TEST_CIPHERS, MINIMAL_TEST_CERTS, available_ports
 from fixtures import managed_process  # noqa: F401
-from providers import Provider, S2N, OpenSSL, GnuTLS
+from providers import S2N, GnuTLS, OpenSSL, Provider
 from utils import (
-    invalid_test_parameters,
-    get_parameter_name,
     get_expected_s2n_version,
+    get_parameter_name,
+    invalid_test_parameters,
     to_bytes,
 )
 
@@ -56,9 +57,7 @@ def signature_marker(mode, protocol, cipher, signature):
             signature = Signatures.RSA_MD5_SHA1
 
     return to_bytes(
-        "{mode} signature negotiated: {type}+{digest}".format(
-            mode=mode.title(), type=signature.sig_type, digest=signature.sig_digest
-        )
+        f"{mode.title()} signature negotiated: {signature.sig_type}+{signature.sig_digest}"
     )
 
 
@@ -151,8 +150,7 @@ def test_s2n_server_signature_algorithms(
     for results in server.get_results():
         results.assert_success()
         assert (
-            to_bytes("Actual protocol version: {}".format(expected_version))
-            in results.stdout
+            to_bytes(f"Actual protocol version: {expected_version}") in results.stdout
         )
         assert (
             signature_marker(Provider.ServerMode, protocol, cipher, signature)
@@ -226,15 +224,14 @@ def test_s2n_client_signature_algorithms(
 
     for results in server.get_results():
         results.assert_success()
-        assert any([random_bytes in stream for stream in results.output_streams()])
+        assert any(random_bytes in stream for stream in results.output_streams())
 
     expected_version = get_expected_s2n_version(protocol, provider)
 
     for results in client.get_results():
         results.assert_success()
         assert (
-            to_bytes("Actual protocol version: {}".format(expected_version))
-            in results.stdout
+            to_bytes(f"Actual protocol version: {expected_version}") in results.stdout
         )
         assert (
             signature_marker(Provider.ServerMode, protocol, cipher, signature)

--- a/tests/integrationv2/test_sni_match.py
+++ b/tests/integrationv2/test_sni_match.py
@@ -2,14 +2,14 @@
 # SPDX-License-Identifier: Apache-2.0
 import pytest
 
-from configuration import available_ports, MULTI_CERT_TEST_CASES
-from common import ProviderOptions, Protocols
+from common import Protocols, ProviderOptions
+from configuration import MULTI_CERT_TEST_CASES, available_ports
 from fixtures import managed_process  # noqa: F401
-from providers import Provider, S2N, OpenSSL
+from providers import S2N, OpenSSL, Provider
 from utils import (
-    invalid_test_parameters,
-    get_parameter_name,
     get_expected_s2n_version,
+    get_parameter_name,
+    invalid_test_parameters,
     to_bytes,
 )
 
@@ -75,11 +75,9 @@ def test_sni_match(managed_process, provider, other_provider, protocol, cert_tes
     for results in server.get_results():
         results.assert_success()
         assert (
-            to_bytes("Actual protocol version: {}".format(expected_version))
-            in results.stdout
+            to_bytes(f"Actual protocol version: {expected_version}") in results.stdout
         )
         if cert_test_case.client_sni is not None:
             assert (
-                to_bytes("Server name: {}".format(cert_test_case.client_sni))
-                in results.stdout
+                to_bytes(f"Server name: {cert_test_case.client_sni}") in results.stdout
             )

--- a/tests/integrationv2/test_sslv2_client_hello.py
+++ b/tests/integrationv2/test_sslv2_client_hello.py
@@ -2,10 +2,10 @@
 # SPDX-License-Identifier: Apache-2.0
 import copy
 
-from configuration import available_ports
 from common import Certificates, Ciphers, Protocols, ProviderOptions, data_bytes
+from configuration import available_ports
 from fixtures import managed_process  # noqa: F401
-from providers import Provider, S2N, JavaSSL
+from providers import S2N, JavaSSL, Provider
 from utils import (
     to_bytes,
 )

--- a/tests/integrationv2/test_sslyze.py
+++ b/tests/integrationv2/test_sslyze.py
@@ -1,16 +1,17 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
-import pytest
-import sslyze
 import abc
 from enum import Enum, auto
 
-from configuration import available_ports, MINIMAL_TEST_CERTS
-from common import ProviderOptions, Protocols, Cipher, Ciphers, Curves
+import pytest
+import sslyze
+
+from common import Cipher, Ciphers, Curves, Protocols, ProviderOptions
+from configuration import MINIMAL_TEST_CERTS, available_ports
 from fixtures import managed_process  # noqa: F401
+from global_flags import S2N_PROVIDER_VERSION, get_flag
 from providers import S2N
 from utils import get_parameter_name, invalid_test_parameters
-from global_flags import get_flag, S2N_PROVIDER_VERSION
 
 HOST = "127.0.0.1"
 

--- a/tests/integrationv2/test_version_negotiation.py
+++ b/tests/integrationv2/test_version_negotiation.py
@@ -1,24 +1,25 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 import copy
+
 import pytest
 
+from common import Protocols, ProviderOptions, data_bytes
 from configuration import (
-    available_ports,
     ALL_TEST_CIPHERS,
     ALL_TEST_CURVES,
     MINIMAL_TEST_CERTS,
+    available_ports,
 )
-from common import ProviderOptions, Protocols, data_bytes
 from fixtures import managed_process  # noqa: F401
-from providers import Provider, S2N, OpenSSL, GnuTLS
+from providers import S2N, GnuTLS, OpenSSL, Provider
 from utils import (
-    invalid_test_parameters,
-    get_parameter_name,
-    get_expected_s2n_version,
-    get_expected_openssl_version,
-    to_bytes,
     get_expected_gnutls_version,
+    get_expected_openssl_version,
+    get_expected_s2n_version,
+    get_parameter_name,
+    invalid_test_parameters,
+    to_bytes,
 )
 
 
@@ -33,7 +34,7 @@ def test_nothing():
 
 def invalid_version_negotiation_test_parameters(*args, **kwargs):
     # Since s2nd/s2nc will always be using TLS 1.3, make sure the libcrypto is compatible
-    if invalid_test_parameters(**{"provider": S2N, "protocol": Protocols.TLS13}):
+    if invalid_test_parameters(provider=S2N, protocol=Protocols.TLS13):
         return True
 
     return invalid_test_parameters(*args, **kwargs)
@@ -94,14 +95,8 @@ def test_s2nc_tls13_negotiates_tls12(
 
     for results in client.get_results():
         results.assert_success()
-        assert (
-            to_bytes("Client protocol version: {}".format(client_version))
-            in results.stdout
-        )
-        assert (
-            to_bytes("Actual protocol version: {}".format(actual_version))
-            in results.stdout
-        )
+        assert to_bytes(f"Client protocol version: {client_version}") in results.stdout
+        assert to_bytes(f"Actual protocol version: {actual_version}") in results.stdout
 
     for results in server.get_results():
         results.assert_success()
@@ -110,15 +105,14 @@ def test_s2nc_tls13_negotiates_tls12(
         if provider is S2N:
             # The client sends a TLS 1.3 client hello so a client protocol version of TLS 1.3 should always be expected.
             assert (
-                to_bytes("Client protocol version: {}".format(Protocols.TLS13.value))
+                to_bytes(f"Client protocol version: {Protocols.TLS13.value}")
                 in results.stdout
             )
             assert (
-                to_bytes("Actual protocol version: {}".format(actual_version))
-                in results.stdout
+                to_bytes(f"Actual protocol version: {actual_version}") in results.stdout
             )
 
-        assert any([random_bytes[1:] in stream for stream in results.output_streams()])
+        assert any(random_bytes[1:] in stream for stream in results.output_streams())
 
 
 @pytest.mark.uncollect_if(func=invalid_version_negotiation_test_parameters)
@@ -174,30 +168,22 @@ def test_s2nd_tls13_negotiates_tls12(
         if provider is S2N:
             # The client will get the server version from the SERVER HELLO, which will be the negotiated version
             assert (
-                to_bytes("Server protocol version: {}".format(actual_version))
-                in results.stdout
+                to_bytes(f"Server protocol version: {actual_version}") in results.stdout
             )
             assert (
-                to_bytes("Actual protocol version: {}".format(actual_version))
-                in results.stdout
+                to_bytes(f"Actual protocol version: {actual_version}") in results.stdout
             )
         elif provider is OpenSSL:
             # This check cares about other providers because we want to know that they did negotiate the version
             # that our S2N server intended to negotiate.
             openssl_version = get_expected_openssl_version(protocol)
-            assert to_bytes("Protocol  : {}".format(openssl_version)) in results.stdout
+            assert to_bytes(f"Protocol  : {openssl_version}") in results.stdout
         elif provider is GnuTLS:
             gnutls_version = get_expected_gnutls_version(protocol)
             assert to_bytes(f"Version: {gnutls_version}") in results.stdout
 
     for results in server.get_results():
         results.assert_success()
-        assert (
-            to_bytes("Server protocol version: {}".format(server_version))
-            in results.stdout
-        )
-        assert (
-            to_bytes("Actual protocol version: {}".format(actual_version))
-            in results.stdout
-        )
+        assert to_bytes(f"Server protocol version: {server_version}") in results.stdout
+        assert to_bytes(f"Actual protocol version: {actual_version}") in results.stdout
         assert random_bytes[1:] in results.stdout

--- a/tests/integrationv2/utils.py
+++ b/tests/integrationv2/utils.py
@@ -1,8 +1,8 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 from common import Protocols
+from global_flags import S2N_FIPS_MODE, get_flag
 from providers import S2N
-from global_flags import get_flag, S2N_FIPS_MODE
 
 
 def to_bytes(val):


### PR DESCRIPTION
# Goal
Fix CI failure

## Why
Looks like there was a new version with some additional rules: https://github.com/aws/s2n-tls/actions/runs/30044476509/job/89332151005?pr=6002

## How
Upgraded ruff locally, and fixes the issues.

## Callouts
I did have to convert the tests/sidetrail/bin/bpl_trace_to_c.py from python 2 -> python3 🫠 

## Testing
No semantic code change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
