### PR TITLE
fix: Add fail-closed default cases to all switch statements

### DIFF
--- a/tests/unit/s2n_alerts_test.c
+++ b/tests/unit/s2n_alerts_test.c
@@ -87,6 +87,16 @@ int main(int argc, char **argv)
         }
     }
 
+    /* s2n_error_get_alert: unknown error type maps to internal_error */
+    {
+        uint8_t alert = 0;
+        /* Fabricate an error code whose type bits exceed S2N_ERR_T_USAGE.
+         * This exercises the default case added to s2n_error_get_alert. */
+        int fabricated_error = ((S2N_ERR_T_USAGE + 1) << S2N_ERR_NUM_VALUE_BITS);
+        EXPECT_SUCCESS(s2n_error_get_alert(fabricated_error, &alert));
+        EXPECT_EQUAL(alert, S2N_TLS_ALERT_INTERNAL_ERROR);
+    }
+
     /* Test S2N_TLS_ALERT_CLOSE_NOTIFY and close_notify_received */
     {
         const uint8_t close_notify_alert[] = {

--- a/tests/unit/s2n_handshake_test.c
+++ b/tests/unit/s2n_handshake_test.c
@@ -556,5 +556,20 @@ int main(int argc, char **argv)
     }
 #endif
 
+    /* s2n_conn_update_required_handshake_hashes: invalid protocol version fails closed */
+    {
+        DEFER_CLEANUP(struct s2n_connection *conn = s2n_connection_new(S2N_SERVER),
+                s2n_connection_ptr_free);
+        EXPECT_NOT_NULL(conn);
+        DEFER_CLEANUP(struct s2n_config *config = s2n_config_new(), s2n_config_ptr_free);
+        EXPECT_NOT_NULL(config);
+        EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
+
+        /* Set an invalid protocol version that no case in the switch handles */
+        conn->actual_protocol_version = 255;
+        EXPECT_FAILURE_WITH_ERRNO(
+                s2n_conn_update_required_handshake_hashes(conn), S2N_ERR_SAFETY);
+    }
+
     END_TEST();
 }

--- a/tls/s2n_alerts.c
+++ b/tls/s2n_alerts.c
@@ -178,9 +178,14 @@ static S2N_RESULT s2n_translate_protocol_error_to_alert(int error_code, uint8_t 
         S2N_NO_ALERT(S2N_ERR_DUPLICATE_EXTENSION);
         S2N_NO_ALERT(S2N_ERR_MAX_EARLY_DATA_SIZE);
         S2N_NO_ALERT(S2N_ERR_EARLY_DATA_TRIAL_DECRYPT);
-    }
 
-    RESULT_BAIL(S2N_ERR_UNIMPLEMENTED);
+        default:
+            /* error_code is a plain int, not an enum, so -Wswitch cannot enforce
+             * exhaustiveness. Fail closed: an unmapped protocol error has no known
+             * alert mapping. This preserves the behavior previously provided by the
+             * post-switch RESULT_BAIL. */
+            RESULT_BAIL(S2N_ERR_UNIMPLEMENTED);
+    }
 }
 
 static bool s2n_alerts_supported(struct s2n_connection *conn)
@@ -231,6 +236,14 @@ int s2n_error_get_alert(int error, uint8_t *alert)
             break;
         case S2N_ERR_T_IO:
         case S2N_ERR_T_INTERNAL:
+            *alert = S2N_TLS_ALERT_INTERNAL_ERROR;
+            break;
+        default:
+            /* error_type comes from s2n_error_get_type, a plain int, so -Wswitch
+             * cannot enforce exhaustiveness. Treat an unknown error type the same
+             * as IO/INTERNAL: map it to internal_error. This avoids returning
+             * success with *alert left unset, and avoids changing the return code
+             * contract for callers that only check success/failure. */
             *alert = S2N_TLS_ALERT_INTERNAL_ERROR;
             break;
     }

--- a/tls/s2n_handshake.c
+++ b/tls/s2n_handshake.c
@@ -179,6 +179,14 @@ int s2n_conn_update_required_handshake_hashes(struct s2n_connection *conn)
             POSIX_GUARD(s2n_handshake_require_hash(&conn->handshake, hash_alg));
             break;
         }
+        default:
+            /* actual_protocol_version is a uint8_t, not an enum, so -Wswitch
+             * cannot enforce exhaustiveness. Fail closed: an unknown version
+             * must not silently skip setting the PRF hash requirement. This path
+             * is currently unreachable (the handshake sets the version to one of
+             * the five known values), but serves as defense-in-depth against
+             * internal state corruption. */
+            POSIX_BAIL(S2N_ERR_SAFETY);
     }
 
     return S2N_SUCCESS;


### PR DESCRIPTION
# Goal
Ensure **every** switch statement in s2n exhaustively covers **all** possible cases. 

(Background Note: I wrote a custom code scanning tool that I ran offline to find these cases. I plan on eventually opening a future PR to add it to s2n's CI, but wanted to get the actual fixes merged in first while I iterate on the code scanner.)

## Why

Ensure there's no unexpected or unhandled cases in any switch statements.

## How

Add `default:` to three switches:
- `s2n_translate_protocol_error_to_alert`: `RESULT_BAIL(S2N_ERR_UNIMPLEMENTED)`
- `s2n_error_get_alert`: `*alert = S2N_TLS_ALERT_INTERNAL_ERROR`
- `s2n_conn_update_required_handshake_hashes`: `POSIX_BAIL(S2N_ERR_SAFETY)`

## Testing

Unit tests added to `s2n_alerts_test.c` and `s2n_handshake_test.c`. Both confirmed to fail when the defaults are reverted.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.