### PR TITLE
fix(psk): return usage error for uninitialized offered PSK

### DIFF
--- a/tests/unit/s2n_psk_offered_test.c
+++ b/tests/unit/s2n_psk_offered_test.c
@@ -428,6 +428,15 @@ int main(int argc, char **argv)
             EXPECT_NULL(conn->psk_params.chosen_psk);
         };
 
+        /* Test: uninitialized PSK (identity not set) */
+        {
+            struct s2n_offered_psk *uninitialized_psk = s2n_offered_psk_new();
+            EXPECT_NOT_NULL(uninitialized_psk);
+            EXPECT_FAILURE_WITH_ERRNO(s2n_offered_psk_list_choose_psk(&offered_psk_list, uninitialized_psk), S2N_ERR_NULL);
+            EXPECT_NULL(conn->psk_params.chosen_psk);
+            EXPECT_SUCCESS(s2n_offered_psk_free(&uninitialized_psk));
+        };
+
         /* Test: Multiple matches exist */
         {
             struct s2n_psk *another_match = NULL;

--- a/tests/unit/s2n_psk_offered_test.c
+++ b/tests/unit/s2n_psk_offered_test.c
@@ -432,7 +432,7 @@ int main(int argc, char **argv)
         {
             struct s2n_offered_psk *uninitialized_psk = s2n_offered_psk_new();
             EXPECT_NOT_NULL(uninitialized_psk);
-            EXPECT_FAILURE_WITH_ERRNO(s2n_offered_psk_list_choose_psk(&offered_psk_list, uninitialized_psk), S2N_ERR_NULL);
+            EXPECT_FAILURE_WITH_ERRNO(s2n_offered_psk_list_choose_psk(&offered_psk_list, uninitialized_psk), S2N_ERR_INVALID_ARGUMENT);
             EXPECT_NULL(conn->psk_params.chosen_psk);
             EXPECT_SUCCESS(s2n_offered_psk_free(&uninitialized_psk));
         };

--- a/tls/s2n_psk.c
+++ b/tls/s2n_psk.c
@@ -327,6 +327,11 @@ int s2n_offered_psk_list_choose_psk(struct s2n_offered_psk_list *psk_list, struc
         return S2N_SUCCESS;
     }
 
+    /* An offered_psk must have its identity set before being chosen.
+     * Without this check, the function would return an internal error
+     * later when attempting to match the identity. */
+    POSIX_ENSURE_REF(psk->identity.data);
+
     if (psk_params->type == S2N_PSK_TYPE_RESUMPTION && psk_list->conn->config->use_tickets) {
         POSIX_GUARD(s2n_stuffer_init(&ticket_stuffer, &psk->identity));
         POSIX_GUARD(s2n_stuffer_skip_write(&ticket_stuffer, psk->identity.size));

--- a/tls/s2n_psk.c
+++ b/tls/s2n_psk.c
@@ -330,7 +330,7 @@ int s2n_offered_psk_list_choose_psk(struct s2n_offered_psk_list *psk_list, struc
     /* An offered_psk must have its identity set before being chosen.
      * Without this check, the function would return an internal error
      * later when attempting to match the identity. */
-    POSIX_ENSURE_REF(psk->identity.data);
+    POSIX_ENSURE(psk->identity.data != NULL, S2N_ERR_INVALID_ARGUMENT);
 
     if (psk_params->type == S2N_PSK_TYPE_RESUMPTION && psk_list->conn->config->use_tickets) {
         POSIX_GUARD(s2n_stuffer_init(&ticket_stuffer, &psk->identity));


### PR DESCRIPTION
## Why

`s2n_offered_psk_list_choose_psk` previously returned an internal error when called with an offered PSK whose identity had not been set (e.g. freshly allocated with `s2n_offered_psk_new`). The NULL identity data was only caught deep inside `s2n_match_psk_identity`, making the error confusing for callers.

## How

Added an early `POSIX_ENSURE(psk->identity.data != NULL, S2N_ERR_INVALID_ARGUMENT)` check so the caller gets a clear, actionable usage error (`S2N_ERR_T_USAGE` category) at the function boundary instead of a confusing internal error (`S2N_ERR_T_INTERNAL`).

## Testing

Added a unit test in `s2n_psk_offered_test.c` that creates an uninitialized PSK via `s2n_offered_psk_new` and verifies the function returns `S2N_ERR_INVALID_ARGUMENT`.

All existing tests should continue to pass since this only adds a new early-return path.

Resolves: #5085