### PR TITLE
feat(bindings): add vectored send to rust bindings

### DIFF
--- a/bindings/rust/extended/s2n-tls-tokio/src/lib.rs
+++ b/bindings/rust/extended/s2n-tls-tokio/src/lib.rs
@@ -419,6 +419,26 @@ where
             .map_err(io::Error::from)
     }
 
+    #[cfg(not(target_os = "windows"))]
+    fn poll_write_vectored(
+        self: Pin<&mut Self>,
+        ctx: &mut Context<'_>,
+        bufs: &[io::IoSlice<'_>],
+    ) -> Poll<io::Result<usize>> {
+        let tls = self.get_mut();
+        tls.with_io(ctx, |mut context| context.conn.as_mut().poll_sendv(bufs))
+            .map_err(io::Error::from)
+    }
+
+    /// Indicates that [`TlsStream`] has an efficient implementation of
+    /// [`AsyncWrite::poll_write_vectored`]: the TLS layer consumes the
+    /// buffers directly when constructing records, without an extra copy
+    /// into contiguous memory.
+    #[cfg(not(target_os = "windows"))]
+    fn is_write_vectored(&self) -> bool {
+        true
+    }
+
     fn poll_flush(self: Pin<&mut Self>, ctx: &mut Context<'_>) -> Poll<io::Result<()>> {
         let tls = self.get_mut();
 

--- a/bindings/rust/extended/s2n-tls-tokio/tests/send_and_recv.rs
+++ b/bindings/rust/extended/s2n-tls-tokio/tests/send_and_recv.rs
@@ -128,6 +128,114 @@ async fn send_error() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
+#[cfg(not(target_os = "windows"))]
+#[tokio::test]
+async fn send_and_recv_vectored() -> Result<(), Box<dyn std::error::Error>> {
+    let (server_stream, client_stream) = common::get_streams().await?;
+
+    let connector = TlsConnector::new(common::client_config()?.build()?);
+    let acceptor = TlsAcceptor::new(common::server_config()?.build()?);
+
+    let (mut client, mut server) =
+        common::run_negotiate(&connector, client_stream, &acceptor, server_stream).await?;
+
+    {
+        use tokio::io::AsyncWrite;
+        assert!(client.is_write_vectored());
+    }
+
+    let bufs = [
+        io::IoSlice::new(b"hello "),
+        io::IoSlice::new(b""),
+        io::IoSlice::new(b"vectored "),
+        io::IoSlice::new(b"world"),
+    ];
+    let expected: Vec<u8> = bufs.iter().flat_map(|buf| buf.iter().copied()).collect();
+
+    let written = client.write_vectored(&bufs).await?;
+    assert_eq!(written, expected.len());
+
+    let mut received = vec![0; expected.len()];
+    server.read_exact(&mut received).await?;
+    assert_eq!(expected, received);
+
+    Ok(())
+}
+
+#[cfg(not(target_os = "windows"))]
+#[tokio::test]
+async fn send_and_recv_vectored_multiple_records() -> Result<(), Box<dyn std::error::Error>> {
+    let (server_stream, client_stream) = common::get_streams().await?;
+
+    let connector = TlsConnector::new(common::client_config()?.build()?);
+    let acceptor = TlsAcceptor::new(common::server_config()?.build()?);
+
+    let (mut client, mut server) =
+        common::run_negotiate(&connector, client_stream, &acceptor, server_stream).await?;
+
+    // Send a payload larger than the maximum TLS record payload (2^14 bytes),
+    // split across multiple buffers, to ensure multiple records and exercise
+    // partial writes.
+    let expected = LARGE_TEST_DATA;
+    let mut received = vec![0; expected.len()];
+
+    let write_all_vectored = async {
+        let mut written = 0;
+        while written < expected.len() {
+            let remaining = &expected[written..];
+            let mid = remaining.len().div_ceil(2);
+            let (first, second) = remaining.split_at(mid);
+            // On a partial write, resume by advancing past the bytes
+            // already written rather than repeating the same buffers.
+            let bufs = [io::IoSlice::new(first), io::IoSlice::new(second)];
+            written += client.write_vectored(&bufs).await?;
+        }
+        Ok::<_, io::Error>(())
+    };
+
+    let (_, read_size) = tokio::try_join!(write_all_vectored, server.read_exact(&mut received))?;
+    assert_eq!(expected.len(), read_size);
+    assert_eq!(expected, received);
+
+    Ok(())
+}
+
+#[cfg(not(target_os = "windows"))]
+#[tokio::test]
+async fn send_vectored_blocked_then_retry() -> Result<(), Box<dyn std::error::Error>> {
+    let client = TlsConnector::new(common::client_config()?.build()?);
+    let server = TlsAcceptor::new(common::server_config()?.build()?);
+
+    let (server_stream, client_stream) = common::get_streams().await?;
+    let client_stream = common::TestStream::new(client_stream);
+    let overrides = client_stream.overrides();
+    let (mut client, mut server) =
+        common::run_negotiate(&client, client_stream, &server, server_stream).await?;
+
+    // Setup the underlying stream to block on the next write
+    overrides.next_write(Some(Box::new(|_, ctx, _| {
+        ctx.waker().wake_by_ref();
+        Pending
+    })));
+
+    let bufs = [
+        io::IoSlice::new(b"blocked "),
+        io::IoSlice::new(b"then retried"),
+    ];
+    let expected: Vec<u8> = bufs.iter().flat_map(|buf| buf.iter().copied()).collect();
+
+    // The first write blocks, so the future retries with the same buffers
+    // once the underlying stream is writable again.
+    let written = client.write_vectored(&bufs).await?;
+    assert_eq!(written, expected.len());
+
+    let mut received = vec![0; expected.len()];
+    server.read_exact(&mut received).await?;
+    assert_eq!(expected, received);
+
+    Ok(())
+}
+
 #[tokio::test]
 async fn recv_error() -> Result<(), Box<dyn std::error::Error>> {
     let client = TlsConnector::new(common::client_config()?.build()?);

--- a/bindings/rust/extended/s2n-tls/src/connection.rs
+++ b/bindings/rust/extended/s2n-tls/src/connection.rs
@@ -667,6 +667,29 @@ impl Connection {
         unsafe { s2n_send(self.connection.as_ptr(), buf_ptr, buf_len, &mut blocked).into_poll() }
     }
 
+    /// Encrypts and sends multiple buffers of data on a connection where
+    /// [negotiate](`Self::poll_negotiate`) has succeeded, avoiding the need
+    /// to copy the buffers into contiguous memory first.
+    ///
+    /// Returns the number of bytes written, and may indicate a partial write.
+    /// After a partial write, the next call should not pass the same `bufs`
+    /// again, but should instead advance past the `n` bytes already written,
+    /// like [`std::io::IoSlice::advance_slices`].
+    ///
+    /// Not available on Windows: [`std::io::IoSlice`] is only guaranteed to be
+    /// ABI compatible with `iovec` on Unix platforms.
+    ///
+    /// Corresponds to [`s2n_sendv`].
+    #[cfg(all(not(windows), not(feature = "unstable-renegotiate")))]
+    pub fn poll_sendv(&mut self, bufs: &[std::io::IoSlice<'_>]) -> Poll<Result<usize, Error>> {
+        let mut blocked = s2n_blocked_status::NOT_BLOCKED;
+        let count: isize = bufs.len().try_into().map_err(|_| Error::INVALID_INPUT)?;
+        // Safety: std::io::IoSlice is guaranteed to be ABI compatible with
+        // iovec on Unix platforms.
+        let bufs_ptr = bufs.as_ptr() as *const ::libc::iovec;
+        unsafe { s2n_sendv(self.connection.as_ptr(), bufs_ptr, count, &mut blocked).into_poll() }
+    }
+
     #[cfg(not(feature = "unstable-renegotiate"))]
     pub(crate) fn poll_recv_raw(
         &mut self,
@@ -1911,6 +1934,86 @@ mod tests {
             assert_eq!(test_pair.client.signature_scheme(), None);
             assert_eq!(test_pair.server.signature_scheme(), None);
         }
+        Ok(())
+    }
+
+    /// Test that poll_sendv sends data from multiple non-contiguous buffers,
+    /// and that the peer receives the concatenation of all the buffers.
+    #[cfg(not(windows))]
+    #[test]
+    fn poll_sendv_multiple_buffers() -> Result<(), Box<dyn std::error::Error>> {
+        let config = build_config(&security::DEFAULT_TLS13)?;
+        let mut pair = TestPair::from_config(&config);
+        pair.handshake()?;
+
+        let bufs = [
+            std::io::IoSlice::new(b"hello "),
+            std::io::IoSlice::new(b""),
+            std::io::IoSlice::new(b"vectored "),
+            std::io::IoSlice::new(b"world"),
+        ];
+        let expected: Vec<u8> = bufs.iter().flat_map(|buf| buf.iter().copied()).collect();
+
+        match pair.server.poll_sendv(&bufs) {
+            Poll::Ready(Ok(written)) => assert_eq!(written, expected.len()),
+            other => panic!("unexpected poll_sendv result: {other:?}"),
+        }
+
+        let mut received = vec![0; expected.len()];
+        let mut total_read = 0;
+        while total_read < expected.len() {
+            match pair.client.poll_recv(&mut received[total_read..]) {
+                Poll::Ready(Ok(read)) => {
+                    assert_ne!(read, 0, "unexpected EOF");
+                    total_read += read;
+                }
+                other => panic!("unexpected poll_recv result: {other:?}"),
+            }
+        }
+        assert_eq!(received, expected);
+        Ok(())
+    }
+
+    /// Test that a blocked poll_sendv returns Pending, and that retrying
+    /// with the same buffers succeeds once IO is unblocked.
+    #[cfg(not(windows))]
+    #[test]
+    fn poll_sendv_blocked_then_retry() -> Result<(), Box<dyn std::error::Error>> {
+        unsafe extern "C" fn blocking_send_cb(
+            _: *mut libc::c_void,
+            _: *const u8,
+            _: u32,
+        ) -> libc::c_int {
+            crate::testing::set_io_would_block();
+            -1
+        }
+
+        let config = build_config(&security::DEFAULT_TLS13)?;
+        let mut pair = TestPair::from_config(&config);
+        pair.handshake()?;
+
+        let bufs = [std::io::IoSlice::new(b"foo"), std::io::IoSlice::new(b"bar")];
+        let expected: Vec<u8> = bufs.iter().flat_map(|buf| buf.iter().copied()).collect();
+
+        // Block the server's sends. No bytes are acknowledged, so the
+        // send must return Pending.
+        pair.server.set_send_callback(Some(blocking_send_cb))?;
+        assert!(pair.server.poll_sendv(&bufs).is_pending());
+
+        // Unblock the server's sends. Retrying with the same buffers
+        // must send all the data.
+        pair.server.set_send_callback(Some(TestPair::send_cb))?;
+        match pair.server.poll_sendv(&bufs) {
+            Poll::Ready(Ok(written)) => assert_eq!(written, expected.len()),
+            other => panic!("unexpected poll_sendv result: {other:?}"),
+        }
+
+        let mut received = vec![0; expected.len()];
+        match pair.client.poll_recv(&mut received) {
+            Poll::Ready(Ok(read)) => assert_eq!(read, expected.len()),
+            other => panic!("unexpected poll_recv result: {other:?}"),
+        }
+        assert_eq!(received, expected);
         Ok(())
     }
 }

--- a/bindings/rust/extended/s2n-tls/src/renegotiate.rs
+++ b/bindings/rust/extended/s2n-tls/src/renegotiate.rs
@@ -318,6 +318,38 @@ impl Connection {
         result
     }
 
+    /// Encrypts and sends multiple buffers of data on a connection where
+    /// [negotiate](`Self::poll_negotiate`) has succeeded, avoiding the need
+    /// to copy the buffers into contiguous memory first.
+    ///
+    /// Returns the number of bytes written, and may indicate a partial write.
+    /// After a partial write, the next call should not pass the same `bufs`
+    /// again, but should instead advance past the `n` bytes already written,
+    /// like [`std::io::IoSlice::advance_slices`].
+    ///
+    /// Not available on Windows: [`std::io::IoSlice`] is only guaranteed to be
+    /// ABI compatible with `iovec` on Unix platforms.
+    ///
+    /// Corresponds to [`s2n_sendv`].
+    #[cfg(not(windows))]
+    pub fn poll_sendv(&mut self, bufs: &[std::io::IoSlice<'_>]) -> Poll<Result<usize, Error>> {
+        if self.is_renegotiating() {
+            return Ready(Err(Error::bindings(
+                ErrorType::Blocked,
+                "RenegotiateError",
+                "Cannot send application data while renegotiating",
+            )));
+        }
+        let mut blocked = s2n_blocked_status::NOT_BLOCKED;
+        let count: isize = bufs.len().try_into().map_err(|_| Error::INVALID_INPUT)?;
+        // Safety: std::io::IoSlice is guaranteed to be ABI compatible with
+        // iovec on Unix platforms.
+        let bufs_ptr = bufs.as_ptr() as *const libc::iovec;
+        let result = unsafe { s2n_sendv(self.as_ptr(), bufs_ptr, count, &mut blocked) }.into_poll();
+        self.renegotiate_state_mut().send_pending = result.is_pending();
+        result
+    }
+
     pub(crate) fn poll_recv_raw(
         &mut self,
         buf_ptr: *mut libc::c_void,
@@ -967,6 +999,32 @@ mod tests {
 
         // Calls to poll_send now fail
         let error = unwrap_poll(pair.client.poll_send(&[0; 1])).unwrap_err();
+        assert_eq!(error.kind(), ErrorType::Blocked);
+        assert!(error.message().contains(RENEG_ERR_MARKER));
+        assert!(error.message().contains("send application data"));
+        assert!(pair.client.is_renegotiating());
+
+        Ok(())
+    }
+
+    // poll_sendv is not currently supported during renegotiation
+    #[cfg(not(windows))]
+    #[test]
+    fn scheduled_renegotiate_with_poll_sendv() -> Result<(), Box<dyn Error>> {
+        let mut builder = config::Builder::new();
+        builder.set_renegotiate_callback(RenegotiateResponse::Schedule)?;
+        let mut pair = RenegotiateTestPair::from(builder)?;
+        pair.handshake().expect("Initial handshake");
+
+        // Read the hello request and start renegotiation
+        pair.send_renegotiate_request()
+            .expect("server HELLO_REQUEST");
+        assert!(pair.client.poll_recv(&mut [0; 1]).is_pending());
+        assert!(pair.client.is_renegotiating());
+
+        // Calls to poll_sendv now fail
+        let bufs = [std::io::IoSlice::new(&[0; 1])];
+        let error = unwrap_poll(pair.client.poll_sendv(&bufs)).unwrap_err();
         assert_eq!(error.kind(), ErrorType::Blocked);
         assert!(error.message().contains(RENEG_ERR_MARKER));
         assert!(error.message().contains("send application data"));


### PR DESCRIPTION
# Goal

Expose s2n's vectored send API through the Rust bindings: `Connection::poll_sendv` in `s2n-tls`, and `AsyncWrite::poll_write_vectored` + `is_write_vectored` for the `s2n-tls-tokio` `TlsStream`.

## Why

Applications that assemble a payload from multiple non-contiguous buffers currently have to copy them into contiguous memory before calling `poll_send`. The C library already supports vectored sends (`s2n_sendv`); the Rust bindings just don't expose it. Letting s2n-tls consume the buffers directly when constructing records removes that copy, reducing CPU and memory-bandwidth cost for write-heavy workloads.

## How

- `s2n-tls` (`connection.rs`): `poll_sendv(&mut self, bufs: &[IoSlice<'_>]) -> Poll<Result<usize, Error>>`, mirroring `poll_send` and calling `s2n_sendv`. `std::io::IoSlice` is guaranteed ABI-compatible with `iovec` on Unix platforms, so the slices are passed straight through without conversion.
- `s2n-tls` (`renegotiate.rs`): the `unstable-renegotiate` variant of `poll_sendv`, mirroring that feature's `poll_send` (same `is_renegotiating()` rejection and `send_pending` bookkeeping).
- `s2n-tls-tokio`: `poll_write_vectored` implemented via `with_io` → `poll_sendv`, exactly like `poll_write` → `poll_send`. `is_write_vectored()` returns `true` since the implementation is genuinely vectored (`s2n_record_writev` consumes the iovecs directly); this matches the convention used by [tokio-rustls](https://github.com/rustls/tokio-rustls/blob/main/src/common/mod.rs) (unconditional `true`), and makes tokio's `write_vectored` adapter forward the buffers instead of degrading to the first non-empty buffer.

The partial-write contract is documented on the new methods: after a partial write of `n` bytes, callers advance past `n` (like `IoSlice::advance_slices`) rather than re-sending the same buffers. This matches `s2n_sendv_with_offset`'s documented resumption semantics (`current_user_data_consumed` bookkeeping in `tls/s2n_send.c` indexes records at the acknowledged position, and a blocked send that acknowledged 0 bytes maps to `Pending` and is retried with byte-identical buffers).

## Callouts

- **Not available on Windows**: `IoSlice`'s ABI guarantee on Windows is `WSABUF` (`{u32 len, ptr}`), which does not match the `iovec` that `s2n.h` defines there (`{ptr, usize len}`) — and the C symbols are `#ifndef _WIN32` anyway (the sys crate already gates the externs via `WINDOWS_UNAVAILABLE_FUNCTIONS`). The new APIs are gated `#[cfg(not(windows))]`, following the existing `use_corked_io` precedent; on Windows the tokio stream keeps the default `poll_write_vectored` behavior.
- `poll_sendv` calls `s2n_sendv` (which is `s2n_sendv_with_offset` with `offs = 0`). An offset-based variant wasn't exposed because the advance-by-n calling pattern is equivalent and is what `IoSlice`-based Rust APIs expect.

## Testing

- `s2n-tls` unit tests: multi-buffer send (including an empty slice) with wire equality against `poll_recv`; blocked send returns `Pending` and a retry with the same buffers succeeds (0 bytes were acknowledged); renegotiate variant rejects `poll_sendv` while renegotiating (mirrors the existing `poll_send` test).
- `s2n-tls-tokio` integration tests: `is_write_vectored` + basic vectored wire equality; a >16KB payload split across buffers driving the partial-write advance loop over real TCP; a blocked-then-retried vectored write using the existing `TestStream` override harness.
- Local runs: `cargo test -p s2n-tls` (default and `--features unstable-renegotiate`), `cargo test -p s2n-tls-tokio`, clippy clean, `cargo +nightly fmt --check` clean.

### Related

None.

release summary: Added s2n_sendv to rust bindings ("poll_sendv"), and vectored write support to s2n-tls-tokio

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
