### PR TITLE
fix(ci): update msrv check to use Cargo.toml

### DIFF
--- a/.github/workflows/ci_msrv_consumers.yml
+++ b/.github/workflows/ci_msrv_consumers.yml
@@ -40,11 +40,13 @@ jobs:
           submodules: true
 
       # The consumer's MSRV is the toolchain we build with.
+      # s2n-quic declares its MSRV via the rust-version field in Cargo.toml
+      # (the rust-toolchain file was removed in aws/s2n-quic#3180).
       - uses: SebRollen/toml-action@v1.2.0
         id: consumer_msrv
         with:
-          file: 's2n-quic/rust-toolchain'
-          field: 'toolchain.channel'
+          file: 's2n-quic/quic/s2n-quic/Cargo.toml'
+          field: 'package.rust-version'
 
       # s2n-tls's own MSRV, read only for a readable log line.
       - uses: SebRollen/toml-action@v1.2.0


### PR DESCRIPTION
# Goal
[Fix failing CI](https://github.com/aws/s2n-tls/actions/runs/30859415033/job/91837879459?pr=6020)

## Why
it broken

## How
s2n-quic no longer has a rust-toolchain.toml as of https://github.com/aws/s2n-quic/pull/3180

So we directly read from Cargo.toml

## Testing
CI should now pass.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
