### PR TITLE
fix(docs): Hide unstable-renegotiate poll_send cfg in rustdoc

### DIFF
--- a/bindings/rust/extended/s2n-tls/src/connection.rs
+++ b/bindings/rust/extended/s2n-tls/src/connection.rs
@@ -660,6 +660,8 @@ impl Connection {
     ///
     /// Corresponds to [`s2n_send`].
     #[cfg(not(feature = "unstable-renegotiate"))]
+    // don't show the renegotiate config in docs.rs, this method has the same signature and docs regardless of that cfg.
+    #[cfg_attr(docsrs, doc(cfg(true)))]
     pub fn poll_send(&mut self, buf: &[u8]) -> Poll<Result<usize, Error>> {
         let mut blocked = s2n_blocked_status::NOT_BLOCKED;
         let buf_len: isize = buf.len().try_into().map_err(|_| Error::INVALID_INPUT)?;


### PR DESCRIPTION
# Goal

Fix documentation to not mislead users that [`poll_send`](https://docs.rs/s2n-tls/latest/s2n_tls/connection/struct.Connection.html#method.poll_send) only exists with `unstable-renegotiate`.

## How

See docs - https://doc.rust-lang.org/nightly/rustdoc/unstable-features.html#doccfg-and-docauto_cfg. `docsrs` config is set by docs.rs (https://docs.rs/about/builds) so this feature should keep working.

## Testing

Generated docs locally using https://crates.io/crates/cargo-docs-rs and confirmed they render without a cfg.

### Related

n/a

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
