### PR TITLE
fix: prevent use-after-free in `Connection::set_config` when C setter rejects replacement

### DIFF
--- a/bindings/rust/extended/s2n-tls/src/connection.rs
+++ b/bindings/rust/extended/s2n-tls/src/connection.rs
@@ -263,9 +263,16 @@ impl Connection {
     /// Corresponds to [`s2n_connection_set_config`].
     pub fn set_config(&mut self, mut config: Config) -> Result<&mut Self, Error> {
         unsafe {
-            // attempt to drop the currently set config
-            self.drop_config()?;
+            // Retrieve the previous config before attempting to set the new one.
+            // We must NOT drop it until we know the new config was successfully installed,
+            // because s2n_connection_set_config has failure paths that return early
+            // without assigning conn->config. Dropping first would leave a dangling pointer.
+            let mut prev_config_ptr = core::ptr::null_mut();
+            let _ = s2n_connection_get_config(self.connection.as_ptr(), &mut prev_config_ptr)
+                .into_result();
 
+            // Attempt to install the new config. If this fails, conn->config is unchanged
+            // and still points to the previous (valid, non-freed) config.
             s2n_connection_set_config(self.connection.as_ptr(), config.as_mut_ptr())
                 .into_result()?;
 
@@ -274,9 +281,17 @@ impl Connection {
                 "s2n_connection_set_config was successful"
             };
 
-            // Setting the config on the connection creates one additional reference to the config
-            // so do not drop so prevent Rust from calling `drop()` at the end of this function.
-            mem::forget(config);
+            // If the C setter was a no-op (same pointer), it didn't take a new
+            // reference. Let `config` drop normally to decrement the clone's refcount.
+            // Otherwise the C side took ownership — forget `config` and drop the old one.
+            let is_same_config = NonNull::new(prev_config_ptr)
+                .is_some_and(|prev| prev.as_ptr() == config.as_mut_ptr());
+            if !is_same_config {
+                if let Some(prev) = NonNull::new(prev_config_ptr) {
+                    drop(Config::from_raw(prev));
+                }
+                mem::forget(config);
+            }
         }
 
         Ok(self)
@@ -1912,5 +1927,53 @@ mod tests {
             assert_eq!(test_pair.server.signature_scheme(), None);
         }
         Ok(())
+    }
+
+    /// Test that a failed set_config does not cause a use-after-free.
+    ///
+    /// Previously, set_config would drop the old config before confirming the
+    /// new config was successfully installed. If the C setter rejected the new
+    /// config, the connection would hold a dangling pointer. This test verifies
+    /// the fix: the old config remains valid when set_config fails.
+    #[test]
+    fn set_config_failure_no_use_after_free() {
+        // Create a valid config and install it on a CLIENT connection.
+        let good_config = {
+            let mut builder = crate::config::Builder::new();
+            builder.set_security_policy(&security::DEFAULT).unwrap();
+            builder.build().unwrap()
+        };
+        let mut conn = Connection::new_client();
+        conn.set_config(good_config).unwrap();
+
+        // Create a config that will be rejected for a CLIENT connection:
+        // loading two certificate chains triggers S2N_ERR_TOO_MANY_CERTIFICATES
+        // because "only 1 certificate is supported in client mode".
+        let rsa_keypair = crate::testing::CertKeyPair::default();
+        let ecdsa_keypair =
+            crate::testing::CertKeyPair::from_path("ecdsa_p384_pkcs1_", "cert", "key", "cert");
+        let bad_config = {
+            let mut builder = crate::config::Builder::new();
+            builder.set_security_policy(&security::DEFAULT).unwrap();
+
+            // Use load_chain to add multiple certs (load_pem only allows one).
+            let rsa_chain = rsa_keypair.into_certificate_chain();
+            let ecdsa_chain = ecdsa_keypair.into_certificate_chain();
+            builder.load_chain(rsa_chain).unwrap();
+            builder.load_chain(ecdsa_chain).unwrap();
+            builder.build().unwrap()
+        };
+
+        // This should fail but NOT cause a use-after-free.
+        let result = conn.set_config(bad_config);
+        assert!(
+            result.is_err(),
+            "set_config should fail with too many certs for client"
+        );
+
+        // The connection should still be usable (no dangling pointer).
+        // Dropping the connection exercises drop_config which would crash
+        // if the old config had been freed.
+        drop(conn);
     }
 }

--- a/bindings/rust/extended/s2n-tls/src/connection.rs
+++ b/bindings/rust/extended/s2n-tls/src/connection.rs
@@ -1966,10 +1966,8 @@ mod tests {
 
         // This should fail but NOT cause a use-after-free.
         let result = conn.set_config(bad_config);
-        assert!(
-            result.is_err(),
-            "set_config should fail with too many certs for client"
-        );
+        let err = result.unwrap_err();
+        assert_eq!(err.name(), "S2N_ERR_TOO_MANY_CERTIFICATES");
 
         // The connection should still be usable (no dangling pointer).
         // Dropping the connection exercises drop_config which would crash


### PR DESCRIPTION
# Goal
Fix a use-after-free / soundness violation in the Rust bindings' `Connection::set_config()` that occurs when `s2n_connection_set_config()` rejects the new config.

## Why
`set_config()` previously called `drop_config()` — freeing the old config — before confirming the new config was successfully installed. The C function `s2n_connection_set_config()` has several early-return failure paths that may execute before assigning `conn->config`. On failure, `conn->config` still pointed at the already-freed memory, and the subsequent `Connection::drop` would dereference it.

## How
Reorder operations in `set_config()` to make the config swap transactional:
1. Save the previous config pointer before attempting installation
2. Call `s2n_connection_set_config()`; if it fails, return early via `?` (old config is still valid, nothing freed)
3. On success, drop the old config and `mem::forget` the new one (C now owns it)
4. Handle the same-config no-op case: when the C setter detects `conn->config == config` and returns immediately without taking a new reference, let the incoming clone drop normally instead of leaking it

## Testing
- Added `set_config_failure_no_use_after_free()` test that installs a valid config on a client connection, then attempts to replace it with a config containing two cert chains (triggering `S2N_ERR_TOO_MANY_CERTIFICATES`). Verifies the error is returned and the connection can be safely dropped without crashing.
- Existing `set_config_multiple_times()` test continues to pass, validating correct refcount behavior when the same config is re-applied.

Panicked test without the fix:
```
thread 'connection::tests::set_config_failure_no_use_after_free' (11071777) panicked at s2n-tls/src/config.rs:93:13:
null pointer dereference occurred
thread caused non-unwinding panic. aborting.
error: test failed, to rerun pass `--lib`
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
