### PR TITLE
fix: null `evp_cipher_ctx` after free in `s2n_session_key_alloc()` error path

### DIFF
--- a/crypto/s2n_cipher.c
+++ b/crypto/s2n_cipher.c
@@ -30,6 +30,7 @@ int s2n_session_key_alloc(struct s2n_session_key *key)
     key->evp_aead_ctx = OPENSSL_malloc(sizeof(EVP_AEAD_CTX));
     if (key->evp_aead_ctx == NULL) {
         EVP_CIPHER_CTX_free(key->evp_cipher_ctx);
+        key->evp_cipher_ctx = NULL;
         S2N_ERROR_PRESERVE_ERRNO();
     }
     EVP_AEAD_CTX_zero(key->evp_aead_ctx);


### PR DESCRIPTION
# Goal
Fix double-free on AEAD malloc failure in `s2n_session_key_alloc()`

## Why
When `OPENSSL_malloc()` fails to allocate `evp_aead_ctx`, the error path frees `evp_cipher_ctx` but did not null the pointer. If `s2n_session_key_free()` is subsequently called on the partially-initialized key (as happens during connection cleanup), `EVP_CIPHER_CTX_free()` is called again on the already-freed pointer, causing a double-free.

## How
Set `key->evp_cipher_ctx = NULL` after freeing it in the malloc-failure error path.

## Testing
This a standard null-after-free pattern already used in the adjacent `s2n_session_key_free()` function. No new test; existing CI should pass.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
