### PR TITLE
fix: zero-init hash state and guard async offload wipe against in-flight ops

### DIFF
--- a/tests/unit/s2n_async_offload_cb_test.c
+++ b/tests/unit/s2n_async_offload_cb_test.c
@@ -100,6 +100,23 @@ int main(int argc, char *argv[])
         EXPECT_FAILURE_WITH_ERRNO(s2n_async_offload_op_perform(&test_op), S2N_ERR_INVALID_STATE);
     }
 
+    /* Test: s2n_async_offload_op_wipe refuses to wipe an in-flight op */
+    {
+        struct s2n_async_offload_op op = { 0 };
+
+        /* Wipe succeeds when not invoked */
+        op.async_state = S2N_ASYNC_NOT_INVOKED;
+        EXPECT_OK(s2n_async_offload_op_wipe(&op));
+
+        /* Wipe succeeds when complete */
+        op.async_state = S2N_ASYNC_COMPLETE;
+        EXPECT_OK(s2n_async_offload_op_wipe(&op));
+
+        /* Wipe fails when still in flight */
+        op.async_state = S2N_ASYNC_INVOKED;
+        EXPECT_ERROR_WITH_ERRNO(s2n_async_offload_op_wipe(&op), S2N_ERR_ASYNC_BLOCKED);
+    }
+
     /* clang-format off */
     struct s2n_async_offload_test_case {
         bool async_test;

--- a/tls/s2n_async_offload.c
+++ b/tls/s2n_async_offload.c
@@ -67,6 +67,7 @@ int s2n_async_offload_op_perform(struct s2n_async_offload_op *op)
 S2N_RESULT s2n_async_offload_op_wipe(struct s2n_async_offload_op *op)
 {
     RESULT_ENSURE_REF(op);
+    RESULT_ENSURE(op->async_state != S2N_ASYNC_INVOKED, S2N_ERR_ASYNC_BLOCKED);
     if (op->op_data_free == NULL) {
         return S2N_RESULT_OK;
     }

--- a/tls/s2n_async_pkey.c
+++ b/tls/s2n_async_pkey.c
@@ -286,7 +286,7 @@ S2N_RESULT s2n_async_pkey_sign_sync(struct s2n_connection *conn, s2n_signature_a
 
     RESULT_ENSURE_REF(conn->config);
     if (conn->config->verify_after_sign) {
-        DEFER_CLEANUP(struct s2n_hash_state digest_for_verify, s2n_hash_free);
+        DEFER_CLEANUP(struct s2n_hash_state digest_for_verify = { 0 }, s2n_hash_free);
         RESULT_GUARD_POSIX(s2n_hash_new(&digest_for_verify));
         RESULT_GUARD_POSIX(s2n_hash_copy(&digest_for_verify, digest));
         RESULT_GUARD_POSIX(s2n_pkey_sign(pkey, sig_alg, digest, &signed_content));
@@ -423,7 +423,7 @@ S2N_RESULT s2n_async_pkey_sign_perform(struct s2n_async_pkey_op *op, s2n_cert_pr
     /* If validation mode is S2N_ASYNC_PKEY_VALIDATION_STRICT
      * then use local hash copy to sign the signature */
     if (op->validation_mode == S2N_ASYNC_PKEY_VALIDATION_STRICT) {
-        DEFER_CLEANUP(struct s2n_hash_state hash_state_copy, s2n_hash_free);
+        DEFER_CLEANUP(struct s2n_hash_state hash_state_copy = { 0 }, s2n_hash_free);
         RESULT_GUARD_POSIX(s2n_hash_new(&hash_state_copy));
         RESULT_GUARD_POSIX(s2n_hash_copy(&hash_state_copy, &sign->digest));
 


### PR DESCRIPTION
# Goal
Fix two defensive issues in the async pkey/offload paths that can cause undefined behavior under rare failure conditions

## Why
In `s2n_async_pkey.c`, `DEFER_CLEANUP` hash states are declared without zero-initialization. If `s2n_hash_new()` fails partway (e.g., `EVP_MD_CTX_new()` returns NULL under memory pressure), the deferred cleanup frees a garbage pointer from the uninitialized `evp_md5_secondary.ctx` field — undefined behavior.

In `s2n_async_offload.c`, `s2n_async_offload_op_wipe()` unconditionally tears down the op without checking whether a background thread is still processing it. If an application calls `s2n_connection_free()` while an offload op is in flight, this races with the background thread.

## How
1. Zero-initialize both `DEFER_CLEANUP` declarations in `s2n_async_pkey.c` with `= { 0 }`, so cleanup always sees NULL pointers on partial-init failure.
2. check `op->async_state` before freeing the struct in `s2n_async_offload_op_wipe()`, matching the guard in the sibling `s2n_async_offload_op_reset()` function.

## Testing
Added a unit test in `s2n_async_offload_cb_test.c` verifying that `s2n_async_offload_op_wipe()` returns `S2N_ERR_ASYNC_BLOCKED` when `async_state == S2N_ASYNC_INVOKED`, and succeeds for `NOT_INVOKED` and `COMPLETE` states.

No test for the hash zero-init as it requires injecting allocation failures at a specific call site, and the fix is an obviously-correct pattern used throughout the codebase.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
