### PR TITLE
ci: install musl from Linux apt and upgrade octokit action to Node 24

### DIFF
--- a/.github/workflows/codebuild.yml
+++ b/.github/workflows/codebuild.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Get permissions
         id: get_permission
         if: github.event_name == 'pull_request_target'
-        uses: octokit/request-action@v2.x
+        uses: octokit/request-action@v3.0.0
         with:
           route: GET /repos/{repo}/collaborators/{author}/permission
           repo: ${{ github.repository }}

--- a/codebuild/spec/buildspec_musl.yml
+++ b/codebuild/spec/buildspec_musl.yml
@@ -15,21 +15,14 @@ version: 0.2
 
 env:
   variables:
-    MUSL_DIR: "test-deps/musl"
     LIBCRYPTO_DIR: "test-deps/musl-awslc"
-    
+
 phases:
   pre_build:
     on-failure: ABORT
     commands:
-      # Install musl libc
-      # Use GitHub mirror because git.musl-libc.org is unreliable in CI
-      - git clone --depth=1 https://github.com/ahjragaas/musl.git $MUSL_DIR
-      - echo "Installing musl to $CODEBUILD_SRC_DIR/$MUSL_DIR"
-      - cd $MUSL_DIR
-      - ./configure --prefix=$CODEBUILD_SRC_DIR/$MUSL_DIR
-      - make install
-      - cd $CODEBUILD_SRC_DIR
+      # Install musl libc from OS package manager
+      - apt-get update && apt-get install -y musl-tools
       # Install libcrypto.
       # We need to modify the usual install so that the library can link to musl.
       # If this becomes a problem, we can switch to more official cross compilation.
@@ -38,7 +31,7 @@ phases:
   build:
     on-failure: ABORT
     commands:
-      - CC="$CODEBUILD_SRC_DIR/$MUSL_DIR/bin/musl-gcc"
+      - CC="musl-gcc"
       - cmake . -Bbuild -DCMAKE_PREFIX_PATH=$CODEBUILD_SRC_DIR/$LIBCRYPTO_DIR
       - cmake --build ./build
   post_build:

--- a/codebuild/spec/buildspec_musl.yml
+++ b/codebuild/spec/buildspec_musl.yml
@@ -23,7 +23,8 @@ phases:
     on-failure: ABORT
     commands:
       # Install musl libc
-      - git clone --depth=1 https://git.musl-libc.org/git/musl $MUSL_DIR
+      # Use GitHub mirror because git.musl-libc.org is unreliable in CI
+      - git clone --depth=1 https://github.com/ahjragaas/musl.git $MUSL_DIR
       - echo "Installing musl to $CODEBUILD_SRC_DIR/$MUSL_DIR"
       - cd $MUSL_DIR
       - ./configure --prefix=$CODEBUILD_SRC_DIR/$MUSL_DIR


### PR DESCRIPTION
# Goal
Fix two flacky CI failures in the CodeBuild workflow: the musl git clone failing with exit status 128, and the permissions check failing with a self-signed certificate error under Node 24.

## Why
1. The official musl-libc git server (git.musl-libc.org) is unreliable and intermittently drops connections, causing the [musl CodeBuild job to fail](https://us-west-2.codebuild.aws.amazon.com/project/eyJlbmNyeXB0ZWREYXRhIjoidUpNb2QzNjZzQ3lrWm1UQ2xzdFZMN1ZGYWE5dVlSQ1ZKd1BnZzZ6aXN1dlZXTmFuZWdvNnR0SitPaFlIcUdjaDZ6RU9KemY2Mi9ybXVBajF0RXo4NmZ1Rnl4dkZrT241UUY4MTVQMkRuNTQ9IiwiaXZQYXJhbWV0ZXJTcGVjIjoiemFRUDgvZUMreVhER0RKaiIsIm1hdGVyaWFsU2V0U2VyaWFsIjoxfQ%3D%3D/build/41bf551c-a4a9-486c-bce5-a3c1a168dde8) during git clone.
2. GitHub Actions runners now default to Node 24, which has stricter TLS certificate validation. `octokit/request-action@v2.x` was built for Node 20 and [fails](https://github.com/aws/s2n-tls/actions/runs/31441028055/attempts/1) when the runner forces Node 24.

## How
- Changed the buildspec to install `musl` from Ubuntu's package manager instead of cloning from a git server. Note: this approach gets whatever version Ubuntu 22 repos ship (currently `musl 1.2.2`) rather than the latest from git.
- Upgraded `octokit/request-action` from v2.x to v3.0.0, which explicitly targets Node 24 with updated dependencies and runtime support.

## Testing
Existing CI continues to pass

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
