### PR TITLE
chore: update http test with new status code

### DIFF
--- a/bindings/rust/standard/integration/src/network/https_client.rs
+++ b/bindings/rust/standard/integration/src/network/https_client.rs
@@ -49,7 +49,8 @@ const TEST_CASES: &[TestCase] = &[
     // 2026-04-28: ebay.com returns 400 under
     // `cargo test --no-default-features --features pq`.
     // 2026-06-16: ebay.com also returns 307 (redirect).
-    TestCase::new("https://www.ebay.com", &[200, 307, 400]),
+    // 2026-08-12: also returns 403
+    TestCase::new("https://www.ebay.com", &[200, 307, 400, 403]),
     TestCase::new("https://www.google.com", &[200]),
     TestCase::new("https://www.mozilla.org", &[200]),
     TestCase::new("https://www.netflix.com", &[200]),


### PR DESCRIPTION
# Goal
Fix broken CI

## Why
`www.ebay.com` is now returning a 403.

```
Unexpected status code "403" for test case TestCase {
    query_target: "https://www.ebay.com/",
    expected_status_codes: [
        200,
        307,
        400,
    ],
}
```
https://github.com/aws/s2n-tls/actions/runs/31621443792/job/94197010038?pr=6032

## How
Update the expected status codes

## Testing
CI should pass

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
