### PR TITLE
feat: deprecate default tls13, pq policies

### DIFF
--- a/bindings/rust/extended/s2n-tls-tokio/tests/handshake.rs
+++ b/bindings/rust/extended/s2n-tls-tokio/tests/handshake.rs
@@ -35,10 +35,6 @@ async fn handshake_basic() -> Result<(), Box<dyn std::error::Error>> {
         // Cipher suite may change, so just makes sure we can retrieve it.
         assert!(tls.as_ref().cipher_suite().is_ok());
         assert!(tls.as_ref().selected_curve().is_ok());
-        assert_eq!(
-            tls.as_ref().selected_curve().ok(),
-            tls.as_ref().selected_key_exchange_group(),
-        );
     }
 
     Ok(())

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -31,7 +31,7 @@ Have you already configure a trust store to be able to trust your peer's certifi
 s2n-tls sleeps for a random period between 10 and 30 seconds after specific errors occur to avoid leaking any secret information via timing data. This technique is called blinding and it is utilized to prevent timing side-channel attacks. See [blinding](usage-guide/topics/ch03-error-handling.md#blinding).
 
 ### Which security policy should I use if I want to make sure that it will never be altered?
-Our numbered security policies are guaranteed to never change. We will not alter or update them based on changing cryptography standards. However, our named security policies (like “default” or “default_tls13”) change based on new cryptography standards that come out. See [security policies](usage-guide/topics/ch06-security-policies.md).
+Our numbered security policies are guaranteed to never change. We will not alter or update them based on changing cryptography standards. However, our named security policies (like “default” or “default_fips”) change based on new cryptography standards that come out. See [security policies](usage-guide/topics/ch06-security-policies.md).
 
 ### Why does s2n-tls have a dependency on OpenSSL? Isn't s2n-tls a replacement for OpenSSL?
 OpenSSL includes both a TLS library, called libssl, and a cryptography library, called libcrypto. s2n-tls implements a TLS library, but does not implement a cryptography library. Instead, s2n-tls links to a separate libcrypto in order to perform cryptographic operations. Libcryptos other than OpenSSL can be used, such as [AWS-LC](https://github.com/aws/aws-lc).

--- a/docs/usage-guide/topics/ch06-security-policies.md
+++ b/docs/usage-guide/topics/ch06-security-policies.md
@@ -27,9 +27,8 @@ The following chart maps the security policy version to protocol version and cip
 
 |    version    | TLS1.0 | TLS1.1 | TLS1.2 | TLS1.3 | AES-CBC | AES-GCM | CHACHAPOLY | 3DES | RC4 | DHE | ECDHE | RSA kx |
 |---------------|--------|--------|--------|--------|---------|---------|------------|------|-----|-----|-------|--------|
-|    default    |        |        |    X   |    X   |    X    |    X    |      X     |      |     |     |   X   |        |
-| default_fips  |        |        |    X   |    X   |    X    |    X    |            |      |     |     |   X   |        |
-| default_tls13 |        |        |    X   |    X   |    X    |    X    |      X     |      |     |     |   X   |        |
+|    default    |        |        |    X   |    X   |         |    X    |      X     |      |     |     |   X   |        |
+| default_fips  |        |        |    X   |    X   |         |    X    |            |      |     |     |   X   |        |
 |   20240501    |        |        |    X   |        |    X    |    X    |            |      |     |     |   X   |        |
 |   20240502    |        |        |    X   |        |    X    |    X    |            |      |     |     |   X   |        |
 |   20240503    |        |        |    X   |    X   |    X    |    X    |            |      |     |     |   X   |        |
@@ -55,7 +54,7 @@ The following chart maps the security policy version to protocol version and cip
 |   20200207    |        |        |        |    X   |         |    X    |      X     |      |     |     |   X   |        |
 |    rfc9151    |        |        |    X   |    X   |         |    X    |            |      |     |     |   X   |        |
 
-The "default", "default_tls13", and "default_fips" versions are special in that they will be updated with future s2n-tls changes to keep up-to-date with current security best practices. Ciphersuites, protocol versions, and other options may be added or removed, or their internal order of preference might change. **Warning**: this means that the default policies may change as a result of library updates, which could break peers that rely on legacy options.
+The "default" and "default_fips" versions are special in that they will be updated with future s2n-tls changes to keep up-to-date with current security best practices. Ciphersuites, protocol versions, and other options may be added or removed, or their internal order of preference might change. **Warning**: this means that the default policies may change as a result of library updates, which could break peers that rely on legacy options.
 
 In contrast, numbered or dated versions are fixed and will never change.
 
@@ -63,9 +62,9 @@ The numbered equivalents for the named policies for the current version and
 historical s2n versions are in the "Named Policy History" below. The current
 matching fixed versions are:
 
-| "default" | "default_fips" | "default_tls13" | "rfc9151" |
-|-----------|----------------|-----------------|-----------|
-| 20251014  |   20251015     |    20240503     |  20251013 |
+| "default" | "default_fips" | "rfc9151" |
+|-----------|----------------|-----------|
+| 20251014  |   20251015     |  20251013 |
 
 "rfc9151" is derived from [Commercial National Security Algorithm (CNSA) Suite Profile for TLS and DTLS 1.2 and 1.3](https://datatracker.ietf.org/doc/html/rfc9151). This policy restricts the algorithms allowed for signatures on certificates in the certificate chain to RSA or ECDSA with sha384, which may require you to update your certificates.
 Like the default policies, this policy may also change if the source RFC definition changes.
@@ -89,7 +88,6 @@ s2n-tls usually prefers AES over ChaCha20. However, some clients-- particularly 
 |---------------|-----------|-------|--------------|---------|
 |    default    |     X     |   X   |              |    X    |
 | default_fips  |     X     |   X   |              |    X    |
-| default_tls13 |     X     |   X   |              |    X    |
 |   20240501    |     X     |   X   |              |    X    |
 |   20240502    |     X     |   X   |              |    X    |
 |   20240503    |     X     |   X   |              |    X    |
@@ -124,7 +122,6 @@ s2n-tls usually prefers AES over ChaCha20. However, some clients-- particularly 
 |---------------|-----------|-----------|--------|
 |    default    |     X     |     X     |    X   |
 | default_fips  |     X     |     X     |        |
-| default_tls13 |     X     |     X     |    X   |
 |   20240501    |     X     |     X     |    X   |
 |   20240502    |     X     |     X     |        |
 |   20240503    |     X     |     X     |    X   |
@@ -151,11 +148,11 @@ s2n-tls usually prefers AES over ChaCha20. However, some clients-- particularly 
 
 ### Named Policy History
 
-|  Version   | "default" | "default_fips" | "default_tls13" | "rfc9151" |
-|------------|-----------|----------------|-----------------|-----------|
-|  v1.6.0    | 20251014  |   20251015     |    20240503     |  20251013 |
-|  v1.5.25   | 20240501  |   20240502     |    20240503     |  20250429 |
-|  v1.4.16   | 20240501  |   20240502     |    20240503     |    (*)    |
-|   Older    | 20170210  |   20240416     |    20240417     |    (*)    |
+|  Version   | "default" | "default_fips" | "rfc9151" |
+|------------|-----------|----------------|-----------|
+|  v1.6.0    | 20251014  |   20251015     |  20251013 |
+|  v1.5.25   | 20240501  |   20240502     |  20250429 |
+|  v1.4.16   | 20240501  |   20240502     |    (*)    |
+|   Older    | 20170210  |   20240416     |    (*)    |
 
 (*): No fixed policy available.

--- a/docs/usage-guide/topics/ch16-post-quantum.md
+++ b/docs/usage-guide/topics/ch16-post-quantum.md
@@ -37,7 +37,7 @@ Listening on localhost:8000
 
 Post-quantum algorithms are enabled by configuring a security policy (see [Security Policies](./ch06-security-policies.md)) that supports post-quantum algorithms. 
 
-"default_pq" is the equivalent of "default_tls13", but with PQ support. Like the other default policies, "default_pq" may change as a result of library updates. The fixed, numbered equivalent of "default_pq" is currently "20250721". For previous defaults, see the "Default Policy History" section below.
+Post quantum algorithms are enabled in the "default" policy. For previous defaults, see the "Default Policy History" section below.
 
 "cnsa_2" is derived from [Commercial National Security Algorithm (CNSA) Suite Profile for TLS 1.3](https://datatracker.ietf.org/doc/draft-becker-cnsa2-tls-profile/). This is a TLS 1.3 PQ only policy that requires pure ML-KEM-1024 for key exchange and ML-DSA-87 for signature and certificate verification.
 
@@ -49,7 +49,7 @@ Other available PQ policies are compared in the tables below.
 
 |        Version        | x25519+mlkem768 | secp256r1+mlkem768 | secp384r1+mlkem1024 | mlkem1024 |
 |-----------------------|-----------------|--------------------|---------------------|-----------|
-| default_pq / 20250721 |        X        |          X         |          X          |           |
+| default / 20251014    |        X        |          X         |          X          |           |
 | 20250512              |        X        |          X         |                     |           |
 | cnsa_2                |                 |                    |                     |     X     |
 | cnsa_1_2_interop      |                 |                    |                     |     X     |
@@ -58,7 +58,7 @@ Other available PQ policies are compared in the tables below.
 
 |        Version        | ML-DSA | ECDSA | RSA | RSA-PSS | Legacy SHA1 |
 |-----------------------|--------|-------|-----|---------|-------------|
-| default_pq / 20250721 |   X    |   X   |  X  |    X    |             |
+| default / 20251014    |   X    |   X   |  X  |    X    |             |
 | 20250512              |   X    |   X   |  X  |    X    |             |
 | cnsa_2                |   87   |       |     |         |             |
 | cnsa_1_2_interop      |   87   |   X   |  X  |    X    |             |
@@ -71,7 +71,7 @@ Note: the "cnsa_2" policy only allows ML-KEM-1024, thus there is no fallback to 
 
 |        Version        | secp256r1 | x25519 | secp384r1 | secp521r1 | DHE | RSA |
 |-----------------------|-----------|--------|-----------|-----------|-----|-----|
-| default_pq / 20250721 |     X     |   X    |     X     |     X     |     |     |
+| default / 20251014    |     X     |   X    |     X     |     X     |     |     |
 | 20250512              |     X     |   X    |     X     |     X     |     |     |
 | cnsa_1_2_interop      |           |        |     X     |           |     |     |
 
@@ -79,7 +79,7 @@ Note: the "cnsa_2" policy only allows ML-KEM-1024, thus there is no fallback to 
 
 |        Version        | AES-CBC | AES-GCM | CHACHAPOLY | 3DES |
 |-----------------------|---------|---------|------------|------|
-| default_pq / 20250721 |    X    |    X    |     X      |      |
+| default / 20251014    |    X    |    X    |     X      |      |
 | 20250512              |    X    |    X    |     X      |      |
 | cnsa_2                |         |    X    |            |      |
 | cnsa_1_2_interop      |         |    X    |            |      |
@@ -88,7 +88,7 @@ Note: the "cnsa_2" policy only allows ML-KEM-1024, thus there is no fallback to 
 
 |        Version        | 1.2 | 1.3 |
 |-----------------------|-----|-----|
-| default_pq / 20250721 |  X  |  X  |
+| default / 20251014    |  X  |  X  |
 | 20250512              |  X  |  X  |
 | cnsa_2                |     |  X  |
 | cnsa_1_2_interop      |  X  |  X  |

--- a/tests/policy_snapshot/snapshots/default_pq
+++ b/tests/policy_snapshot/snapshots/default_pq
@@ -7,19 +7,10 @@ cipher suites:
 - TLS_AES_256_GCM_SHA384
 - TLS_CHACHA20_POLY1305_SHA256
 - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
-- TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
 - TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+- TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
 - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
-- TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256
-- TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
-- TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384
-- TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384
-- TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256
-- TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256
 signature schemes:
-- mldsa44
-- mldsa65
-- mldsa87
 - ecdsa_sha256
 - ecdsa_sha384
 - ecdsa_sha512
@@ -37,24 +28,6 @@ curves:
 - x25519
 - secp384r1
 - secp521r1
-certificate signature schemes:
-- mldsa44
-- mldsa65
-- mldsa87
-- rsa_pss_pss_sha256
-- rsa_pss_pss_sha384
-- rsa_pss_pss_sha512
-- rsa_pss_rsae_sha256
-- rsa_pss_rsae_sha384
-- rsa_pss_rsae_sha512
-- rsa_pkcs1_sha256
-- rsa_pkcs1_sha384
-- rsa_pkcs1_sha512
-- legacy_rsa_sha224
-- ecdsa_sha256
-- ecdsa_sha384
-- ecdsa_sha512
-- legacy_ecdsa_sha224
 pq:
 - revision: 5
 - kem groups:

--- a/tests/policy_snapshot/snapshots/default_tls13
+++ b/tests/policy_snapshot/snapshots/default_tls13
@@ -7,15 +7,9 @@ cipher suites:
 - TLS_AES_256_GCM_SHA384
 - TLS_CHACHA20_POLY1305_SHA256
 - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
-- TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
 - TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+- TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
 - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
-- TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256
-- TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
-- TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384
-- TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384
-- TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256
-- TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256
 signature schemes:
 - ecdsa_sha256
 - ecdsa_sha384
@@ -34,18 +28,9 @@ curves:
 - x25519
 - secp384r1
 - secp521r1
-certificate signature schemes:
-- rsa_pss_pss_sha256
-- rsa_pss_pss_sha384
-- rsa_pss_pss_sha512
-- rsa_pss_rsae_sha256
-- rsa_pss_rsae_sha384
-- rsa_pss_rsae_sha512
-- rsa_pkcs1_sha256
-- rsa_pkcs1_sha384
-- rsa_pkcs1_sha512
-- legacy_rsa_sha224
-- ecdsa_sha256
-- ecdsa_sha384
-- ecdsa_sha512
-- legacy_ecdsa_sha224
+pq:
+- revision: 5
+- kem groups:
+-- X25519MLKEM768
+-- SecP256r1MLKEM768
+-- SecP384r1MLKEM1024

--- a/tests/unit/s2n_client_early_data_indication_test.c
+++ b/tests/unit/s2n_client_early_data_indication_test.c
@@ -420,14 +420,14 @@ int main(int argc, char **argv)
         {
             struct s2n_connection *client_conn = s2n_connection_new(S2N_CLIENT);
             EXPECT_NOT_NULL(client_conn);
-            EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(client_conn, "default_tls13"));
+            EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(client_conn, "20240503"));
             EXPECT_OK(s2n_append_test_psk_with_early_data(client_conn, 1, &s2n_tls13_aes_256_gcm_sha384));
             EXPECT_EQUAL(client_conn->early_data_state, S2N_UNKNOWN_EARLY_DATA_STATE);
             EXPECT_SUCCESS(s2n_connection_set_early_data_expected(client_conn));
 
             struct s2n_connection *server_conn = s2n_connection_new(S2N_SERVER);
             EXPECT_NOT_NULL(server_conn);
-            EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(server_conn, "default_tls13"));
+            EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(server_conn, "20240503"));
             EXPECT_OK(s2n_append_test_psk_with_early_data(server_conn, 0, &s2n_tls13_aes_256_gcm_sha384));
             EXPECT_EQUAL(server_conn->early_data_state, S2N_UNKNOWN_EARLY_DATA_STATE);
             EXPECT_SUCCESS(s2n_connection_set_early_data_expected(server_conn));

--- a/tests/unit/s2n_client_hello_retry_test.c
+++ b/tests/unit/s2n_client_hello_retry_test.c
@@ -1295,6 +1295,7 @@ int main(int argc, char **argv)
             EXPECT_NOT_NULL(server_conn);
             EXPECT_SUCCESS(s2n_connection_set_blinding(server_conn, S2N_SELF_SERVICE_BLINDING));
             EXPECT_SUCCESS(s2n_connection_set_config(server_conn, config));
+            EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(server_conn, "20240503"));
 
             DEFER_CLEANUP(struct s2n_connection *client_conn = s2n_connection_new(S2N_CLIENT),
                     s2n_connection_ptr_free);

--- a/tests/unit/s2n_client_key_share_extension_test.c
+++ b/tests/unit/s2n_client_key_share_extension_test.c
@@ -72,6 +72,7 @@ int main(int argc, char **argv)
         struct s2n_stuffer key_share_extension = { 0 };
         struct s2n_connection *conn = NULL;
         EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
+        EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(conn, "20240503"));
 
         uint32_t key_share_size = 0;
         EXPECT_OK(s2n_extensions_client_key_share_size(conn, &key_share_size));
@@ -98,6 +99,7 @@ int main(int argc, char **argv)
             struct s2n_stuffer key_share_extension = { 0 };
             struct s2n_connection *conn = NULL;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
+            EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(conn, "20240503"));
             EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&key_share_extension, 0));
 
             EXPECT_SUCCESS(s2n_client_key_share_extension.send(conn, &key_share_extension));
@@ -119,6 +121,7 @@ int main(int argc, char **argv)
             struct s2n_stuffer key_share_extension = { 0 };
             struct s2n_connection *conn = NULL;
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
+            EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(conn, "20240503"));
             EXPECT_SUCCESS(s2n_stuffer_growable_alloc(&key_share_extension, 0));
             EXPECT_SUCCESS(s2n_client_key_share_extension.send(conn, &key_share_extension));
 
@@ -342,6 +345,7 @@ int main(int argc, char **argv)
         {
             struct s2n_connection *conn = s2n_connection_new(S2N_CLIENT);
             EXPECT_NOT_NULL(conn);
+            EXPECT_SUCCESS(s2n_connection_set_cipher_preferences(conn, "20240503"));
 
             const struct s2n_ecc_preferences *ecc_preferences = NULL;
             EXPECT_SUCCESS(s2n_connection_get_ecc_preferences(conn, &ecc_preferences));

--- a/tests/unit/s2n_security_policies_test.c
+++ b/tests/unit/s2n_security_policies_test.c
@@ -235,11 +235,11 @@ int main(int argc, char **argv)
         EXPECT_SUCCESS(s2n_find_security_policy_from_version("default_tls13", &security_policy));
         EXPECT_TRUE(s2n_ecc_is_extension_required(security_policy));
         EXPECT_FALSE(s2n_pq_kem_is_extension_required(security_policy));
-        EXPECT_TRUE(s2n_security_policy_supports_tls13(security_policy));
-        EXPECT_EQUAL(0, security_policy->kem_preferences->kems);
-        EXPECT_NULL(security_policy->kem_preferences->tls13_kem_groups);
-        EXPECT_EQUAL(0, security_policy->kem_preferences->tls13_kem_group_count);
         EXPECT_NULL(security_policy->kem_preferences->kems);
+        EXPECT_EQUAL(0, security_policy->kem_preferences->kem_count);
+        EXPECT_EQUAL(security_policy->kem_preferences, &kem_preferences_pq_tls_1_3_ietf_2025_07);
+        EXPECT_EQUAL(3, security_policy->kem_preferences->tls13_kem_group_count);
+        EXPECT_TRUE(s2n_security_policy_supports_tls13(security_policy));
 
         /* The "all" security policy contains both TLS 1.2 KEM extension and TLS 1.3 KEM SupportedGroup entries*/
         security_policy = NULL;
@@ -1086,6 +1086,7 @@ int main(int argc, char **argv)
             const struct s2n_security_policy *versioned_policies[] = {
                 &security_policy_20240417,
                 &security_policy_20240503,
+                &security_policy_20251014,
             };
 
             DEFER_CLEANUP(struct s2n_test_cert_chain_list cert_chains = { 0 },
@@ -1125,6 +1126,7 @@ int main(int argc, char **argv)
                 &security_policy_20241001,
                 &security_policy_20250512,
                 &security_policy_20250721,
+                &security_policy_20251014,
             };
 
             DEFER_CLEANUP(struct s2n_test_cert_chain_list cert_chains = { 0 },
@@ -1156,79 +1158,24 @@ int main(int argc, char **argv)
         };
     };
 
-    /* Test that default_pq always matches default_tls13 */
+    /* Test that default, default_pq, and default_tls13 are all aliases of the
+     * same security policy */
     {
+        const struct s2n_security_policy *default_policy = NULL;
+        EXPECT_SUCCESS(s2n_find_security_policy_from_version("default", &default_policy));
+
         const struct s2n_security_policy *default_pq = NULL;
         EXPECT_SUCCESS(s2n_find_security_policy_from_version("default_pq", &default_pq));
         EXPECT_NOT_EQUAL(default_pq->kem_preferences, &kem_preferences_null);
 
         const struct s2n_security_policy *default_tls13 = NULL;
         EXPECT_SUCCESS(s2n_find_security_policy_from_version("default_tls13", &default_tls13));
-        EXPECT_EQUAL(default_tls13->kem_preferences, &kem_preferences_null);
+        EXPECT_NOT_EQUAL(default_tls13->kem_preferences, &kem_preferences_null);
 
-        /* Except for PQ algorithms, the two policies should match */
-
-        /* Most fields can be compared directly. We just ignore kem_preferences. */
-        EXPECT_EQUAL(default_pq->minimum_protocol_version, default_tls13->minimum_protocol_version);
-        EXPECT_EQUAL(default_pq->cipher_preferences, default_tls13->cipher_preferences);
-        EXPECT_EQUAL(default_pq->ecc_preferences, default_tls13->ecc_preferences);
-        EXPECT_EQUAL(default_pq->certificate_key_preferences, default_tls13->certificate_key_preferences);
-        EXPECT_EQUAL(default_pq->certificate_preferences_apply_locally,
-                default_tls13->certificate_preferences_apply_locally);
-
-        /* The signature preferences match,
-         * EXCEPT for the added PQ algorithms, which should come first.
-         */
-        {
-            const struct s2n_signature_preferences *pq_sig_prefs = default_pq->signature_preferences;
-            const struct s2n_signature_preferences *tls13_sig_prefs = default_tls13->signature_preferences;
-
-            /* Count how many PQ sig schemes */
-            size_t pq_count = 0;
-            while (pq_count < pq_sig_prefs->count) {
-                if (pq_sig_prefs->signature_schemes[pq_count]->sig_alg
-                        == S2N_SIGNATURE_MLDSA) {
-                    pq_count++;
-                } else {
-                    break;
-                }
-            }
-            EXPECT_TRUE(pq_count > 0);
-
-            /* Compare the two preference lists, minus the PQ sig schemes */
-            EXPECT_EQUAL(pq_sig_prefs->count - pq_count, tls13_sig_prefs->count);
-            for (size_t i = 0; i < default_tls13->signature_preferences->count; i++) {
-                EXPECT_EQUAL(pq_sig_prefs->signature_schemes[i + pq_count],
-                        tls13_sig_prefs->signature_schemes[i]);
-            }
-        }
-
-        /* The certificate signature preferences match,
-         * EXCEPT for the added PQ algorithms, which should come first.
-         */
-        {
-            const struct s2n_signature_preferences *pq_sig_prefs = default_pq->certificate_signature_preferences;
-            const struct s2n_signature_preferences *tls13_sig_prefs = default_tls13->certificate_signature_preferences;
-
-            /* Count how many PQ sig schemes */
-            size_t pq_count = 0;
-            while (pq_count < pq_sig_prefs->count) {
-                if (pq_sig_prefs->signature_schemes[pq_count]->sig_alg
-                        == S2N_SIGNATURE_MLDSA) {
-                    pq_count++;
-                } else {
-                    break;
-                }
-            }
-            EXPECT_TRUE(pq_count > 0);
-
-            /* Compare the two preference lists, minus the PQ sig schemes */
-            EXPECT_EQUAL(pq_sig_prefs->count - pq_count, tls13_sig_prefs->count);
-            for (size_t i = 0; i < default_tls13->signature_preferences->count; i++) {
-                EXPECT_EQUAL(pq_sig_prefs->signature_schemes[i + pq_count],
-                        tls13_sig_prefs->signature_schemes[i]);
-            }
-        }
+        /* All three default policies now alias the same underlying policy */
+        EXPECT_EQUAL(default_pq, default_policy);
+        EXPECT_EQUAL(default_tls13, default_policy);
+        EXPECT_EQUAL(default_pq, default_tls13);
     };
 
     /* s2n_find_version_from_security_policy */
@@ -1245,11 +1192,16 @@ int main(int argc, char **argv)
             EXPECT_STRING_EQUAL(s2n_find_version_from_security_policy(policy), "20240501");
         };
 
-        /* Returns correct version for default_tls13 */
+        /* Returns correct version for default_tls13.
+         *
+         * default, default_tls13, and default_pq all alias the same underlying
+         * policy. Since "default" is the first entry in the table with that
+         * policy pointer, it is the version returned.
+         */
         {
             const struct s2n_security_policy *policy = NULL;
             EXPECT_SUCCESS(s2n_find_security_policy_from_version("default_tls13", &policy));
-            EXPECT_STRING_EQUAL(s2n_find_version_from_security_policy(policy), "default_tls13");
+            EXPECT_STRING_EQUAL(s2n_find_version_from_security_policy(policy), "default");
         };
 
         /* Returns "unknown" for a policy not in the selection table */

--- a/tests/unit/s2n_security_policies_test.c
+++ b/tests/unit/s2n_security_policies_test.c
@@ -1132,8 +1132,10 @@ int main(int argc, char **argv)
             DEFER_CLEANUP(struct s2n_test_cert_chain_list cert_chains = { 0 },
                     s2n_test_cert_chains_free);
             EXPECT_OK(s2n_test_cert_chains_init(&cert_chains));
+            /* default_pq now aliases the "default" policy (20251014), whose
+             * signature preferences do not include ML-DSA. */
             EXPECT_OK(s2n_test_cert_chains_set_supported(&cert_chains,
-                    S2N_PKEY_TYPE_MLDSA, 2));
+                    S2N_PKEY_TYPE_MLDSA, S2N_TEST_CERT_UNSUPPORTED));
 
             EXPECT_OK(s2n_test_default_backwards_compatible("default_pq",
                     versioned_policies, s2n_array_len(versioned_policies),

--- a/tests/unit/s2n_x509_validator_certificate_signatures_test.c
+++ b/tests/unit/s2n_x509_validator_certificate_signatures_test.c
@@ -86,13 +86,14 @@ int main(int argc, char **argv)
             X509_free(cert);
         };
 
-        /* Connection using the default_tls13 security policy does not validate SHA-1 signatures in certificates */
+        /* Connection using a security policy with certificate_signature_preferences does not validate SHA-1 signatures in certificates */
         {
             struct s2n_connection *conn = NULL;
             struct s2n_config *config = s2n_config_new();
 
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
-            EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "default_tls13"));
+            /* 20240503 is a security policy with a certificate_signature_preferences list that rejects SHA-1 */
+            EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "20240503"));
             EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
 
             EXPECT_SUCCESS(s2n_read_test_pem(S2N_RSA_2048_PKCS1_CERT_CHAIN, (char *) cert_file, S2N_MAX_TEST_PEM_SIZE));
@@ -112,13 +113,13 @@ int main(int argc, char **argv)
             X509_free(cert);
         };
 
-        /* Connection using the default_tls13 security policy ignores a SHA-1 signature on a root certificate */
+        /* Connection using a security policy with certificate_signature_preferences ignores a SHA-1 signature on a root certificate */
         {
             struct s2n_connection *conn = NULL;
             struct s2n_config *config = s2n_config_new();
 
             EXPECT_NOT_NULL(conn = s2n_connection_new(S2N_CLIENT));
-            EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "default_tls13"));
+            EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "20240503"));
             EXPECT_SUCCESS(s2n_connection_set_config(conn, config));
 
             EXPECT_SUCCESS(s2n_read_test_pem(S2N_SHA1_ROOT_SIGNATURE_CA_CERT, (char *) cert_file, S2N_MAX_TEST_PEM_SIZE));

--- a/tests/unit/s2n_x509_validator_test.c
+++ b/tests/unit/s2n_x509_validator_test.c
@@ -1977,7 +1977,8 @@ int main(int argc, char **argv)
         s2n_x509_validator_init(&validator, &trust_store, 1);
 
         struct s2n_config *config = s2n_config_new();
-        EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "default_tls13"));
+        /* 20240503 is a security policy with a certificate_signature_preferences list that rejects SHA-1 */
+        EXPECT_SUCCESS(s2n_config_set_cipher_preferences(config, "20240503"));
 
         struct s2n_connection *connection = s2n_connection_new(S2N_CLIENT);
         EXPECT_SUCCESS(s2n_connection_set_config(connection, config));

--- a/tls/s2n_security_policies.c
+++ b/tls/s2n_security_policies.c
@@ -72,7 +72,6 @@ const struct s2n_security_policy security_policy_20240502 = {
     },
 };
 
-/* TLS1.3 default as of 05/24 */
 const struct s2n_security_policy security_policy_20240503 = {
     .minimum_protocol_version = S2N_TLS12,
     .cipher_preferences = &cipher_preferences_cloudfront_tls_1_2_2019,
@@ -1583,9 +1582,9 @@ struct s2n_security_policy_selection security_policy_selection[] = {
      * You likely also want to update the compatibility unit tests in (tests/unit/s2n_security_rules_test.c).
      */
     { .version = "default", .security_policy = &security_policy_20251014, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
-    { .version = "default_tls13", .security_policy = &security_policy_20240503, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
+    { .version = "default_tls13", .security_policy = &security_policy_20251014, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
+    { .version = "default_pq", .security_policy = &security_policy_20251014, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
     { .version = "default_fips", .security_policy = &security_policy_20251015, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
-    { .version = "default_pq", .security_policy = &security_policy_20250721, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
     { .version = "20241106", .security_policy = &security_policy_20241106, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
     { .version = "20240501", .security_policy = &security_policy_20240501, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
     { .version = "20240502", .security_policy = &security_policy_20240502, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },


### PR DESCRIPTION
# Goal
Make the `default_pq` and `default_tls13` policies good.

## Why
`default_tls13` isn't currently PQ enabled. `default_pq` supports CBC ciphers.

## How
Just alias everything to the `default` policy.

## Callouts
This is a slight regression for the `default_tls13` policy, which was previously rejecting SHA1 signatures on certificates. I think the PQ enablement is worth it. 

Although we should follow up with the removal of SHA1 signatures on the default cert preferences.

I will also be following up with a PR to clean up the TLS 1.3 default config spaghetti.

## Testing
Had to update some security policy tests. All unit tests should pass. The previous `default_pq` and `default_tls13` policies are negotiable with the current `default`, so this is a safe change to make.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
