### PR TITLE
fix(tls13): Reject oversized Finished messages via exact length check

### DIFF
--- a/tests/unit/s2n_tls13_client_finished_test.c
+++ b/tests/unit/s2n_tls13_client_finished_test.c
@@ -76,6 +76,15 @@ int main(int argc, char **argv)
             EXPECT_SUCCESS(s2n_stuffer_write_uint8(&server_conn->handshake.io, 0));
             EXPECT_FAILURE(s2n_tls13_client_finished_recv(server_conn));
 
+            /* Expect failure if verify has 256 extra bytes (uint8 wrap-around regression) */
+            EXPECT_SUCCESS(reset_stuffers(&client_conn->handshake.io, &server_conn->handshake.io));
+            EXPECT_SUCCESS(s2n_stuffer_copy(&client_conn->handshake.io, &server_conn->handshake.io, hash_size));
+            for (int j = 0; j < 256; j++) {
+                EXPECT_SUCCESS(s2n_stuffer_write_uint8(&server_conn->handshake.io, 0));
+            }
+            EXPECT_EQUAL(s2n_stuffer_data_available(&server_conn->handshake.io), hash_size + 256);
+            EXPECT_FAILURE(s2n_tls13_client_finished_recv(server_conn));
+
             /* Expect failure if verify on wire is modified by 1 bit */
             EXPECT_SUCCESS(reset_stuffers(&client_conn->handshake.io, &server_conn->handshake.io));
             EXPECT_SUCCESS(s2n_stuffer_copy(&client_conn->handshake.io, &server_conn->handshake.io, hash_size));

--- a/tls/s2n_client_finished.c
+++ b/tls/s2n_client_finished.c
@@ -52,15 +52,16 @@ int s2n_tls13_client_finished_recv(struct s2n_connection *conn)
 {
     POSIX_ENSURE_EQ(conn->actual_protocol_version, S2N_TLS13);
 
-    uint8_t length = s2n_stuffer_data_available(&conn->handshake.io);
-    S2N_ERROR_IF(length == 0, S2N_ERR_BAD_MESSAGE);
+    /* get tls13 keys first so we can validate length */
+    s2n_tls13_connection_keys(keys, conn);
+
+    /* RFC 8446 §4.4.4: Finished message must be exactly the HMAC output length */
+    uint32_t length = s2n_stuffer_data_available(&conn->handshake.io);
+    POSIX_ENSURE_EQ(length, keys.size);
 
     /* read finished mac from handshake */
     struct s2n_blob wire_finished_mac = { 0 };
     POSIX_GUARD(s2n_blob_init(&wire_finished_mac, s2n_stuffer_raw_read(&conn->handshake.io, length), length));
-
-    /* get tls13 keys */
-    s2n_tls13_connection_keys(keys, conn);
 
     /* get transcript hash */
     POSIX_ENSURE_REF(conn->handshake.hashes);

--- a/tls/s2n_server_finished.c
+++ b/tls/s2n_server_finished.c
@@ -81,15 +81,16 @@ int s2n_tls13_server_finished_recv(struct s2n_connection *conn)
 {
     POSIX_ENSURE_EQ(conn->actual_protocol_version, S2N_TLS13);
 
-    uint8_t length = s2n_stuffer_data_available(&conn->handshake.io);
-    S2N_ERROR_IF(length == 0, S2N_ERR_BAD_MESSAGE);
+    /* get tls13 keys first so we can validate length */
+    s2n_tls13_connection_keys(keys, conn);
+
+    /* RFC 8446 §4.4.4: Finished message must be exactly the HMAC output length */
+    uint32_t length = s2n_stuffer_data_available(&conn->handshake.io);
+    POSIX_ENSURE_EQ(length, keys.size);
 
     /* read finished mac from handshake */
     struct s2n_blob wire_finished_mac = { 0 };
     POSIX_GUARD(s2n_blob_init(&wire_finished_mac, s2n_stuffer_raw_read(&conn->handshake.io, length), length));
-
-    /* get tls13 keys */
-    s2n_tls13_connection_keys(keys, conn);
 
     /* get transcript hash */
     POSIX_ENSURE_REF(conn->handshake.hashes);


### PR DESCRIPTION
# Goal

Reject TLS 1.3 Finished messages whose length does not exactly match the negotiated HMAC output size.

## Why

`s2n_stuffer_data_available` returns `uint32_t` but the result was stored in a `uint8_t`. A Finished message with `hash_size + 256` trailing bytes wraps back to `hash_size`, bypassing length validation. This silently corrupts the handshake transcript hash and breaks session resumption state.

## How

- Change `uint8_t length` to `uint32_t length` in both `s2n_tls13_client_finished_recv` and `s2n_tls13_server_finished_recv`.
- Move `s2n_tls13_connection_keys` initialization before the length check so `keys.size` is available.
- Replace `S2N_ERROR_IF(length == 0, ...)` with `POSIX_ENSURE_EQ(length, keys.size)`, an exact match per RFC 8446 §4.4.4.

## Callouts

The existing "+1 byte" test already passed before this fix because 33 != 32 without truncation. The new test targets the specific wrap-around at +256 bytes that the `uint8_t` allowed through.

## Testing
New unit test.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.