### PR TITLE
fix(cbc): Disable padding after key init and check decrypt len

### DIFF
--- a/crypto/s2n_cbc_cipher_3des.c
+++ b/crypto/s2n_cbc_cipher_3des.c
@@ -46,10 +46,10 @@ static int s2n_cbc_cipher_3des_decrypt(struct s2n_session_key *key, struct s2n_b
 
     POSIX_GUARD_OSSL(EVP_DecryptInit_ex(key->evp_cipher_ctx, NULL, NULL, NULL, iv->data), S2N_ERR_KEY_INIT);
 
-    /* len is set by EVP_DecryptUpdate. It is not checked here but padding is manually removed and therefore
-     * the decryption operation is validated. */
+    /* len is set by EVP_DecryptUpdate and checked post operation. */
     int len = 0;
     POSIX_GUARD_OSSL(EVP_DecryptUpdate(key->evp_cipher_ctx, out->data, &len, in->data, in->size), S2N_ERR_DECRYPT);
+    POSIX_ENSURE((int64_t) len == (int64_t) in->size, S2N_ERR_DECRYPT);
 
     return 0;
 }
@@ -58,8 +58,9 @@ static S2N_RESULT s2n_cbc_cipher_3des_set_decryption_key(struct s2n_session_key 
 {
     RESULT_ENSURE_EQ(in->size, 192 / 8);
 
-    EVP_CIPHER_CTX_set_padding(key->evp_cipher_ctx, 0);
     RESULT_GUARD_OSSL(EVP_DecryptInit_ex(key->evp_cipher_ctx, EVP_des_ede3_cbc(), NULL, in->data, NULL), S2N_ERR_KEY_INIT);
+    /* Padding must be disabled after key init to take effect. */
+    EVP_CIPHER_CTX_set_padding(key->evp_cipher_ctx, 0);
 
     return S2N_RESULT_OK;
 }
@@ -68,8 +69,9 @@ static S2N_RESULT s2n_cbc_cipher_3des_set_encryption_key(struct s2n_session_key 
 {
     RESULT_ENSURE_EQ(in->size, 192 / 8);
 
-    EVP_CIPHER_CTX_set_padding(key->evp_cipher_ctx, 0);
     RESULT_GUARD_OSSL(EVP_EncryptInit_ex(key->evp_cipher_ctx, EVP_des_ede3_cbc(), NULL, in->data, NULL), S2N_ERR_KEY_INIT);
+    /* Padding must be disabled after key init to take effect. */
+    EVP_CIPHER_CTX_set_padding(key->evp_cipher_ctx, 0);
 
     return S2N_RESULT_OK;
 }

--- a/crypto/s2n_cbc_cipher_3des.c
+++ b/crypto/s2n_cbc_cipher_3des.c
@@ -46,7 +46,6 @@ static int s2n_cbc_cipher_3des_decrypt(struct s2n_session_key *key, struct s2n_b
 
     POSIX_GUARD_OSSL(EVP_DecryptInit_ex(key->evp_cipher_ctx, NULL, NULL, NULL, iv->data), S2N_ERR_KEY_INIT);
 
-    /* len is set by EVP_DecryptUpdate and checked post operation. */
     int len = 0;
     POSIX_GUARD_OSSL(EVP_DecryptUpdate(key->evp_cipher_ctx, out->data, &len, in->data, in->size), S2N_ERR_DECRYPT);
     POSIX_ENSURE((int64_t) len == (int64_t) in->size, S2N_ERR_DECRYPT);

--- a/crypto/s2n_cbc_cipher_aes.c
+++ b/crypto/s2n_cbc_cipher_aes.c
@@ -51,10 +51,10 @@ int s2n_cbc_cipher_aes_decrypt(struct s2n_session_key *key, struct s2n_blob *iv,
 
     POSIX_GUARD_OSSL(EVP_DecryptInit_ex(key->evp_cipher_ctx, NULL, NULL, NULL, iv->data), S2N_ERR_KEY_INIT);
 
-    /* len is set by EVP_DecryptUpdate. It is not checked here but padding is manually removed and therefore
-     * the decryption operation is validated. */
+    /* len is set by EVP_DecryptUpdate and checked post operation. */
     int len = 0;
     POSIX_GUARD_OSSL(EVP_DecryptUpdate(key->evp_cipher_ctx, out->data, &len, in->data, in->size), S2N_ERR_DECRYPT);
+    POSIX_ENSURE((int64_t) len == (int64_t) in->size, S2N_ERR_DECRYPT);
 
     return 0;
 }
@@ -63,9 +63,9 @@ S2N_RESULT s2n_cbc_cipher_aes128_set_decryption_key(struct s2n_session_key *key,
 {
     RESULT_ENSURE_EQ(in->size, 128 / 8);
 
-    /* Always returns 1 */
-    EVP_CIPHER_CTX_set_padding(key->evp_cipher_ctx, 0);
     RESULT_GUARD_OSSL(EVP_DecryptInit_ex(key->evp_cipher_ctx, EVP_aes_128_cbc(), NULL, in->data, NULL), S2N_ERR_KEY_INIT);
+    /* Padding must be disabled after key init to take effect. */
+    EVP_CIPHER_CTX_set_padding(key->evp_cipher_ctx, 0);
 
     return S2N_RESULT_OK;
 }
@@ -74,8 +74,9 @@ static S2N_RESULT s2n_cbc_cipher_aes128_set_encryption_key(struct s2n_session_ke
 {
     RESULT_ENSURE_EQ(in->size, 128 / 8);
 
-    EVP_CIPHER_CTX_set_padding(key->evp_cipher_ctx, 0);
     RESULT_GUARD_OSSL(EVP_EncryptInit_ex(key->evp_cipher_ctx, EVP_aes_128_cbc(), NULL, in->data, NULL), S2N_ERR_KEY_INIT);
+    /* Padding must be disabled after key init to take effect. */
+    EVP_CIPHER_CTX_set_padding(key->evp_cipher_ctx, 0);
 
     return S2N_RESULT_OK;
 }
@@ -84,8 +85,9 @@ static S2N_RESULT s2n_cbc_cipher_aes256_set_decryption_key(struct s2n_session_ke
 {
     RESULT_ENSURE_EQ(in->size, 256 / 8);
 
-    EVP_CIPHER_CTX_set_padding(key->evp_cipher_ctx, 0);
     RESULT_GUARD_OSSL(EVP_DecryptInit_ex(key->evp_cipher_ctx, EVP_aes_256_cbc(), NULL, in->data, NULL), S2N_ERR_KEY_INIT);
+    /* Padding must be disabled after key init to take effect. */
+    EVP_CIPHER_CTX_set_padding(key->evp_cipher_ctx, 0);
 
     return S2N_RESULT_OK;
 }
@@ -94,8 +96,9 @@ S2N_RESULT s2n_cbc_cipher_aes256_set_encryption_key(struct s2n_session_key *key,
 {
     RESULT_ENSURE_EQ(in->size, 256 / 8);
 
-    EVP_CIPHER_CTX_set_padding(key->evp_cipher_ctx, 0);
     RESULT_GUARD_OSSL(EVP_EncryptInit_ex(key->evp_cipher_ctx, EVP_aes_256_cbc(), NULL, in->data, NULL), S2N_ERR_KEY_INIT);
+    /* Padding must be disabled after key init to take effect. */
+    EVP_CIPHER_CTX_set_padding(key->evp_cipher_ctx, 0);
 
     return S2N_RESULT_OK;
 }

--- a/crypto/s2n_cbc_cipher_aes.c
+++ b/crypto/s2n_cbc_cipher_aes.c
@@ -51,7 +51,6 @@ int s2n_cbc_cipher_aes_decrypt(struct s2n_session_key *key, struct s2n_blob *iv,
 
     POSIX_GUARD_OSSL(EVP_DecryptInit_ex(key->evp_cipher_ctx, NULL, NULL, NULL, iv->data), S2N_ERR_KEY_INIT);
 
-    /* len is set by EVP_DecryptUpdate and checked post operation. */
     int len = 0;
     POSIX_GUARD_OSSL(EVP_DecryptUpdate(key->evp_cipher_ctx, out->data, &len, in->data, in->size), S2N_ERR_DECRYPT);
     POSIX_ENSURE((int64_t) len == (int64_t) in->size, S2N_ERR_DECRYPT);

--- a/crypto/s2n_composite_cipher_aes_sha.c
+++ b/crypto/s2n_composite_cipher_aes_sha.c
@@ -180,10 +180,10 @@ static int s2n_composite_cipher_aes_sha_decrypt(struct s2n_session_key *key, str
     POSIX_ENSURE_EQ(out->size, in->size);
     POSIX_GUARD_OSSL(EVP_DecryptInit_ex(key->evp_cipher_ctx, NULL, NULL, NULL, iv->data), S2N_ERR_KEY_INIT);
 
-    /* len is set by EVP_DecryptUpdate. It is not checked here but padding is manually removed and therefore
-     * the decryption operation is validated. */
+    /* len is set by EVP_DecryptUpdate and checked post operation. */
     int len = 0;
     POSIX_GUARD_OSSL(EVP_DecryptUpdate(key->evp_cipher_ctx, out->data, &len, in->data, in->size), S2N_ERR_DECRYPT);
+    POSIX_ENSURE((int64_t) len == (int64_t) in->size, S2N_ERR_DECRYPT);
 
     return 0;
 }
@@ -210,8 +210,9 @@ static S2N_RESULT s2n_composite_cipher_aes128_sha_set_encryption_key(struct s2n_
 {
     RESULT_ENSURE_EQ(in->size, 16);
 
+    RESULT_GUARD_OSSL(EVP_EncryptInit_ex(key->evp_cipher_ctx, s2n_evp_aes_128_cbc_hmac_sha1(), NULL, in->data, NULL), S2N_ERR_KEY_INIT);
+    /* Padding must be disabled after key init to take effect. */
     EVP_CIPHER_CTX_set_padding(key->evp_cipher_ctx, 0);
-    EVP_EncryptInit_ex(key->evp_cipher_ctx, s2n_evp_aes_128_cbc_hmac_sha1(), NULL, in->data, NULL);
 
     return S2N_RESULT_OK;
 }
@@ -220,8 +221,9 @@ static S2N_RESULT s2n_composite_cipher_aes128_sha_set_decryption_key(struct s2n_
 {
     RESULT_ENSURE_EQ(in->size, 16);
 
+    RESULT_GUARD_OSSL(EVP_DecryptInit_ex(key->evp_cipher_ctx, s2n_evp_aes_128_cbc_hmac_sha1(), NULL, in->data, NULL), S2N_ERR_KEY_INIT);
+    /* Padding must be disabled after key init to take effect. */
     EVP_CIPHER_CTX_set_padding(key->evp_cipher_ctx, 0);
-    EVP_DecryptInit_ex(key->evp_cipher_ctx, s2n_evp_aes_128_cbc_hmac_sha1(), NULL, in->data, NULL);
 
     return S2N_RESULT_OK;
 }
@@ -230,8 +232,9 @@ static S2N_RESULT s2n_composite_cipher_aes256_sha_set_encryption_key(struct s2n_
 {
     RESULT_ENSURE_EQ(in->size, 32);
 
+    RESULT_GUARD_OSSL(EVP_EncryptInit_ex(key->evp_cipher_ctx, s2n_evp_aes_256_cbc_hmac_sha1(), NULL, in->data, NULL), S2N_ERR_KEY_INIT);
+    /* Padding must be disabled after key init to take effect. */
     EVP_CIPHER_CTX_set_padding(key->evp_cipher_ctx, 0);
-    EVP_EncryptInit_ex(key->evp_cipher_ctx, s2n_evp_aes_256_cbc_hmac_sha1(), NULL, in->data, NULL);
 
     return S2N_RESULT_OK;
 }
@@ -240,8 +243,9 @@ static S2N_RESULT s2n_composite_cipher_aes256_sha_set_decryption_key(struct s2n_
 {
     RESULT_ENSURE_EQ(in->size, 32);
 
+    RESULT_GUARD_OSSL(EVP_DecryptInit_ex(key->evp_cipher_ctx, s2n_evp_aes_256_cbc_hmac_sha1(), NULL, in->data, NULL), S2N_ERR_KEY_INIT);
+    /* Padding must be disabled after key init to take effect. */
     EVP_CIPHER_CTX_set_padding(key->evp_cipher_ctx, 0);
-    EVP_DecryptInit_ex(key->evp_cipher_ctx, s2n_evp_aes_256_cbc_hmac_sha1(), NULL, in->data, NULL);
 
     return S2N_RESULT_OK;
 }
@@ -250,8 +254,9 @@ static S2N_RESULT s2n_composite_cipher_aes128_sha256_set_encryption_key(struct s
 {
     RESULT_ENSURE_EQ(in->size, 16);
 
+    RESULT_GUARD_OSSL(EVP_EncryptInit_ex(key->evp_cipher_ctx, s2n_evp_aes_128_cbc_hmac_sha256(), NULL, in->data, NULL), S2N_ERR_KEY_INIT);
+    /* Padding must be disabled after key init to take effect. */
     EVP_CIPHER_CTX_set_padding(key->evp_cipher_ctx, 0);
-    EVP_EncryptInit_ex(key->evp_cipher_ctx, s2n_evp_aes_128_cbc_hmac_sha256(), NULL, in->data, NULL);
 
     return S2N_RESULT_OK;
 }
@@ -260,8 +265,9 @@ static S2N_RESULT s2n_composite_cipher_aes128_sha256_set_decryption_key(struct s
 {
     RESULT_ENSURE_EQ(in->size, 16);
 
+    RESULT_GUARD_OSSL(EVP_DecryptInit_ex(key->evp_cipher_ctx, s2n_evp_aes_128_cbc_hmac_sha256(), NULL, in->data, NULL), S2N_ERR_KEY_INIT);
+    /* Padding must be disabled after key init to take effect. */
     EVP_CIPHER_CTX_set_padding(key->evp_cipher_ctx, 0);
-    EVP_DecryptInit_ex(key->evp_cipher_ctx, s2n_evp_aes_128_cbc_hmac_sha256(), NULL, in->data, NULL);
 
     return S2N_RESULT_OK;
 }
@@ -270,8 +276,9 @@ static S2N_RESULT s2n_composite_cipher_aes256_sha256_set_encryption_key(struct s
 {
     RESULT_ENSURE_EQ(in->size, 32);
 
+    RESULT_GUARD_OSSL(EVP_EncryptInit_ex(key->evp_cipher_ctx, s2n_evp_aes_256_cbc_hmac_sha256(), NULL, in->data, NULL), S2N_ERR_KEY_INIT);
+    /* Padding must be disabled after key init to take effect. */
     EVP_CIPHER_CTX_set_padding(key->evp_cipher_ctx, 0);
-    EVP_EncryptInit_ex(key->evp_cipher_ctx, s2n_evp_aes_256_cbc_hmac_sha256(), NULL, in->data, NULL);
 
     return S2N_RESULT_OK;
 }
@@ -280,8 +287,9 @@ static S2N_RESULT s2n_composite_cipher_aes256_sha256_set_decryption_key(struct s
 {
     RESULT_ENSURE_EQ(in->size, 32);
 
+    RESULT_GUARD_OSSL(EVP_DecryptInit_ex(key->evp_cipher_ctx, s2n_evp_aes_256_cbc_hmac_sha256(), NULL, in->data, NULL), S2N_ERR_KEY_INIT);
+    /* Padding must be disabled after key init to take effect. */
     EVP_CIPHER_CTX_set_padding(key->evp_cipher_ctx, 0);
-    EVP_DecryptInit_ex(key->evp_cipher_ctx, s2n_evp_aes_256_cbc_hmac_sha256(), NULL, in->data, NULL);
 
     return S2N_RESULT_OK;
 }

--- a/crypto/s2n_composite_cipher_aes_sha.c
+++ b/crypto/s2n_composite_cipher_aes_sha.c
@@ -180,7 +180,6 @@ static int s2n_composite_cipher_aes_sha_decrypt(struct s2n_session_key *key, str
     POSIX_ENSURE_EQ(out->size, in->size);
     POSIX_GUARD_OSSL(EVP_DecryptInit_ex(key->evp_cipher_ctx, NULL, NULL, NULL, iv->data), S2N_ERR_KEY_INIT);
 
-    /* len is set by EVP_DecryptUpdate and checked post operation. */
     int len = 0;
     POSIX_GUARD_OSSL(EVP_DecryptUpdate(key->evp_cipher_ctx, out->data, &len, in->data, in->size), S2N_ERR_DECRYPT);
     POSIX_ENSURE((int64_t) len == (int64_t) in->size, S2N_ERR_DECRYPT);


### PR DESCRIPTION
# Goal

Move disable cipher padding calls until after cipher initialization to avoid clobbering the padding flag, and verify the decrypt output length.

## Why

The 14 CBC/composite set-key functions call `EVP_CIPHER_CTX_set_padding(ctx, 0)` before `EVP_{Encrypt,Decrypt}Init_ex(ctx, cipher, ...)`. Initializing with a non-NULL cipher resets the context flags, clearing `EVP_CIPH_NO_PADDING`, so the call is a no-op and the contexts run with padding enabled.

The decrypt wrappers also ignore the length reported by `EVP_DecryptUpdate`.

## How

- Move `EVP_CIPHER_CTX_set_padding(ctx, 0)` after the key init at all 14 sites. Per-record init passes a NULL cipher and preserves the flag, so setting it once suffices.
- Assert `len == in->size` in the three decrypt wrappers, matching the encrypt wrappers.
- Guard the eight composite `EVP_{Encrypt,Decrypt}Init_ex` calls with `RESULT_GUARD_OSSL`.

## Callouts

- None

## Testing

Full unit suite passes (283/283), including `s2n_cbc_test`, `s2n_aes_test`, `s2n_3des_test`, `s2n_aes_sha_composite_test`, and `s2n_sslv3_test`.

### Related

release summary: s2n-tls now delays disabling cipher padding until after init on CBC and composite cipher suites and now validates decrypt output length

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.