### PR TITLE
fix: initialize s2n_cert fields in s2n_connection_get_peer_cert_chain

### DIFF
--- a/tls/s2n_connection.c
+++ b/tls/s2n_connection.c
@@ -1616,6 +1616,7 @@ int s2n_connection_get_peer_cert_chain(const struct s2n_connection *conn, struct
 
         struct s2n_blob mem = { 0 };
         POSIX_GUARD(s2n_alloc(&mem, sizeof(struct s2n_cert)));
+        POSIX_GUARD(s2n_blob_zero(&mem));
 
         struct s2n_cert *new_node = (struct s2n_cert *) (void *) mem.data;
         POSIX_ENSURE_REF(new_node);
@@ -1626,6 +1627,18 @@ int s2n_connection_get_peer_cert_chain(const struct s2n_connection *conn, struct
 
         POSIX_GUARD(s2n_alloc(&new_node->raw, cert_size));
         POSIX_CHECKED_MEMCPY(new_node->raw.data, cert_data, cert_size);
+
+        /* Populate the cert info for every cert, and the public key and key
+         * type for the leaf cert, matching s2n_cert_chain_and_key_load() */
+        POSIX_GUARD_RESULT(s2n_openssl_x509_get_cert_info(cert, &new_node->info));
+
+        if (cert_idx == 0) {
+            DEFER_CLEANUP(struct s2n_pkey public_key = { 0 }, s2n_pkey_free);
+            s2n_pkey_type pkey_type = S2N_PKEY_TYPE_UNKNOWN;
+            POSIX_GUARD_RESULT(s2n_pkey_from_x509(cert, &public_key, &pkey_type));
+            POSIX_ENSURE(pkey_type != S2N_PKEY_TYPE_UNKNOWN, S2N_ERR_CERT_TYPE_UNSUPPORTED);
+            POSIX_GUARD(s2n_cert_set_cert_type(new_node, pkey_type));
+        }
     }
 
     ZERO_TO_DISABLE_DEFER_CLEANUP(cert_chain);


### PR DESCRIPTION
# Goal

Ensure `s2n_connection_get_peer_cert_chain()` returns fully-initialized `s2n_cert` nodes.

## Why

The function allocated each `s2n_cert` node with `s2n_alloc` (which does not zero memory) and only set the `raw` and `next` fields. The `pkey_type`, `public_key`, and `info` fields were left as uninitialized heap bytes. Callers reading those fields (e.g. via `s2n_cert_chain_and_key_get_pkey_type()`) could leak heap residue or act on a garbage key type. The correct pattern was already used in `s2n_create_cert_chain_from_stuffer()`.

## How

- Zero each node after allocation with `s2n_blob_zero()`, so all fields have a defined value.
- Populate `info` for every cert, and `pkey_type`/`public_key` for the leaf cert, from the parsed X509, mirroring `s2n_cert_chain_and_key_load()`.

## Callouts

An unknown leaf key type now fails with `S2N_ERR_CERT_TYPE_UNSUPPORTED`, matching `s2n_cert_chain_and_key_load()`.

## Testing

Existing `s2n_certificate_test` (covers `s2n_connection_get_peer_cert_chain` success/failure paths) and `s2n_cert_validation_callback_test` pass.


### Related
<!-- E.g. "resolves #3456" -->

<!-- for significant features includes a release summary -->
<!-- The release summary must be a single line that starts with "release summary" -->
<!-- release summary: s2n-tls users can now dance the tango -->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
