### PR TITLE
fix: enforce JA4 list limit when building fingerprint

### DIFF
--- a/tests/unit/s2n_fingerprint_ja4_test.c
+++ b/tests/unit/s2n_fingerprint_ja4_test.c
@@ -635,6 +635,51 @@ int main(int argc, char **argv)
             };
         };
 
+        /* Only the first S2N_JA4_LIST_LIMIT (99) ciphers and extensions are
+         * collected into the sorted list. Lists longer than the limit therefore
+         * produce the same hash as a list of exactly the limit, since the helpers
+         * generate a deterministic sequence and the extra entries are not included.
+         */
+        {
+            const uint16_t counts_over_limit[] = { 99, 100, 255 };
+
+            /* Ciphers */
+            {
+                uint8_t limit_hash[S2N_TEST_OUTPUT_SIZE] = { 0 };
+                uint32_t limit_hash_size = 0;
+                EXPECT_OK(s2n_test_ja4_hash_from_cipher_count(99,
+                        sizeof(limit_hash), limit_hash, &limit_hash_size));
+
+                for (size_t i = 0; i < s2n_array_len(counts_over_limit); i++) {
+                    uint8_t hash[S2N_TEST_OUTPUT_SIZE] = { 0 };
+                    uint32_t hash_size = 0;
+                    EXPECT_OK(s2n_test_ja4_hash_from_cipher_count(counts_over_limit[i],
+                            sizeof(hash), hash, &hash_size));
+
+                    EXPECT_EQUAL(hash_size, limit_hash_size);
+                    EXPECT_BYTEARRAY_EQUAL(hash, limit_hash, limit_hash_size);
+                }
+            };
+
+            /* Extensions */
+            {
+                uint8_t limit_hash[S2N_TEST_OUTPUT_SIZE] = { 0 };
+                uint32_t limit_hash_size = 0;
+                EXPECT_OK(s2n_test_ja4_hash_from_extension_count(99,
+                        sizeof(limit_hash), limit_hash, &limit_hash_size));
+
+                for (size_t i = 0; i < s2n_array_len(counts_over_limit); i++) {
+                    uint8_t hash[S2N_TEST_OUTPUT_SIZE] = { 0 };
+                    uint32_t hash_size = 0;
+                    EXPECT_OK(s2n_test_ja4_hash_from_extension_count(counts_over_limit[i],
+                            sizeof(hash), hash, &hash_size));
+
+                    EXPECT_EQUAL(hash_size, limit_hash_size);
+                    EXPECT_BYTEARRAY_EQUAL(hash, limit_hash, limit_hash_size);
+                }
+            };
+        };
+
         /* Test ALPN */
         {
             /* Test basic ALPN

--- a/tls/s2n_fingerprint_ja4.c
+++ b/tls/s2n_fingerprint_ja4.c
@@ -362,6 +362,7 @@ static S2N_RESULT s2n_fingerprint_ja4_ciphers(struct s2n_fingerprint_hash *hash,
     RESULT_GUARD_POSIX(s2n_stuffer_init_written(&cipher_suites, &ch->cipher_suites));
 
     DEFER_CLEANUP(struct s2n_stuffer *iana_list = sort_space, s2n_stuffer_wipe_pointer);
+    size_t written_count = 0;
     while (s2n_stuffer_data_available(&cipher_suites)) {
         uint16_t iana = 0;
         RESULT_GUARD_POSIX(s2n_stuffer_read_uint16(&cipher_suites, &iana));
@@ -372,6 +373,14 @@ static S2N_RESULT s2n_fingerprint_ja4_ciphers(struct s2n_fingerprint_hash *hash,
         if (s2n_fingerprint_is_grease_value(iana)) {
             continue;
         }
+        /* The count is capped at 99 (see s2n_fingerprint_ja4_count), so there
+         * is no need to collect more than S2N_JA4_LIST_LIMIT entries. This keeps
+         * the workspace within its pre-sized bounds.
+         */
+        if (written_count >= S2N_JA4_LIST_LIMIT) {
+            continue;
+        }
+        written_count++;
         RESULT_GUARD(s2n_stuffer_write_uint16_hex(iana_list, iana));
         RESULT_GUARD_POSIX(s2n_stuffer_write_char(iana_list, S2N_JA4_LIST_DIV));
     }
@@ -426,6 +435,7 @@ static S2N_RESULT s2n_fingerprint_ja4_extensions(struct s2n_fingerprint_hash *ha
     RESULT_GUARD_POSIX(s2n_stuffer_init_written(&extensions, &ch->extensions.raw));
 
     DEFER_CLEANUP(struct s2n_stuffer *iana_list = sort_space, s2n_stuffer_wipe_pointer);
+    size_t written_count = 0;
     while (s2n_stuffer_data_available(&extensions)) {
         uint16_t iana = 0;
         RESULT_GUARD(s2n_fingerprint_parse_extension(&extensions, &iana));
@@ -451,6 +461,15 @@ static S2N_RESULT s2n_fingerprint_ja4_extensions(struct s2n_fingerprint_hash *ha
         if (iana == TLS_EXTENSION_SERVER_NAME || iana == S2N_EXTENSION_ALPN) {
             continue;
         }
+        /* The count is capped at 99 (see s2n_fingerprint_ja4_count), so there
+         * is no need to collect more than S2N_JA4_LIST_LIMIT entries. This keeps
+         * the workspace within its pre-sized bounds. extensions_count is still
+         * incremented above for every extension.
+         */
+        if (written_count >= S2N_JA4_LIST_LIMIT) {
+            continue;
+        }
+        written_count++;
         RESULT_GUARD(s2n_stuffer_write_uint16_hex(iana_list, iana));
         RESULT_GUARD_POSIX(s2n_stuffer_write_char(iana_list, S2N_JA4_LIST_DIV));
     }


### PR DESCRIPTION
# Goal
<!-- What is the PR doing? -->
Enforce `S2N_JA4_LIST_LIMIT` when collecting cipher and extension IDs into the JA4 fingerprint workspace.

## Why
<!-- Why is this PR necessary? -->
The JA4 code sized its workspace for 99 entries (the max the format's 2-digit count can represent), but never enforced that cap while reading the ClientHello. Since the cipher and extension list lengths are client-controlled, an unusually large ClientHello could grow the workspace far beyond its intended size and inflate the cost of the sort applied to it.

## How
<!-- How is this PR accomplishing its goals? -->
Both the cipher and extension collection loops now stop writing to the workspace once `S2N_JA4_LIST_LIMIT` entries have been collected. The reported count is unaffected, since it is already capped at 99 by `s2n_fingerprint_ja4_count`.

## Callouts
<!-- Any specific item to callout? Non-optimal choices, future actions needed, etc -->
- Collection is capped rather than failed, to preserve the spec-defined behavior of reporting "99" for lists longer than 99 (existing tests cover counts of 100 and 255).
- For a list longer than 99, the JA4_b/JA4_c hash is computed over the first 99 entries. The spec does not define a canonical hash for this case, so this is acceptable.

## Testing
<!-- How is it tested? -->
Existing `s2n_fingerprint_ja4_test` suite passes


### Related
<!-- E.g. "resolves #3456" -->

<!-- for significant features includes a release summary -->
<!-- The release summary must be a single line that starts with "release summary" -->
<!-- release summary: s2n-tls users can now dance the tango -->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
