### PR TITLE
fix: zero-initialize s2n_tls13_keys in PSK binder functions

### DIFF
--- a/tls/s2n_psk.c
+++ b/tls/s2n_psk.c
@@ -421,7 +421,7 @@ int s2n_psk_calculate_binder(struct s2n_psk *psk, const struct s2n_blob *binder_
     POSIX_ENSURE_REF(binder_hash);
     POSIX_ENSURE_REF(output_binder);
 
-    DEFER_CLEANUP(struct s2n_tls13_keys psk_keys, s2n_tls13_keys_free);
+    DEFER_CLEANUP(struct s2n_tls13_keys psk_keys = { 0 }, s2n_tls13_keys_free);
     POSIX_GUARD(s2n_tls13_keys_init(&psk_keys, psk->hmac_alg));
     POSIX_ENSURE_EQ(binder_hash->size, psk_keys.size);
     POSIX_ENSURE_EQ(output_binder->size, psk_keys.size);
@@ -447,7 +447,7 @@ int s2n_psk_verify_binder(struct s2n_connection *conn, struct s2n_psk *psk,
     POSIX_ENSURE_REF(psk);
     POSIX_ENSURE_REF(binder_to_verify);
 
-    DEFER_CLEANUP(struct s2n_tls13_keys psk_keys, s2n_tls13_keys_free);
+    DEFER_CLEANUP(struct s2n_tls13_keys psk_keys = { 0 }, s2n_tls13_keys_free);
     POSIX_GUARD(s2n_tls13_keys_init(&psk_keys, psk->hmac_alg));
     POSIX_ENSURE_EQ(binder_to_verify->size, psk_keys.size);
 


### PR DESCRIPTION
# Goal
Zero-initialize the `s2n_tls13_keys` stack variables in `s2n_psk_calculate_binder` and `s2n_psk_verify_binder`.

## Why
Without `= { 0 }`, a partial-init failure in `s2n_tls13_keys_init` (e.g. an allocation failure in `s2n_hmac_new`) leaves the deferred `s2n_tls13_keys_free` operating on a partially-initialized struct, dereferencing an uninitialized `hash_impl` pointer.

## How
Added `= { 0 }` to both `DEFER_CLEANUP` declarations so cleanup on the error path is safe-by-construction.

## Callouts
Matches the existing `s2n_tls13_connection_keys` safety pattern.

## Testing
Existing tests pass

### Related
<!-- E.g. "resolves #3456" -->

<!-- for significant features includes a release summary -->
<!-- The release summary must be a single line that starts with "release summary" -->
<!-- release summary: s2n-tls users can now dance the tango -->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
