### PR TITLE
fix: set actual_protocol_version_established on deserialized connections

### DIFF
--- a/tests/unit/s2n_connection_serialize_test.c
+++ b/tests/unit/s2n_connection_serialize_test.c
@@ -1298,7 +1298,7 @@ int main(int argc, char **argv)
      *# regardless of the AlertLevel in the message.  Unknown Alert types
      *# MUST be treated as error alerts.
      */
-    {
+    if (s2n_is_tls13_fully_supported()) {
         DEFER_CLEANUP(struct s2n_connection *client_conn = s2n_connection_new(S2N_CLIENT),
                 s2n_connection_ptr_free);
         EXPECT_NOT_NULL(client_conn);

--- a/tests/unit/s2n_connection_serialize_test.c
+++ b/tests/unit/s2n_connection_serialize_test.c
@@ -1288,10 +1288,15 @@ int main(int argc, char **argv)
     };
 
     /* A deserialized TLS1.3 connection treats warning-level alerts as fatal, even
-     * when S2N_ALERT_IGNORE_WARNINGS is configured. TLS1.3 requires all alerts
-     * to be treated as fatal, and that relies on the deserialized connection having
-     * actual_protocol_version_established set. See s2n_process_as_warning() and
-     * RFC 8446 Section 6.
+     * when S2N_ALERT_IGNORE_WARNINGS is configured. This relies on the deserialized
+     * connection having actual_protocol_version_established set so that
+     * s2n_process_as_warning() applies the TLS1.3 alert rules.
+     *
+     *= https://www.rfc-editor.org/rfc/rfc8446#section-6
+     *# All the alerts listed in Section 6.2 MUST be sent with
+     *# AlertLevel=fatal and MUST be treated as error alerts when received
+     *# regardless of the AlertLevel in the message.  Unknown Alert types
+     *# MUST be treated as error alerts.
      */
     {
         DEFER_CLEANUP(struct s2n_connection *client_conn = s2n_connection_new(S2N_CLIENT),

--- a/tests/unit/s2n_connection_serialize_test.c
+++ b/tests/unit/s2n_connection_serialize_test.c
@@ -18,6 +18,7 @@
 #include "crypto/s2n_fips.h"
 #include "s2n_test.h"
 #include "testlib/s2n_testlib.h"
+#include "tls/s2n_alerts.h"
 #include "tls/s2n_config.h"
 #include "tls/s2n_tls.h"
 
@@ -1284,6 +1285,58 @@ int main(int argc, char **argv)
         uint8_t buffer[S2N_SERIALIZED_CONN_TLS12_SIZE] = { 0 };
         EXPECT_FAILURE_WITH_ERRNO(s2n_connection_serialize(server_conn, buffer, sizeof(buffer)),
                 S2N_ERR_INVALID_STATE);
+    };
+
+    /* A deserialized TLS1.3 connection treats warning-level alerts as fatal, even
+     * when S2N_ALERT_IGNORE_WARNINGS is configured. TLS1.3 requires all alerts
+     * to be treated as fatal, and that relies on the deserialized connection having
+     * actual_protocol_version_established set. See s2n_process_as_warning() and
+     * RFC 8446 Section 6.
+     */
+    {
+        DEFER_CLEANUP(struct s2n_connection *client_conn = s2n_connection_new(S2N_CLIENT),
+                s2n_connection_ptr_free);
+        EXPECT_NOT_NULL(client_conn);
+        DEFER_CLEANUP(struct s2n_connection *server_conn = s2n_connection_new(S2N_SERVER),
+                s2n_connection_ptr_free);
+        EXPECT_NOT_NULL(server_conn);
+
+        EXPECT_SUCCESS(s2n_connection_set_config(client_conn, tls13_config));
+        EXPECT_SUCCESS(s2n_connection_set_config(server_conn, tls13_config));
+
+        DEFER_CLEANUP(struct s2n_test_io_stuffer_pair io_pair = { 0 }, s2n_io_stuffer_pair_free);
+        EXPECT_OK(s2n_io_stuffer_pair_init(&io_pair));
+        EXPECT_OK(s2n_connections_set_io_stuffer_pair(client_conn, server_conn, &io_pair));
+
+        EXPECT_SUCCESS(s2n_negotiate_test_server_and_client(server_conn, client_conn));
+        EXPECT_EQUAL(client_conn->actual_protocol_version, S2N_TLS13);
+
+        uint8_t buffer[S2N_SERIALIZED_CONN_TLS12_SIZE] = { 0 };
+        EXPECT_SUCCESS(s2n_connection_serialize(client_conn, buffer, sizeof(buffer)));
+
+        /* Deserialize into a new connection configured to ignore warnings */
+        DEFER_CLEANUP(struct s2n_config *ignore_warnings_config = s2n_config_new(), s2n_config_ptr_free);
+        EXPECT_SUCCESS(s2n_config_set_alert_behavior(ignore_warnings_config, S2N_ALERT_IGNORE_WARNINGS));
+
+        DEFER_CLEANUP(struct s2n_connection *new_client_conn = s2n_connection_new(S2N_CLIENT),
+                s2n_connection_ptr_free);
+        EXPECT_NOT_NULL(new_client_conn);
+        EXPECT_SUCCESS(s2n_connection_set_config(new_client_conn, ignore_warnings_config));
+        EXPECT_SUCCESS(s2n_connection_deserialize(new_client_conn, buffer, sizeof(buffer)));
+
+        /* The deserialized connection must know its protocol version is established */
+        EXPECT_TRUE(new_client_conn->actual_protocol_version_established);
+
+        /* A warning-level alert must be treated as fatal on the deserialized TLS1.3
+         * connection, not silently ignored. */
+        const uint8_t warning_alert[] = {
+            1 /* AlertLevel = warning */,
+            70 /* AlertDescription = protocol_version (arbitrary value) */
+        };
+        EXPECT_SUCCESS(s2n_stuffer_write_bytes(&new_client_conn->in, warning_alert, sizeof(warning_alert)));
+
+        EXPECT_FAILURE_WITH_ERRNO(s2n_process_alert_fragment(new_client_conn), S2N_ERR_ALERT);
+        EXPECT_TRUE(s2n_connection_check_io_status(new_client_conn, S2N_IO_CLOSED));
     };
 
     END_TEST();

--- a/tls/s2n_connection_serialize.c
+++ b/tls/s2n_connection_serialize.c
@@ -435,6 +435,10 @@ int s2n_connection_deserialize(struct s2n_connection *conn, uint8_t *buffer, uin
 
     /* Rehydrate fields now that parsing has completed successfully */
     conn->actual_protocol_version = parsed_values.protocol_version;
+    /* The deserialized connection has a fully negotiated, known protocol version.
+     * Mark it as established so that protocol-version-dependent logic (such as the
+     * TLS1.3 alert handling rules in s2n_process_as_warning) is enforced correctly. */
+    conn->actual_protocol_version_established = 1;
     conn->secure->cipher_suite = parsed_values.cipher_suite;
     POSIX_GUARD_RESULT(s2n_connection_set_max_fragment_length(conn, parsed_values.max_fragment_len));
 


### PR DESCRIPTION
# Goal

Ensure deserialized TLS 1.3 connections enforce the RFC 8446 rule that all alerts are treated as fatal, regardless of the alert level field.

## Why

`s2n_connection_deserialize` restored `conn->actual_protocol_version` but never set `conn->actual_protocol_version_established`. As a result, `s2n_process_as_warning` fell through to the pre-TLS1.3 code path, and a deserialized TLS 1.3 connection configured with `S2N_ALERT_IGNORE_WARNINGS` would silently ignore warning-level alerts that TLS 1.3 requires to be treated as fatal (e.g. a `bad_record_mac`). This could mask error conditions or active attacks from a malicious peer.

## How

Set `conn->actual_protocol_version_established = 1` in `s2n_connection_deserialize` right after restoring the protocol version. A deserialized connection has a fully negotiated, known protocol version, so the flag should reflect that. This restores correct TLS 1.3 alert handling (and the record-layer version checks that read the same flag).

## Testing

Added a test in `s2n_connection_serialize_test.c` that negotiates a real TLS 1.3 connection, serializes and deserializes it into a connection configured with `S2N_ALERT_IGNORE_WARNINGS`, then feeds a warning-level alert and asserts it is treated as fatal (`S2N_ERR_ALERT` and the connection is closed). Verified the test fails without the fix and passes with it.


### Related
<!-- E.g. "resolves #3456" -->

<!-- for significant features includes a release summary -->
<!-- The release summary must be a single line that starts with "release summary" -->
<!-- release summary: s2n-tls users can now dance the tango -->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
