### PR TITLE
chore: bump metrics subscriber for release

### DIFF
--- a/bindings/rust/standard/integration/Cargo.toml
+++ b/bindings/rust/standard/integration/Cargo.toml
@@ -56,7 +56,7 @@ serde_json = "1"
 # s2n_tls_extension_type enum (u32 vs i32), so it can't compile on Windows.
 [target.'cfg(not(target_os = "windows"))'.dev-dependencies]
 # This should be the latest version of metrics subscriber available on crates.io
-old-metrics-subscriber = { package = "s2n-tls-metrics-subscriber", version = "0.0.3" }
+old-metrics-subscriber = { package = "s2n-tls-metrics-subscriber", version = "0.0.5" }
 
 # NOTE: BoringSSL is disabled on macOS to avoid symbol collisions with
 # OpenSSL (see https://github.com/aws/s2n-tls/pull/5659), and on Windows because BoringSSL can't be built under the MSYS2/MinGW toolchain.

--- a/bindings/rust/standard/integration/tests/metrics_stability.rs
+++ b/bindings/rust/standard/integration/tests/metrics_stability.rs
@@ -36,7 +36,7 @@ impl VecSink {
 }
 
 impl TelemetrySink for VecSink {
-    fn export_record(&self, record: &MetricRecord) {
+    fn export_record(&self, record: MetricRecord) {
         self.records.lock().unwrap().push(record.clone());
     }
 }
@@ -74,7 +74,7 @@ fn old_event_subscriber_builds() {
     let handshake = &json["handshake"];
 
     // One successful handshake was recorded
-    assert_eq!(handshake["handshake_count"], 1);
+    assert_eq!(handshake["handshake_success_count"], 1);
     assert_eq!(handshake["synthetic_traffic_count"], 0);
 
     // Negotiated parameters: exactly one of each was counted

--- a/bindings/rust/standard/s2n-tls-metrics-subscriber/Cargo.toml
+++ b/bindings/rust/standard/s2n-tls-metrics-subscriber/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "s2n-tls-metrics-subscriber"
-version = "0.0.5"
+version = "0.0.6"
 edition = "2024"
 description = "Telemetry provider for s2n-tls"
 authors = ["AWS s2n"]


### PR DESCRIPTION
# Goal
Bump metrics subscriber for release.

## Why
Release the jitter fixes and the "drop on flush" behavior.

## How
bump

## Callouts
There hasn't been any change in the metrics schema, so that doesn't need to be updated.

## Testing
CI should pass.

Note that I also updated the pseudo-stability test.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
