### PR TITLE
fix: prevent s2n_alloc from overwriting allocated blobs

### DIFF
--- a/tests/unit/s2n_mem_test.c
+++ b/tests/unit/s2n_mem_test.c
@@ -141,5 +141,43 @@ int main(int argc, char **argv)
         EXPECT_OK(s2n_mem_override_callbacks(mem_init_cb, mem_cleanup_cb, mem_malloc_cb, mem_free_cb));
     };
 
+    /* Test: s2n_alloc rejects blobs with existing allocations */
+    {
+        /* Test: s2n_alloc rejects blob with allocated data */
+        {
+            struct s2n_blob blob = { 0 };
+            EXPECT_SUCCESS(s2n_alloc(&blob, 10));
+            EXPECT_NOT_NULL(blob.data);
+            EXPECT_EQUAL(blob.size, 10);
+            EXPECT_TRUE(blob.allocated > 0);
+
+            /* Attempting to call s2n_alloc again should fail */
+            EXPECT_FAILURE_WITH_ERRNO(s2n_alloc(&blob, 20), S2N_ERR_ALLOC);
+
+            /* Clean up */
+            EXPECT_SUCCESS(s2n_free(&blob));
+        };
+
+        /* Test: s2n_alloc rejects blob with non-zero size but NULL data */
+        {
+            struct s2n_blob blob = { .data = NULL, .size = 10, .allocated = 0 };
+            EXPECT_FAILURE_WITH_ERRNO(s2n_alloc(&blob, 20), S2N_ERR_ALLOC);
+        };
+
+        /* Test: s2n_alloc rejects blob with non-zero allocated but NULL data */
+        {
+            struct s2n_blob blob = { .data = NULL, .size = 0, .allocated = 10 };
+            EXPECT_FAILURE_WITH_ERRNO(s2n_alloc(&blob, 20), S2N_ERR_ALLOC);
+        };
+
+        /* Test: s2n_alloc accepts properly zero-initialized blob */
+        {
+            struct s2n_blob blob = { 0 };
+            EXPECT_SUCCESS(s2n_alloc(&blob, 10));
+            EXPECT_NOT_NULL(blob.data);
+            EXPECT_SUCCESS(s2n_free(&blob));
+        };
+    };
+
     END_TEST();
 }

--- a/tests/unit/s2n_tls13_hybrid_pq_shared_secret_test.c
+++ b/tests/unit/s2n_tls13_hybrid_pq_shared_secret_test.c
@@ -422,7 +422,7 @@ static int read_priv_ecc(EVP_PKEY **pkey, const char *priv_ecc)
      * input buffer. */
 
     DEFER_CLEANUP(struct s2n_blob priv_ecc_blob = { 0 }, s2n_free);
-    POSIX_GUARD(s2n_alloc(&priv_ecc_blob, key_len));
+    POSIX_GUARD(s2n_realloc(&priv_ecc_blob, key_len));
     for (size_t i = 0; i < key_len; i++) {
         priv_ecc_blob.data[i] = priv_ecc[i];
     }
@@ -470,7 +470,7 @@ static int set_up_conns(struct s2n_connection *client_conn, struct s2n_connectio
     /* Populate the client's PQ private key with something - it doesn't have to be a
      * legitimate private key since it doesn't get used in the shared secret derivation,
      * but we want to make sure its definitely been freed after shared secret calculation */
-    POSIX_GUARD(s2n_alloc(&client_conn->kex_params.client_kem_group_params.kem_params.private_key, 2));
+    POSIX_GUARD(s2n_realloc(&client_conn->kex_params.client_kem_group_params.kem_params.private_key, 2));
     struct s2n_stuffer private_key_stuffer = { 0 };
     POSIX_GUARD(s2n_stuffer_init(&private_key_stuffer,
             &client_conn->kex_params.client_kem_group_params.kem_params.private_key));

--- a/tls/s2n_ktls_io.c
+++ b/tls/s2n_ktls_io.c
@@ -329,7 +329,7 @@ static S2N_RESULT s2n_ktls_update_bufs_with_offset(const struct iovec **bufs, si
     /* If possible, use the existing stack memory in `mem` for the copy.
      * Otherwise, we need to allocate sufficient new heap memory. */
     if (size > mem->size) {
-        RESULT_GUARD_POSIX(s2n_alloc(mem, size));
+        RESULT_GUARD_POSIX(s2n_realloc(mem, size));
     }
 
     struct iovec *new_bufs = (struct iovec *) (void *) mem->data;

--- a/tls/s2n_quic_support.c
+++ b/tls/s2n_quic_support.c
@@ -66,8 +66,7 @@ int s2n_connection_set_quic_transport_parameters(struct s2n_connection *conn,
 {
     POSIX_ENSURE_REF(conn);
 
-    POSIX_GUARD(s2n_free(&conn->our_quic_transport_parameters));
-    POSIX_GUARD(s2n_alloc(&conn->our_quic_transport_parameters, data_len));
+    POSIX_GUARD(s2n_realloc(&conn->our_quic_transport_parameters, data_len));
     POSIX_CHECKED_MEMCPY(conn->our_quic_transport_parameters.data, data_buffer, data_len);
 
     return S2N_SUCCESS;

--- a/utils/s2n_mem.c
+++ b/utils/s2n_mem.c
@@ -226,6 +226,9 @@ int s2n_alloc(struct s2n_blob *b, uint32_t size)
 {
     POSIX_ENSURE(initialized, S2N_ERR_NOT_INITIALIZED);
     POSIX_ENSURE_REF(b);
+    POSIX_ENSURE(b->data == NULL, S2N_ERR_ALLOC);
+    POSIX_ENSURE(b->size == 0, S2N_ERR_ALLOC);
+    POSIX_ENSURE(b->allocated == 0, S2N_ERR_ALLOC);
     const struct s2n_blob temp = { 0 };
     *b = temp;
     POSIX_GUARD(s2n_realloc(b, size));


### PR DESCRIPTION
This fix addresses issue #3702 by preventing s2n_alloc() from silently discarding existing allocations.

## Problem
s2n_alloc() would silently discard any existing allocation in the blob, leading to memory leaks.

## Solution
Added POSIX_ENSURE checks in s2n_alloc() to validate that the blob is properly zero-initialized (data == NULL, size == 0, allocated == 0) before proceeding with allocation.

## Changes
- Added validation checks in s2n_alloc()
- Fixed call sites in s2n_quic_support.c and s2n_ktls_io.c to use s2n_realloc()
- Updated test cases to use s2n_realloc() where appropriate
- Added regression tests to verify the fix

## Testing
- Added comprehensive regression tests in s2n_mem_test.c
- Verified that s2n_alloc() now properly rejects non-zero-initialized blobs
- All existing s2n_alloc() call sites were audited and fixed where necessary

Fixes #3702