### PR TITLE
fix: resolve Clang 18 strict warning errors

### DIFF
--- a/.github/workflows/ci_linting.yml
+++ b/.github/workflows/ci_linting.yml
@@ -117,6 +117,33 @@ jobs:
         with:
           clang-format-version: '18'
           include-regex: '^(\.\/)?(api|bin|crypto|stuffer|error|tls|utils|tests\/unit|tests\/testlib|docs\/examples).*\.(c|h)$'
+
+  clang-18-strict-warnings:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Setup
+        run: source ./codebuild/bin/s2n_setup_env.sh
+
+      - name: Install Clang 18
+        run: |
+          sudo add-apt-repository -y universe
+          sudo apt-get update
+          sudo apt-get install -y clang-18
+
+      - name: Install dependencies
+        run: source ./codebuild/bin/install_default_dependencies.sh
+
+      - name: Build with Clang 18 strict warnings
+        run: |
+          export CC=clang-18
+          export CXX=clang++-18
+          cmake . -Bbuild -DCMAKE_C_COMPILER=clang-18 -DCMAKE_CXX_COMPILER=clang++-18 \
+            -DCMAKE_C_FLAGS="-Werror -Wdocumentation -Wshorten-64-to-32" \
+            -DCMAKE_CXX_FLAGS="-Werror -Wdocumentation -Wshorten-64-to-32"
+          cmake --build build
+
   nixflake:
     # The nix develop changes contain broken nixpkg dependenecies; the allow/impure flags workaround this.
     runs-on: ubuntu-latest

--- a/.github/workflows/ci_linting.yml
+++ b/.github/workflows/ci_linting.yml
@@ -138,10 +138,8 @@ jobs:
       - name: Build with Clang 18 strict warnings
         run: |
           export CC=clang-18
-          export CXX=clang++-18
-          cmake . -Bbuild -DCMAKE_C_COMPILER=clang-18 -DCMAKE_CXX_COMPILER=clang++-18 \
-            -DCMAKE_C_FLAGS="-Werror -Wdocumentation -Wshorten-64-to-32" \
-            -DCMAKE_CXX_FLAGS="-Werror -Wdocumentation -Wshorten-64-to-32"
+          cmake . -Bbuild -DCMAKE_C_COMPILER=clang-18 \
+            -DCMAKE_C_FLAGS="-Werror -Wdocumentation -Wshorten-64-to-32"
           cmake --build build
 
   nixflake:

--- a/api/s2n.h
+++ b/api/s2n.h
@@ -243,7 +243,7 @@ S2N_API extern int s2n_init(void);
  *
  * @returns S2N_SUCCESS on success. S2N_FAILURE on failure
  */
-S2N_API extern int s2n_cleanup(void);
+S2N_API extern int s2n_cleanup(void) __attribute__((deprecated));
 
 /**
  * Performs a complete deinitialization and cleanup of the s2n-tls library.
@@ -324,7 +324,7 @@ S2N_API extern int s2n_config_free_dhparams(struct s2n_config *config);
 /**
  * Frees the certificate chain and key associated with an `s2n_config` object.
  *
- * @param config The configuration object with DH params being freed
+ * @param config The configuration object with certificate chain and key being freed
  * @returns S2N_SUCCESS on success. S2N_FAILURE on failure
  */
 S2N_API extern int s2n_config_free_cert_chain_and_key(struct s2n_config *config);
@@ -333,8 +333,12 @@ S2N_API extern int s2n_config_free_cert_chain_and_key(struct s2n_config *config)
  * Callback function type used to get the system time.
  *
  * The function should return 0 on success and -1 on failure.
+ *
+ * @param context Arbitrary context data for the callback
+ * @param nanoseconds Pointer to store the current time in nanoseconds
+ * @returns 0 on success, -1 on failure
  */
-typedef int (*s2n_clock_time_nanoseconds)(void *, uint64_t *);
+typedef int (*s2n_clock_time_nanoseconds)(void *context, uint64_t *nanoseconds);
 
 /**
  * Cache callback function that allows the caller to retrieve SSL session data
@@ -807,7 +811,7 @@ S2N_API extern int s2n_config_set_cert_tiebreak_callback(struct s2n_config *conf
  * @param private_key_pem A byte array of a PEM encoded key.
  * @returns S2N_SUCCESS on success. S2N_FAILURE on failure.
  */
-S2N_API extern int s2n_config_add_cert_chain_and_key(struct s2n_config *config, const char *cert_chain_pem, const char *private_key_pem);
+S2N_API extern int s2n_config_add_cert_chain_and_key(struct s2n_config *config, const char *cert_chain_pem, const char *private_key_pem) __attribute__((deprecated));
 
 /**
  * The preferred method of associating a certificate chain and private key pair with an `s2n_config` object.
@@ -1234,7 +1238,7 @@ S2N_API extern int s2n_config_set_alert_behavior(struct s2n_config *config, s2n_
  * @param data Data for the extension
  * @param length Length of the `data` buffer
  */
-S2N_API extern int s2n_config_set_extension_data(struct s2n_config *config, s2n_tls_extension_type type, const uint8_t *data, uint32_t length);
+S2N_API extern int s2n_config_set_extension_data(struct s2n_config *config, s2n_tls_extension_type type, const uint8_t *data, uint32_t length) __attribute__((deprecated));
 
 /**
  * Allows the caller to set a TLS Maximum Fragment Length extension that will be used
@@ -2515,7 +2519,7 @@ S2N_API extern int s2n_connection_set_client_auth_type(struct s2n_connection *co
  * prepended by a 3 byte network-endian length value. Note that this format is used regardless of the connection's
  * protocol version.
  *
- * @warning The buffer pointed to by `cert_chain_out` shares its lifetime with the s2n_connection object.
+ * @warning The buffer pointed to by `der_cert_chain_out` shares its lifetime with the s2n_connection object.
  *
  * @param conn A pointer to the s2n_connection object
  * @param der_cert_chain_out A pointer that's set to the client certificate chain.
@@ -3208,10 +3212,10 @@ typedef int (*s2n_psk_selection_callback)(struct s2n_connection *conn, void *con
  * server PSK.
  * 
  * @param config A pointer to the s2n_config object.
- * @param cb The function that should be called when the callback is triggered.
+ * @param psk_selection_callback The function that should be called when the callback is triggered.
  * @param context A pointer to a context for the caller to pass state to the callback, if needed.
  */
-S2N_API int s2n_config_set_psk_selection_callback(struct s2n_config *config, s2n_psk_selection_callback cb, void *context);
+S2N_API int s2n_config_set_psk_selection_callback(struct s2n_config *config, s2n_psk_selection_callback psk_selection_callback, void *context);
 
 /**
  * Get the number of bytes the connection has received.
@@ -3428,7 +3432,7 @@ S2N_API extern int s2n_connection_is_valid_for_cipher_preferences(struct s2n_con
  * @param conn A pointer to the s2n connection
  * @returns A string indicating the elliptic curve used during ECDHE key exchange. The string "NONE" is returned if no curve was used.
  */
-S2N_API extern const char *s2n_connection_get_curve(struct s2n_connection *conn);
+S2N_API extern const char *s2n_connection_get_curve(struct s2n_connection *conn) __attribute__((deprecated));
 
 /**
  * Function to get the human readable KEM name for the connection.
@@ -3440,7 +3444,7 @@ S2N_API extern const char *s2n_connection_get_curve(struct s2n_connection *conn)
  * @param conn A pointer to the s2n connection
  * @returns A human readable string for the KEM group. If there is no KEM configured returns "NONE"
  */
-S2N_API extern const char *s2n_connection_get_kem_name(struct s2n_connection *conn);
+S2N_API extern const char *s2n_connection_get_kem_name(struct s2n_connection *conn) __attribute__((deprecated));
 
 /**
  * Function to get the human readable KEM group name for the connection.

--- a/api/s2n.h
+++ b/api/s2n.h
@@ -579,26 +579,26 @@ S2N_API extern int s2n_mem_set_callbacks(s2n_mem_init_callback mem_init_callback
 /**
  * @deprecated No longer used. See `s2n_rand_set_callbacks`.
  */
-typedef int (*s2n_rand_init_callback)(void);
+typedef int (*s2n_rand_init_callback)(void) __attribute__((deprecated));
 
 /**
  * @deprecated No longer used. See `s2n_rand_set_callbacks`.
  */
-typedef int (*s2n_rand_cleanup_callback)(void);
+typedef int (*s2n_rand_cleanup_callback)(void) __attribute__((deprecated));
 
 /**
  * @deprecated No longer used. See `s2n_rand_set_callbacks`.
  */
-typedef int (*s2n_rand_seed_callback)(void *data, uint32_t size);
+typedef int (*s2n_rand_seed_callback)(void *data, uint32_t size) __attribute__((deprecated));
 
 /**
  * @deprecated No longer used. See `s2n_rand_set_callbacks`.
  */
-typedef int (*s2n_rand_mix_callback)(void *data, uint32_t size);
+typedef int (*s2n_rand_mix_callback)(void *data, uint32_t size) __attribute__((deprecated));
 
 /**
  * Allows the caller to override s2n-tls's entropy functions.
- * 
+ *
  * @deprecated Custom random callbacks are no longer supported. Randomness is
  * now delegated directly to libcrypto or /dev/urandom. This function is a
  * no-op kept for backwards compatibility.
@@ -610,7 +610,7 @@ typedef int (*s2n_rand_mix_callback)(void *data, uint32_t size);
  * @returns S2N_SUCCESS on success. S2N_FAILURE on failure
  */
 S2N_API extern int s2n_rand_set_callbacks(s2n_rand_init_callback rand_init_callback, s2n_rand_cleanup_callback rand_cleanup_callback,
-        s2n_rand_seed_callback rand_seed_callback, s2n_rand_mix_callback rand_mix_callback);
+        s2n_rand_seed_callback rand_seed_callback, s2n_rand_mix_callback rand_mix_callback) __attribute__((deprecated));
 
 /**
  * TLS extensions supported by s2n-tls

--- a/api/unstable/cleanup.h
+++ b/api/unstable/cleanup.h
@@ -27,7 +27,7 @@ extern "C" {
  *
  * @returns S2N_SUCCESS on success. S2N_FAILURE on failure
  */
-S2N_API extern int s2n_cleanup_thread(void);
+S2N_API extern int s2n_cleanup_thread(void) __attribute__((deprecated));
 
 #ifdef __cplusplus
 }

--- a/api/unstable/crl.h
+++ b/api/unstable/crl.h
@@ -55,7 +55,7 @@ typedef int (*s2n_crl_lookup_callback)(struct s2n_crl_lookup *lookup, void *cont
  * Set a callback to provide CRLs to use for CRL validation.
  *
  * @param config A pointer to the connection config
- * @param s2n_crl_lookup_callback The function to be called for each received certificate.
+ * @param callback The function to be called for each received certificate.
  * @param context Context to be passed to the callback function.
  * @return S2N_SUCCESS on success, S2N_FAILURE on failure
  */

--- a/crypto/s2n_certificate.c
+++ b/crypto/s2n_certificate.c
@@ -145,7 +145,7 @@ int s2n_cert_chain_and_key_set_private_key(struct s2n_cert_chain_and_key *cert_a
 
     /* Put the private key pem in a stuffer */
     POSIX_GUARD(s2n_stuffer_alloc_ro_from_string(&key_in_stuffer, private_key_pem));
-    POSIX_GUARD(s2n_stuffer_growable_alloc(&key_out_stuffer, strlen(private_key_pem)));
+    POSIX_GUARD(s2n_stuffer_growable_alloc(&key_out_stuffer, (uint32_t) strlen(private_key_pem)));
 
     POSIX_GUARD(s2n_cert_chain_and_key_set_private_key_from_stuffer(cert_and_key, &key_in_stuffer, &key_out_stuffer));
 
@@ -240,12 +240,13 @@ int s2n_cert_chain_and_key_load_sans(struct s2n_cert_chain_and_key *chain_and_ke
                 POSIX_BAIL(S2N_ERR_NULL_SANS);
             }
 
-            if (s2n_alloc(san_blob, san_str_len)) {
+            POSIX_ENSURE_LTE(san_str_len, UINT32_MAX);
+            if (s2n_alloc(san_blob, (uint32_t) san_str_len)) {
                 S2N_ERROR_PRESERVE_ERRNO();
             }
 
             POSIX_CHECKED_MEMCPY(san_blob->data, san_str, san_str_len);
-            san_blob->size = san_str_len;
+            san_blob->size = (uint32_t) san_str_len;
             /* normalize san_blob to lowercase */
             POSIX_GUARD(s2n_blob_char_to_lower(san_blob));
         }
@@ -780,9 +781,8 @@ static int s2n_parse_x509_extension(struct s2n_cert *cert, const uint8_t *oid,
      * X509_get_ext_count returns the number of extensions in the x509 certificate.
      * Ref: https://www.openssl.org/docs/man1.1.0/man3/X509_get_ext_count.html.
      */
-    int ext_count_value = X509_get_ext_count(x509_cert);
-    POSIX_ENSURE_GT(ext_count_value, 0);
-    size_t ext_count = (size_t) ext_count_value;
+    int ext_count = X509_get_ext_count(x509_cert);
+    POSIX_ENSURE_GT(ext_count, 0);
 
     /* OBJ_txt2obj() converts the input text string into an ASN1_OBJECT structure.
      * If no_name is 0 then long names and short names will be interpreted as well as numerical forms.
@@ -792,7 +792,7 @@ static int s2n_parse_x509_extension(struct s2n_cert *cert, const uint8_t *oid,
     DEFER_CLEANUP(ASN1_OBJECT *asn1_obj_in = OBJ_txt2obj((const char *) oid, 0), s2n_asn1_obj_free);
     POSIX_ENSURE_REF(asn1_obj_in);
 
-    for (size_t loc = 0; loc < ext_count; loc++) {
+    for (int loc = 0; loc < ext_count; loc++) {
         ASN1_OCTET_STRING *asn1_str = NULL;
         bool match_found = false;
 

--- a/crypto/s2n_ecc_evp.c
+++ b/crypto/s2n_ecc_evp.c
@@ -257,7 +257,8 @@ static int s2n_ecc_evp_compute_shared_secret(EVP_PKEY *own_key, EVP_PKEY *peer_p
     POSIX_GUARD_OSSL(EVP_PKEY_derive_init(ctx), S2N_ERR_ECDHE_SHARED_SECRET);
     POSIX_GUARD_OSSL(EVP_PKEY_derive_set_peer(ctx, peer_public), S2N_ERR_ECDHE_SHARED_SECRET);
     POSIX_GUARD_OSSL(EVP_PKEY_derive(ctx, NULL, &shared_secret_size), S2N_ERR_ECDHE_SHARED_SECRET);
-    POSIX_GUARD(s2n_alloc(shared_secret, shared_secret_size));
+    POSIX_ENSURE_LTE(shared_secret_size, UINT32_MAX);
+    POSIX_GUARD(s2n_alloc(shared_secret, (uint32_t) shared_secret_size));
 
     if (EVP_PKEY_derive(ctx, shared_secret->data, &shared_secret_size) != 1) {
         POSIX_GUARD(s2n_free(shared_secret));
@@ -451,7 +452,8 @@ int s2n_ecc_evp_write_params_point(struct s2n_ecc_evp_params *ecc_evp_params, st
         OPENSSL_free(encoded_point);
         POSIX_BAIL(S2N_ERR_ECDHE_SERIALIZING);
     } else {
-        POSIX_GUARD(s2n_stuffer_write_bytes(out, encoded_point, size));
+        POSIX_ENSURE_LTE(size, UINT32_MAX);
+        POSIX_GUARD(s2n_stuffer_write_bytes(out, encoded_point, (uint32_t) size));
         OPENSSL_free(encoded_point);
     }
 #else

--- a/crypto/s2n_hkdf.c
+++ b/crypto/s2n_hkdf.c
@@ -231,7 +231,8 @@ static S2N_RESULT s2n_hkdf_kdf(struct s2n_hmac_state *hmac, s2n_hmac_algorithm a
         size_t key_size = EVP_KDF_CTX_get_kdf_size(hkdf_ctx);
         RESULT_ENSURE(key_size > 0, S2N_ERR_HKDF_OUTPUT_SIZE);
         RESULT_ENSURE(key_size <= output->size, S2N_ERR_HKDF_OUTPUT_SIZE);
-        output->size = key_size;
+        RESULT_ENSURE_LTE(key_size, UINT32_MAX);
+        output->size = (uint32_t) key_size;
     }
 
     RESULT_GUARD_OSSL(EVP_KDF_derive(hkdf_ctx, output->data, output->size, params),

--- a/crypto/s2n_hmac.c
+++ b/crypto/s2n_hmac.c
@@ -323,7 +323,7 @@ int s2n_hmac_reset(struct s2n_hmac_state *state)
     bytes_in_hash %= state->hash_block_size;
     POSIX_ENSURE(bytes_in_hash <= UINT32_MAX, S2N_ERR_INTEGER_OVERFLOW);
     /* The length of the key is not private, so don't need to do tricky math here */
-    state->currently_in_hash_block = bytes_in_hash;
+    state->currently_in_hash_block = (uint32_t) bytes_in_hash;
     return S2N_SUCCESS;
 }
 


### PR DESCRIPTION
# Goal

Fix Clang 18 compilation errors when building s2n-tls with strict warning flags:

`-Werror -Wdocumentation -Wshorten-64-to-32`

## Why

Clang 18 reports documentation mismatches, deprecated API documentation inconsistencies, and unsafe narrowing conversions that cause builds to fail when warnings are treated as errors.

## How

### `-Wdocumentation`

- Corrected mismatched Doxygen `@param` names in `api/s2n.h`.
- Fixed parameter documentation for:
  - `s2n_config_free_cert_chain_and_key`
  - `s2n_connection_get_client_cert_chain`
  - `s2n_clock_time_nanoseconds`
  - `s2n_config_set_psk_selection_callback`

### `-Wdocumentation-deprecated-sync`

Added the appropriate `__attribute__((deprecated))` annotations to APIs already documented as deprecated:

- `s2n_cleanup`
- `s2n_config_add_cert_chain_and_key`
- `s2n_config_set_extension_data`
- `s2n_connection_get_curve`
- `s2n_connection_get_kem_name`

### `-Wshorten-64-to-32`

- Added bounds checks for `size_t` → `uint32_t` conversions.
- Added explicit casts where the conversion is verified to be safe.
- Adjusted the affected loop variable to avoid implicit narrowing conversions.

No public API behavior is intentionally changed.

## Callouts

The changes are limited to resolving Clang 18 strict-warning failures and keeping documentation, deprecation attributes, and integer conversions consistent with the existing implementation.

## Testing

- Built with Clang 18 using:
  - `-Werror`
  - `-Wdocumentation`
  - `-Wshorten-64-to-32`
- Ran the relevant s2n-tls tests.
- Verified that the affected warnings no longer cause compilation failures.
- Ran formatting/lint checks on the changed files.

## Related

Fixes #5696

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.