### PR TITLE
fix(bindings): avoid mutable aliasing in shared Config callbacks

### DIFF
--- a/bindings/rust/extended/s2n-tls/src/callbacks.rs
+++ b/bindings/rust/extended/s2n-tls/src/callbacks.rs
@@ -95,7 +95,7 @@ pub trait MonotonicClock: 'static + Send + Sync {
 pub(crate) unsafe fn verify_host(
     host_name: *const ::libc::c_char,
     host_name_len: usize,
-    handler: &mut Box<dyn VerifyHostNameCallback>,
+    handler: &dyn VerifyHostNameCallback,
 ) -> u8 {
     let host_name = host_name as *const u8;
     let host_name = core::slice::from_raw_parts(host_name, host_name_len);

--- a/bindings/rust/extended/s2n-tls/src/config.rs
+++ b/bindings/rust/extended/s2n-tls/src/config.rs
@@ -570,9 +570,11 @@ impl Builder {
             host_name_len: usize,
             context: *mut ::libc::c_void,
         ) -> u8 {
-            let context = &mut *(context as *mut Context);
-            let handler = context.verify_host_callback.as_mut().unwrap();
-            verify_host(host_name, host_name_len, handler)
+            // Cloned Configs share one context, so only take a shared
+            // reference: a `&mut` would be UB under concurrent handshakes.
+            let context = &*(context as *const Context);
+            let handler = context.verify_host_callback.as_ref().unwrap();
+            verify_host(host_name, host_name_len, handler.as_ref())
         }
 
         let context = unsafe {
@@ -907,8 +909,10 @@ impl Builder {
             context: *mut ::libc::c_void,
             time_in_nanos: *mut u64,
         ) -> libc::c_int {
-            let context = &mut *(context as *mut Context);
-            if let Some(handler) = context.wall_clock.as_mut() {
+            // Cloned Configs share one context, so only take a shared
+            // reference: a `&mut` would be UB under concurrent handshakes.
+            let context = &*(context as *const Context);
+            if let Some(handler) = context.wall_clock.as_ref() {
                 if let Ok(nanos) = handler.get_time_since_epoch().as_nanos().try_into() {
                     *time_in_nanos = nanos;
                     return CallbackResult::Success.into();
@@ -950,8 +954,10 @@ impl Builder {
             context: *mut ::libc::c_void,
             time_in_nanos: *mut u64,
         ) -> libc::c_int {
-            let context = &mut *(context as *mut Context);
-            if let Some(handler) = context.monotonic_clock.as_mut() {
+            // Cloned Configs share one context, so only take a shared
+            // reference: a `&mut` would be UB under concurrent handshakes.
+            let context = &*(context as *const Context);
+            if let Some(handler) = context.monotonic_clock.as_ref() {
                 if let Ok(nanos) = handler.get_time().as_nanos().try_into() {
                     *time_in_nanos = nanos;
                     return CallbackResult::Success.into();

--- a/bindings/rust/extended/s2n-tls/src/connection.rs
+++ b/bindings/rust/extended/s2n-tls/src/connection.rs
@@ -493,9 +493,9 @@ impl Connection {
             host_name_len: usize,
             context: *mut ::libc::c_void,
         ) -> u8 {
-            let context = &mut *(context as *mut Context);
-            let handler = context.verify_host_callback.as_mut().unwrap();
-            verify_host(host_name, host_name_len, handler)
+            let context = &*(context as *const Context);
+            let handler = context.verify_host_callback.as_ref().unwrap();
+            verify_host(host_name, host_name_len, handler.as_ref())
         }
 
         self.context_mut().verify_host_callback = Some(Box::new(handler));


### PR DESCRIPTION
# Goal

Eliminate undefined behavior from mutable aliasing in the Rust bindings' shared `Config` callbacks.

## Why

A `Config` is reference-counted, so all of its clones point at the same `Context`. The `verify_host`, `wall_clock`, and `monotonic_clock` callbacks created a `&mut Context` from that shared pointer. When a `Config` is shared across threads, concurrent handshakes create multiple live `&mut Context` references to the same memory. Rust requires `&mut` references to be unique while live, so this is undefined behavior on its own ([Rust Reference: breaking the pointer aliasing rules](https://doc.rust-lang.org/stable/reference/behavior-considered-undefined.html#r-undefined.alias)).

## How

Replaced `&mut *(context as *mut Context)` with a shared `&*(context as *const Context)` in the affected callbacks

## Callouts

The other config callbacks (`client_hello`, `cert_validation`, `event_subscriber`) were already sound; they access the context via `with_context`, which uses a shared reference. The connection-level `verify_host` callback was updated for consistency, though its context is not shared across threads.

## Testing
Existing tests pass

### Related
<!-- E.g. "resolves #3456" -->

<!-- for significant features includes a release summary -->
<!-- The release summary must be a single line that starts with "release summary" -->
<!-- release summary: s2n-tls users can now dance the tango -->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
