### PR TITLE
fix: bounds-check cert pkey type before array indexing

### DIFF
--- a/tls/s2n_config.c
+++ b/tls/s2n_config.c
@@ -158,6 +158,8 @@ static int s2n_config_update_domain_name_to_cert_map(struct s2n_config *config,
         return 0;
     }
     s2n_pkey_type cert_type = s2n_cert_chain_and_key_get_pkey_type(cert_key_pair);
+    POSIX_ENSURE(cert_type >= 0, S2N_ERR_CERT_TYPE_UNSUPPORTED);
+    POSIX_ENSURE(cert_type < S2N_CERT_TYPE_COUNT, S2N_ERR_CERT_TYPE_UNSUPPORTED);
     struct s2n_blob s2n_map_value = { 0 };
     bool key_found = false;
     POSIX_GUARD_RESULT(s2n_map_lookup(domain_name_to_cert_map, name, &s2n_map_value, &key_found));
@@ -545,6 +547,8 @@ static int s2n_config_add_cert_chain_and_key_impl(struct s2n_config *config, str
     POSIX_GUARD_RESULT(s2n_security_policy_validate_certificate_chain(config->security_policy, cert_key_pair));
 
     s2n_pkey_type cert_type = s2n_cert_chain_and_key_get_pkey_type(cert_key_pair);
+    POSIX_ENSURE(cert_type >= 0, S2N_ERR_CERT_TYPE_UNSUPPORTED);
+    POSIX_ENSURE(cert_type < S2N_CERT_TYPE_COUNT, S2N_ERR_CERT_TYPE_UNSUPPORTED);
     config->is_rsa_cert_configured |= (cert_type == S2N_PKEY_TYPE_RSA);
 
     /* Perform all fallible checks BEFORE inserting into the domain name map.
@@ -553,8 +557,6 @@ static int s2n_config_add_cert_chain_and_key_impl(struct s2n_config *config, str
      * resulting in dangling pointers and a use-after-free during SNI lookup.
      */
     if (!config->default_certs_are_explicit) {
-        POSIX_ENSURE(cert_type >= 0, S2N_ERR_CERT_TYPE_UNSUPPORTED);
-        POSIX_ENSURE(cert_type < S2N_CERT_TYPE_COUNT, S2N_ERR_CERT_TYPE_UNSUPPORTED);
         if (config->default_certs_by_type.certs[cert_type] != NULL) {
             /* Because library-owned certificates are tracked and cleaned up via the
              * default_certs_by_type mapping, library-owned chains MUST be set as the default
@@ -744,6 +746,8 @@ int s2n_config_set_cert_chain_and_key_defaults(struct s2n_config *config,
     for (size_t i = 0; i < num_cert_key_pairs; i++) {
         POSIX_ENSURE_REF(cert_key_pairs[i]);
         s2n_pkey_type cert_type = s2n_cert_chain_and_key_get_pkey_type(cert_key_pairs[i]);
+        POSIX_ENSURE(cert_type >= 0, S2N_ERR_CERT_TYPE_UNSUPPORTED);
+        POSIX_ENSURE(cert_type < S2N_CERT_TYPE_COUNT, S2N_ERR_CERT_TYPE_UNSUPPORTED);
         S2N_ERROR_IF(new_defaults.certs[cert_type] != NULL, S2N_ERR_MULTIPLE_DEFAULT_CERTIFICATES_PER_AUTH_TYPE);
         new_defaults.certs[cert_type] = cert_key_pairs[i];
     }
@@ -751,6 +755,8 @@ int s2n_config_set_cert_chain_and_key_defaults(struct s2n_config *config,
     POSIX_GUARD(s2n_config_clear_default_certificates(config));
     for (size_t i = 0; i < num_cert_key_pairs; i++) {
         s2n_pkey_type cert_type = s2n_cert_chain_and_key_get_pkey_type(cert_key_pairs[i]);
+        POSIX_ENSURE(cert_type >= 0, S2N_ERR_CERT_TYPE_UNSUPPORTED);
+        POSIX_ENSURE(cert_type < S2N_CERT_TYPE_COUNT, S2N_ERR_CERT_TYPE_UNSUPPORTED);
         config->is_rsa_cert_configured |= (cert_type == S2N_PKEY_TYPE_RSA);
         config->default_certs_by_type.certs[cert_type] = cert_key_pairs[i];
     }

--- a/tls/s2n_server_cert_request.c
+++ b/tls/s2n_server_cert_request.c
@@ -161,7 +161,10 @@ static int s2n_set_cert_chain_as_client(struct s2n_connection *conn)
             POSIX_ENSURE_REF(cert);
         }
         conn->handshake_params.our_chain_and_key = cert;
-        conn->handshake_params.client_cert_pkey_type = s2n_cert_chain_and_key_get_pkey_type(cert);
+        s2n_pkey_type cert_type = s2n_cert_chain_and_key_get_pkey_type(cert);
+        POSIX_ENSURE(cert_type >= 0, S2N_ERR_CERT_TYPE_UNSUPPORTED);
+        POSIX_ENSURE(cert_type < S2N_CERT_TYPE_COUNT, S2N_ERR_CERT_TYPE_UNSUPPORTED);
+        conn->handshake_params.client_cert_pkey_type = cert_type;
 
         POSIX_GUARD_RESULT(s2n_signature_algorithm_select(conn));
     }


### PR DESCRIPTION
# Goal
Prevent out-of-bounds array access when a certificate's public key type cannot be determined.

## Why
`s2n_cert_chain_and_key_get_pkey_type()` returns `S2N_PKEY_TYPE_UNKNOWN` (-1) for a partially-initialized cert chain. Several call sites used that return value directly as an index into fixed-size `certs_by_type` arrays, so a `-1` index produced out-of-bounds reads and writes on both the stack and the config struct. This is reachable through application-side API misuse (e.g. a cert chain that was never loaded).

## How
Added bounds checks (`>= 0` and `< S2N_CERT_TYPE_COUNT`) immediately after each call that uses the returned type as an array index, so an invalid type now fails cleanly with `S2N_ERR_CERT_TYPE_UNSUPPORTED` instead of corrupting memory. Covers all affected sites in `s2n_config.c` and `s2n_server_cert_request.c`, including one path whose existing guard was only applied conditionally.

## Testing
Existing test suites pass.

### Related
<!-- E.g. "resolves #3456" -->

<!-- for significant features includes a release summary -->
<!-- The release summary must be a single line that starts with "release summary" -->
<!-- release summary: s2n-tls users can now dance the tango -->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
