### PR TITLE
perf(sidetrail): Avoid digest zeroing in proof

### DIFF
--- a/tests/sidetrail/working/patches/cbc.patch
+++ b/tests/sidetrail/working/patches/cbc.patch
@@ -1,7 +1,6 @@
 --- a/tests/sidetrail/working/s2n-cbc/tls/s2n_cbc.c
 +++ b/tests/sidetrail/working/s2n-cbc/tls/s2n_cbc.c
-@@ -22,6 +22,28 @@
- #include "utils/s2n_mem.h"
+@@ -23,4 +23,26 @@
  #include "utils/s2n_safety.h"
  
 +#include <smack.h>
@@ -28,9 +27,7 @@
 +
  /* A TLS CBC record looks like ..
   *
-  * [ Payload data ] [ HMAC ] [ Padding ] [ Padding length byte ]
-@@ -44,23 +66,28 @@
-  */
+@@ -45,6 +67,6 @@
  int s2n_verify_cbc(struct s2n_connection *conn, struct s2n_hmac_state *hmac, struct s2n_blob *decrypted)
  {
 -    uint8_t mac_digest_size = 0;
@@ -39,8 +36,7 @@
 +    //POSIX_GUARD(s2n_hmac_digest_size(hmac->alg, &mac_digest_size));
  
      /* The record has to be at least big enough to contain the MAC,
-      * plus the padding length byte */
-     POSIX_ENSURE_GT(decrypted->size, mac_digest_size);
+@@ -53,7 +75,10 @@
  
      int payload_and_padding_size = decrypted->size - mac_digest_size;
 +    __VERIFIER_assert(payload_and_padding_size <= MAX_SIZE - 20);
@@ -51,17 +47,18 @@
 +    __VERIFIER_assume(padding_length <  256);
  
      int payload_length = S2N_MAX(payload_and_padding_size - padding_length - 1, 0);
- 
-     /* Update the MAC */
+@@ -62,7 +87,9 @@
      POSIX_GUARD(s2n_hmac_update(hmac, decrypted->data, payload_length));
      int currently_in_hash_block = hmac->currently_in_hash_block;
 +    __VERIFIER_assume(currently_in_hash_block >= 0);
 +    __VERIFIER_assume(currently_in_hash_block < BLOCK_SIZE);
  
      /* Check the MAC */
-     uint8_t check_digest[S2N_MAX_DIGEST_LEN] = { 0 };
-@@ -82,9 +109,9 @@
-      * recommended. If SSLv3 must be used, the blinding feature (enabled
+-    uint8_t check_digest[S2N_MAX_DIGEST_LEN] = { 0 };
++    uint8_t check_digest[S2N_MAX_DIGEST_LEN];
+     POSIX_ENSURE_LTE(mac_digest_size, sizeof(check_digest));
+     POSIX_GUARD(s2n_hmac_digest_two_compression_rounds(hmac, check_digest, mac_digest_size));
+@@ -83,7 +110,7 @@
       * by default) helps mitigates this issue as well.
       */
 -    if (conn->actual_protocol_version == S2N_SSLv3) {
@@ -72,9 +69,7 @@
 +    //}
  
      /* Check the maximum amount that could theoretically be padding */
-     uint32_t check = S2N_MIN(255, (payload_and_padding_size - 1));
-@@ -92,10 +119,11 @@
-     POSIX_ENSURE_GTE(check, padding_length);
+@@ -93,8 +120,9 @@
  
      uint32_t cutoff = check - padding_length;
 -    for (size_t i = 0, j = decrypted->size - 1 - check; i < check && j < decrypted->size; i++, j++) {
@@ -88,4 +83,3 @@
 +    //}
  
      S2N_ERROR_IF(mismatches, S2N_ERR_CBC_VERIFY);
- 


### PR DESCRIPTION
# Goal

Restore the `s2nSidetrail` CodeBuild job to its pre-#6007 runtime without removing the defense-in-depth initialization from production code.

## Why

After #6007, the Sidetrail BUILD phase increased from 776 seconds to approximately 2,080 seconds and became the critical path for `s2nGeneralBatch`.

## How
Remove the `check_digest` zero-initializer only from the generated `s2n-cbc` proof input. Production `tls/s2n_cbc.c` retains its defense-in-depth initialization.

## Callouts

This changes only the verification input. It does not change production behavior.

## Testing

- Confirmed all patch hunks apply locally with `patch --fuzz=0`.
- Confirmed the patch passes `git apply --check`.
- CodeBuild will validate the Sidetrail proof and runtime.

### Related

Follow-up to #6007.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
