### PR TITLE
ci: add clang-tidy to linting

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,11 @@
+Checks: >
+  -*,
+  bugprone-*,
+  -bugprone-reserved-identifier,
+  clang-analyzer-*,
+  concurrency-*,
+  performance-*
+
+WarningsAsErrors: ''
+HeaderFilterRegex: '.*'
+FormatStyle: none

--- a/.github/workflows/ci_linting.yml
+++ b/.github/workflows/ci_linting.yml
@@ -117,6 +117,35 @@ jobs:
         with:
           clang-format-version: '18'
           include-regex: '^(\.\/)?(api|bin|crypto|stuffer|error|tls|utils|tests\/unit|tests\/testlib|docs\/examples).*\.(c|h)$'
+
+  clang-tidy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Build s2n-tls
+        run: |
+          cmake . -Bbuild \
+            -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_INSTALL_PREFIX=./s2n-tls-install
+          cmake --build build -j $(nproc)
+      - name: Run clang-tidy
+        id: linter
+        uses: cpp-linter/cpp-linter-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          style: ''
+          tidy-checks: ''
+          database: build
+          version: '18'
+          file-annotations: false
+          thread-comments: false
+          tidy-review: false
+      - name: Fail if clang-tidy found issues
+        if: steps.linter.outputs.checks-failed > 0
+        run: exit 1
+
   nixflake:
     # The nix develop changes contain broken nixpkg dependenecies; the allow/impure flags workaround this.
     runs-on: ubuntu-latest


### PR DESCRIPTION
# Goal
_Continuation of stale PR #5826 which implements #5250
I've fixed the PR of @NA-V10 and will therefore also use his description_

Add clang-tidy to the linting CI workflow so C/C++ static analysis is run automatically on pull requests, pushes to main, and merge groups.

## Why
The repository currently runs several linting and formatting checks in CI, but does not run clang-tidy. Adding it helps catch potential code quality and maintainability issues earlier in the development process.

## How
This PR adds a new clang-tidy job to .github/workflows/ci_linting.yml and a minimal `.clang-tidy` file.

The new job uses [C/C++ Linter Action](https://github.com/marketplace/actions/c-c-linter) to run `clang-tidy-18` on **file changes in the PR only** and fails if there are any findings.

## Callouts
3 things to consider/discuss:

1. What `.clang-tidy` config should be used? Which specific checks? For now this is more of an placeholder
2. Should only line/files changes of the PR be checked?
3. Should there be a separate PR to clean up clang-tidy reports of the whole codebase? 

## Testing
<!-- How is it tested? -->
Ran CI on private fork.

### Related
<!-- E.g. "resolves #3456" -->
Resolves #5250 

<!-- for significant features includes a release summary -->
<!-- The release summary must be a single line that starts with "release summary" -->
<!-- release summary: s2n-tls users can now dance the tango -->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
