### PR TITLE
fix: use ASN1_STRING accessors for OpenSSL 4.0 compatibility

### DIFF
--- a/crypto/s2n_certificate.c
+++ b/crypto/s2n_certificate.c
@@ -232,8 +232,8 @@ int s2n_cert_chain_and_key_load_sans(struct s2n_cert_chain_and_key *chain_and_ke
 
         if (san_name->type == GEN_DNS) {
             /* Decoding isn't necessary here since a DNS SAN name is ASCII(type V_ASN1_IA5STRING) */
-            unsigned char *san_str = san_name->d.dNSName->data;
-            const size_t san_str_len = san_name->d.dNSName->length;
+            const unsigned char *san_str = ASN1_STRING_get0_data(san_name->d.dNSName);
+            const size_t san_str_len = ASN1_STRING_length(san_name->d.dNSName);
             struct s2n_blob *san_blob = NULL;
             POSIX_GUARD_RESULT(s2n_array_pushback(chain_and_key->san_names, (void **) &san_blob));
             if (!san_blob) {

--- a/tls/s2n_x509_validator.c
+++ b/tls/s2n_x509_validator.c
@@ -249,9 +249,9 @@ static S2N_RESULT s2n_verify_host_information_san_entry(struct s2n_connection *c
         *san_found = true;
 
         /* try to validate an IP address if it's in the subject alt name. */
-        const unsigned char *ip_addr = current_name->d.iPAddress->data;
+        const unsigned char *ip_addr = ASN1_STRING_get0_data(current_name->d.iPAddress);
         RESULT_ENSURE_REF(ip_addr);
-        int ip_addr_len = current_name->d.iPAddress->length;
+        int ip_addr_len = ASN1_STRING_length(current_name->d.iPAddress);
         RESULT_ENSURE_GT(ip_addr_len, 0);
 
         RESULT_STACK_BLOB(address, INET6_ADDRSTRLEN + 1, INET6_ADDRSTRLEN + 1);


### PR DESCRIPTION
# Goal
Make crypto/s2n_certificate.c and tls/s2n_x509_validator.c compile against OpenSSL 4.0, by reading ASN1_STRING contents through the accessor functions instead of dereferencing the struct directly.



## Why
OpenSSL 4.0 made struct asn1_string_st opaque

## How
ASN1_STRING_get0_data() and ASN1_STRING_length() return exactly the data and length fields, so the change is behaviour-preserving. Both have existed since OpenSSL 1.1.0 and are provided by AWS-LC, BoringSSL and LibreSSL, so no version guard is needed.

san_str in s2n_certificate.c becomes const unsigned char * to match the accessor's return type; it is only ever read (POSIX_CHECKED_MEMCPY copies out of it).

## Callouts
This is complementary to #5781, which converts the four ASN1_STRING_data() call sites in these same two files. That macro is a separate OpenSSL concern (deprecation rather than struct opacity), and both changes are required to build against OpenSSL 4.0. This PR deliberately leaves those call sites alone to avoid conflicting with #5781.
Related to the discussion in #5783 about the intended OpenSSL compatibility ceiling. If the decision there is to always intern AWS-LC, this change becomes unnecessary — it is offered as a low-cost unblock while that is being decided.
## Testing
<!-- How is it tested? -->

### Related
<!-- E.g. "resolves #3456" -->

<!-- for significant features includes a release summary -->
<!-- The release summary must be a single line that starts with "release summary" -->
<!-- release summary: s2n-tls users can now dance the tango -->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
