### PR TITLE
chore: upgrade CBMC to 6.11.0

### DIFF
--- a/.github/workflows/proof_ci_resources/config.yaml
+++ b/.github/workflows/proof_ci_resources/config.yaml
@@ -1,5 +1,5 @@
 cadical-tag: latest
-cbmc-version: "6.9.0"
+cbmc-version: "6.11.0"
 cbmc-viewer-version: latest
 kissat-tag: "rel-4.0.3"
 litani-version: latest


### PR DESCRIPTION
# Goal
Upgrade the CBMC version used by proof CI from 6.9.0 to 6.11.0.

## Why
Use the latest CBMC release for formal verification.

## How
Update the pinned `cbmc-version` in the proof CI configuration.

## Callouts
None.

## Testing
- `git diff --check`
- Verified the CBMC 6.11.0 Ubuntu 24.04 package is available

### Related
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.