### PR TITLE
fix: guard DH param sizes against uint16 truncation

### DIFF
--- a/crypto/s2n_dhe.c
+++ b/crypto/s2n_dhe.c
@@ -234,9 +234,17 @@ int s2n_dh_params_to_p_g_Ys(struct s2n_dh_params *server_dh_params, struct s2n_s
     const BIGNUM *bn_g = s2n_get_g_dh_param(server_dh_params);
     const BIGNUM *bn_Ys = s2n_get_Ys_dh_param(server_dh_params);
 
-    uint16_t p_size = BN_num_bytes(bn_p);
-    uint16_t g_size = BN_num_bytes(bn_g);
-    uint16_t Ys_size = BN_num_bytes(bn_Ys);
+    /* Reject sizes that don't fit in the uint16 wire encoding before truncating. */
+    int p_num_bytes = BN_num_bytes(bn_p);
+    int g_num_bytes = BN_num_bytes(bn_g);
+    int Ys_num_bytes = BN_num_bytes(bn_Ys);
+    POSIX_ENSURE(p_num_bytes >= 0 && p_num_bytes <= UINT16_MAX, S2N_ERR_DH_SERIALIZING);
+    POSIX_ENSURE(g_num_bytes >= 0 && g_num_bytes <= UINT16_MAX, S2N_ERR_DH_SERIALIZING);
+    POSIX_ENSURE(Ys_num_bytes >= 0 && Ys_num_bytes <= UINT16_MAX, S2N_ERR_DH_SERIALIZING);
+
+    uint16_t p_size = p_num_bytes;
+    uint16_t g_size = g_num_bytes;
+    uint16_t Ys_size = Ys_num_bytes;
     uint8_t *p = NULL;
     uint8_t *g = NULL;
     uint8_t *Ys = NULL;
@@ -279,7 +287,14 @@ int s2n_dh_compute_shared_secret_as_client(struct s2n_dh_params *server_dh_param
 
     const BIGNUM *client_pub_key_bn = s2n_get_Ys_dh_param(&client_params);
     POSIX_ENSURE_REF(client_pub_key_bn);
-    client_pub_key_size = BN_num_bytes(client_pub_key_bn);
+    /* Reject sizes that don't fit in the uint16 wire encoding before truncating. */
+    int client_pub_key_num_bytes = BN_num_bytes(client_pub_key_bn);
+    if (client_pub_key_num_bytes < 0 || client_pub_key_num_bytes > UINT16_MAX) {
+        POSIX_GUARD(s2n_free(shared_key));
+        POSIX_GUARD(s2n_dh_params_free(&client_params));
+        POSIX_BAIL(S2N_ERR_DH_WRITING_PUBLIC_KEY);
+    }
+    client_pub_key_size = client_pub_key_num_bytes;
     POSIX_GUARD(s2n_stuffer_write_uint16(Yc_out, client_pub_key_size));
     client_pub_key = s2n_stuffer_raw_write(Yc_out, client_pub_key_size);
     if (client_pub_key == NULL) {


### PR DESCRIPTION
# Goal

Prevent an out-of-bounds write when serializing DH parameters whose byte length exceeds the uint16 wire encoding.

## Why

In `s2n_dh_params_to_p_g_Ys`, the sizes of `p`, `g`, and `Ys` come from `BN_num_bytes` (an `int`) but are stored in `uint16_t`. A size over 65535 truncates silently, so the stuffer reserves fewer bytes than `BN_bn2bin` then writes, overrunning the buffer. The `BN_bn2bin(...) == size` check only runs after the write. The same pattern exists in `s2n_dh_compute_shared_secret_as_client`.

## How

Capture the `BN_num_bytes` result as an `int` and validate it fits in `[0, UINT16_MAX]` before the cast, failing early with `S2N_ERR_DH_SERIALIZING` (server) or `S2N_ERR_DH_WRITING_PUBLIC_KEY` (client). This mirrors the existing `UINT8_MAX` guard in `s2n_ecc_evp_calculate_point_length`.

## Callouts

This is a correctness/hardening fix, not an exploitable vulnerability: triggering it requires a server configured with a prime larger than ~524,288 bits, which is not a realistic value and cannot be influenced by a remote peer.

## Testing
<!-- How is it tested? -->
All tests pass

### Related
<!-- E.g. "resolves #3456" -->

<!-- for significant features includes a release summary -->
<!-- The release summary must be a single line that starts with "release summary" -->
<!-- release summary: s2n-tls users can now dance the tango -->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
