### PR TITLE
fix: free client pub_key on all error paths in server shared secret

### DIFF
--- a/crypto/s2n_dhe.c
+++ b/crypto/s2n_dhe.c
@@ -27,6 +27,8 @@
 #include "utils/s2n_mem.h"
 #include "utils/s2n_safety.h"
 
+DEFINE_POINTER_CLEANUP_FUNC(BIGNUM *, BN_free);
+
 #define S2N_MIN_DH_PRIME_SIZE_BYTES (2048 / 8)
 
 /* Caller is not responsible for freeing values returned by these accessors
@@ -317,7 +319,7 @@ int s2n_dh_compute_shared_secret_as_server(struct s2n_dh_params *server_dh_param
     uint16_t Yc_length = 0;
     struct s2n_blob Yc = { 0 };
     int shared_key_size = 0;
-    BIGNUM *pub_key = NULL;
+    DEFER_CLEANUP(BIGNUM *pub_key = NULL, BN_free_pointer);
 
     POSIX_GUARD(s2n_check_all_dh_params(server_dh_params));
     int server_dh_params_size = DH_size(server_dh_params->dh);
@@ -347,14 +349,9 @@ int s2n_dh_compute_shared_secret_as_server(struct s2n_dh_params *server_dh_param
     POSIX_GUARD(s2n_alloc(shared_key, server_dh_params_size));
 
     shared_key_size = DH_compute_key(shared_key->data, pub_key, server_dh_params->dh);
-    if (shared_key_size <= 0) {
-        BN_free(pub_key);
-        POSIX_BAIL(S2N_ERR_DH_SHARED_SECRET);
-    }
+    POSIX_ENSURE(shared_key_size > 0, S2N_ERR_DH_SHARED_SECRET);
 
     s2n_dh_pad_shared_secret(shared_key, shared_key_size, server_dh_params_size);
-
-    BN_free(pub_key);
 
     return S2N_SUCCESS;
 }


### PR DESCRIPTION
# Goal

Free the client public key BIGNUM on all error paths in the server DHE shared-secret computation.

## Why

In `s2n_dh_compute_shared_secret_as_server`, `pub_key` is allocated with `BN_bin2bn`, but the immediately following `POSIX_GUARD(s2n_alloc(shared_key, ...))` returns early on failure without freeing it, leaking the BIGNUM. Only the later `DH_compute_key` error path freed `pub_key`.

## How

Declare `pub_key` with `DEFER_CLEANUP(..., BN_free_pointer)` so it is freed on every exit path, and remove the now-redundant manual `BN_free` calls. Adds a `DEFINE_POINTER_CLEANUP_FUNC` for `BIGNUM`, matching the cleanup pattern used elsewhere in the crypto code.

## Callouts

This is a correctness/hardening fix, not an exploitable issue: the leak only occurs if `s2n_alloc` fails (out-of-memory), which cannot be triggered on demand.
## Testing
<!-- How is it tested? -->
All tests pass

### Related
<!-- E.g. "resolves #3456" -->

<!-- for significant features includes a release summary -->
<!-- The release summary must be a single line that starts with "release summary" -->
<!-- release summary: s2n-tls users can now dance the tango -->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
