### PR TITLE
ci: test libcrypto interning on ARM

### DIFF
--- a/codebuild/bin/s2n_codebuild_al.sh
+++ b/codebuild/bin/s2n_codebuild_al.sh
@@ -45,5 +45,8 @@ case "$TESTS" in
     cmake --build ./build -j "$(nproc)"
     CTEST_PARALLEL_LEVEL="$(nproc)" cmake --build ./build --target test -- ARGS="-L unit --output-on-failure"
     ;;
+  "interning")
+    ./codebuild/bin/test_libcrypto_interning.sh
+    ;;
   *) echo "Unknown test"; exit 1;;
 esac

--- a/codebuild/spec/buildspec_generalbatch.yml
+++ b/codebuild/spec/buildspec_generalbatch.yml
@@ -112,6 +112,15 @@ batch:
       identifier: s2nUnitAl2Arm
     - buildspec: codebuild/spec/buildspec_amazonlinux.yml
       env:
+        compute-type: BUILD_GENERAL1_LARGE
+        image: aws/codebuild/amazonlinux2-aarch64-standard:2.0
+        privileged-mode: true
+        type: ARM_CONTAINER
+        variables:
+          TESTS: interning
+      identifier: s2nLibcryptoInterningAl2Arm
+    - buildspec: codebuild/spec/buildspec_amazonlinux.yml
+      env:
         compute-type: BUILD_GENERAL1_SMALL
         image: aws/codebuild/amazonlinux2-x86_64-standard:3.0
         privileged-mode: true


### PR DESCRIPTION
## Goal
Run the existing libcrypto interning coverage on an ARM CodeBuild runner.

## Why
Issue #5018 asks for ARM coverage of the interning builds after platform-specific behavior exposed a failure on ARM. The general batch currently has separate Amazon Linux ARM unit jobs and x86 interning jobs, but no job exercising both.

## How
- Add `s2nLibcryptoInterningAl2Arm` to `buildspec_generalbatch.yml`, reusing the existing Amazon Linux 2 AArch64 CodeBuild image, ARM container type, and large compute size.
- Add the corresponding `interning` dispatch to `s2n_codebuild_al.sh`, invoking the existing `test_libcrypto_interning.sh` coverage without changing the test script or existing jobs.

## Testing
- Ruby YAML parsing for the general batch and Amazon Linux buildspecs
- Batch structure assertions for the new identifier, ARM image/type, compute size, and `TESTS` value
- `bash -n codebuild/bin/s2n_codebuild_al.sh`
- `bash -n codebuild/bin/test_libcrypto_interning.sh`
- `git diff --check`

The ARM CodeBuild job itself was not run locally; it will execute in CI.

### Related
Resolves #5018

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.