### PR TITLE
feat: skip blinding delay on missing required client cert

### DIFF
--- a/tests/unit/s2n_safety_blinding_test.c
+++ b/tests/unit/s2n_safety_blinding_test.c
@@ -143,6 +143,15 @@ int main(int argc, char **argv)
             EXPECT_TRUE(s2n_connection_check_io_status(conn, S2N_IO_CLOSED));
         };
 
+        /* Closes connection but does not blind for a missing client cert */
+        {
+            SETUP_TEST(conn);
+            s2n_errno = S2N_ERR_MISSING_CLIENT_CERT;
+            EXPECT_OK(s2n_connection_apply_error_blinding(&conn));
+            EXPECT_EQUAL(s2n_connection_get_delay(conn), 0);
+            EXPECT_TRUE(s2n_connection_check_io_status(conn, S2N_IO_CLOSED));
+        };
+
         /* Blinds for an average error */
         {
             SETUP_TEST(conn);

--- a/tls/s2n_connection.c
+++ b/tls/s2n_connection.c
@@ -1397,6 +1397,7 @@ S2N_CLEANUP_RESULT s2n_connection_apply_error_blinding(struct s2n_connection **c
         case S2N_ERR_CIPHER_NOT_SUPPORTED:
         case S2N_ERR_PROTOCOL_VERSION_UNSUPPORTED:
         case S2N_ERR_CONFIG_NULL_BEFORE_CH_CALLBACK:
+        case S2N_ERR_MISSING_CLIENT_CERT:
             RESULT_GUARD(s2n_connection_set_closed(*conn));
             break;
         default:


### PR DESCRIPTION
# Goal
Allow an mTLS server to fail fast when a client omits a required certificate.

## Why
Blinding delayed the fatal alert by 10-30s on a missing required client cert, causing connections to hang until the client timed out instead of getting an immediate rejection.

## How
Added `S2N_ERR_MISSING_CLIENT_CERT` to the blinding skip-list in `s2n_connection_apply_error_blinding()`, so the connection closes immediately and sends the `certificate_required`/`handshake_failure` alert without delay.

## Callouts
Scopednto the missing/empty required client cert case. Cert validation errors (untrusted, revoked, expired, bad hostname) remain blinded since they run after crypto on attacker-supplied bytes.

## Testing
Added a unit case asserting zero delay and a closed connection for this error.

### Related
<!-- E.g. "resolves #3456" -->

<!-- for significant features includes a release summary -->
<!-- The release summary must be a single line that starts with "release summary" -->
<!-- release summary: s2n-tls users can now dance the tango -->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
