### PR TITLE
fix: restrict cert signature preferences in custom CNSA2 interop policies

### DIFF
--- a/nix/README.md
+++ b/nix/README.md
@@ -75,9 +75,9 @@ The CI does this in one shot with: `nix develop --max-jobs auto --ignore-environ
 From inside a devShell after running `configure` and `build`, use `uvinteg <test name>` to run the integration tests matching the regex `<test name>`, or with no arguments to run all the integration tests.  Note that some of the tests are still broken under nix, so some failures are expected.
 For example: `uvinteg happy_path`.
 
-The CI does this in one shot with `nix develop --max-jobs auto --ignore-environnment --command bash -c "source ./nix/shell.sh; configure;build;uvinteg" `
+The CI does this in one shot with `nix develop --max-jobs auto --ignore-environment --command bash -c "source ./nix/shell.sh; configure;build;uvinteg" `
 
-Like with the unit tests, an individual test, like [happy_path](https://github.com/aws/s2n-tls/blob/main/tests/integrationv2/test_happy_path.py) in this example, can be run with: `nix develop --max-jobs auto --ignore-environnment --command bash -c "source ./nix/shell.sh; configure;build;uvinteg happy_path"`
+Like with the unit tests, an individual test, like [happy_path](https://github.com/aws/s2n-tls/blob/main/tests/integrationv2/test_happy_path.py) in this example, can be run with: `nix develop --max-jobs auto --ignore-environment --command bash -c "source ./nix/shell.sh; configure;build;uvinteg happy_path"`
 
 For Rust integration tests, use `rust_test` from within a rust-enabled devshell after running `rust_configure` and `rust_build`.
 

--- a/tests/policy_snapshot/snapshots/20260720
+++ b/tests/policy_snapshot/snapshots/20260720
@@ -15,17 +15,7 @@ curves:
 certificate signature schemes:
 - mldsa87
 - ecdsa_sha384
-- rsa_pss_pss_sha384
-- rsa_pss_rsae_sha384
 - rsa_pkcs1_sha384
-- ecdsa_sha256
-- rsa_pss_pss_sha256
-- rsa_pss_rsae_sha256
-- rsa_pkcs1_sha256
-- ecdsa_sha512
-- rsa_pss_pss_sha512
-- rsa_pss_rsae_sha512
-- rsa_pkcs1_sha512
 pq:
 - revision: 5
 - kem groups:

--- a/tests/policy_snapshot/snapshots/ELBSecurityPolicy-TLS13-1-2-CNSA2-INTEROP2-FIPS-PQ-2026-07
+++ b/tests/policy_snapshot/snapshots/ELBSecurityPolicy-TLS13-1-2-CNSA2-INTEROP2-FIPS-PQ-2026-07
@@ -17,17 +17,7 @@ curves:
 certificate signature schemes:
 - mldsa87
 - ecdsa_sha384
-- rsa_pss_pss_sha384
-- rsa_pss_rsae_sha384
 - rsa_pkcs1_sha384
-- ecdsa_sha256
-- rsa_pss_pss_sha256
-- rsa_pss_rsae_sha256
-- rsa_pkcs1_sha256
-- ecdsa_sha512
-- rsa_pss_pss_sha512
-- rsa_pss_rsae_sha512
-- rsa_pkcs1_sha512
 pq:
 - revision: 5
 - kem groups:

--- a/tests/policy_snapshot/snapshots/ELBSecurityPolicy-TLS13-1-3-CNSA2-INTEROP1-FIPS-PQ-2026-07
+++ b/tests/policy_snapshot/snapshots/ELBSecurityPolicy-TLS13-1-3-CNSA2-INTEROP1-FIPS-PQ-2026-07
@@ -15,17 +15,7 @@ curves:
 certificate signature schemes:
 - mldsa87
 - ecdsa_sha384
-- rsa_pss_pss_sha384
-- rsa_pss_rsae_sha384
 - rsa_pkcs1_sha384
-- ecdsa_sha256
-- rsa_pss_pss_sha256
-- rsa_pss_rsae_sha256
-- rsa_pkcs1_sha256
-- ecdsa_sha512
-- rsa_pss_pss_sha512
-- rsa_pss_rsae_sha512
-- rsa_pkcs1_sha512
 pq:
 - revision: 5
 - kem groups:

--- a/tests/unit/s2n_security_policies_test.c
+++ b/tests/unit/s2n_security_policies_test.c
@@ -1030,8 +1030,8 @@ int main(int argc, char **argv)
                 EXPECT_SUCCESS(s2n_test_cert_chain_and_key_new(&mldsa87_chain_and_key, S2N_MLDSA87_CERT, S2N_MLDSA87_KEY));
 
                 /* Handshake with each other using ML-DSA-87 certs */
-                EXPECT_OK(s2n_test_security_policies_compatible(&security_policy_20260721, "20260720", mldsa87_chain_and_key));
-                EXPECT_OK(s2n_test_security_policies_compatible(&security_policy_20260721, "20260722", mldsa87_chain_and_key));
+                EXPECT_OK(s2n_test_security_policies_compatible(&security_policy_20260220, "20260720", mldsa87_chain_and_key));
+                EXPECT_OK(s2n_test_security_policies_compatible(&security_policy_20260220, "20260722", mldsa87_chain_and_key));
                 EXPECT_OK(s2n_test_security_policies_compatible(&security_policy_20260722, "20260720", mldsa87_chain_and_key));
 
                 /* CNSA2-INTEROP1 can only negotiate TLS 1.3, not TLS 1.2 */

--- a/tls/s2n_security_policies.c
+++ b/tls/s2n_security_policies.c
@@ -1389,27 +1389,13 @@ const struct s2n_security_policy security_policy_20260220 = {
     },
 };
 
-/* TLS 1.3 only CNSA2 interop policy: remove TLS 1.2 ciphers from 20260721 */
+/* TLS 1.3 only CNSA2 interop policy: remove TLS 1.2 ciphers from 20260220 */
 const struct s2n_security_policy security_policy_20260720 = {
     .minimum_protocol_version = S2N_TLS13,
     .cipher_preferences = &cipher_preferences_20250211,
     .kem_preferences = &kem_preferences_pq_tls_1_3_cnsa2_2026_02,
     .signature_preferences = &s2n_signature_preferences_20260220,
-    .certificate_signature_preferences = &s2n_signature_preferences_20260722,
-    .ecc_preferences = &s2n_ecc_preferences_20210816,
-    .rules = {
-            [S2N_PERFECT_FORWARD_SECRECY] = true,
-            [S2N_FIPS_140_3] = true,
-    },
-};
-
-/* 20260220 with expanded cert signature preferences */
-const struct s2n_security_policy security_policy_20260721 = {
-    .minimum_protocol_version = S2N_TLS12,
-    .cipher_preferences = &cipher_preferences_20260220,
-    .kem_preferences = &kem_preferences_pq_tls_1_3_cnsa2_2026_02,
-    .signature_preferences = &s2n_signature_preferences_20260220,
-    .certificate_signature_preferences = &s2n_signature_preferences_20260722,
+    .certificate_signature_preferences = &s2n_certificate_signature_preferences_20260220,
     .ecc_preferences = &s2n_ecc_preferences_20210816,
     .rules = {
             [S2N_PERFECT_FORWARD_SECRECY] = true,
@@ -1648,7 +1634,7 @@ struct s2n_security_policy_selection security_policy_selection[] = {
     { .version = "ELBSecurityPolicy-FS-1-1-2019-08", .security_policy = &security_policy_elb_fs_1_1_2019_08, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
     { .version = "ELBSecurityPolicy-FS-1-2-Res-2019-08", .security_policy = &security_policy_elb_fs_1_2_Res_2019_08, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
     { .version = "ELBSecurityPolicy-TLS13-1-3-CNSA2-INTEROP1-FIPS-PQ-2026-07", .security_policy = &security_policy_20260720, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
-    { .version = "ELBSecurityPolicy-TLS13-1-2-CNSA2-INTEROP2-FIPS-PQ-2026-07", .security_policy = &security_policy_20260721, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
+    { .version = "ELBSecurityPolicy-TLS13-1-2-CNSA2-INTEROP2-FIPS-PQ-2026-07", .security_policy = &security_policy_20260220, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
     { .version = "ELBSecurityPolicy-TLS13-1-2-CNSA2-INTEROP3-FIPS-PQ-2026-07", .security_policy = &security_policy_20260722, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
     { .version = "CloudFront-Upstream", .security_policy = &security_policy_cloudfront_upstream, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },
     { .version = "CloudFront-Upstream-TLS-1-0", .security_policy = &security_policy_cloudfront_upstream_tls10, .ecc_extension_required = 0, .pq_kem_extension_required = 0 },

--- a/tls/s2n_security_policies.h
+++ b/tls/s2n_security_policies.h
@@ -162,7 +162,6 @@ extern const struct s2n_security_policy security_policy_20260522_gcm;
 extern const struct s2n_security_policy security_policy_20260523;
 extern const struct s2n_security_policy security_policy_20260523_gcm;
 extern const struct s2n_security_policy security_policy_20260720;
-extern const struct s2n_security_policy security_policy_20260721;
 extern const struct s2n_security_policy security_policy_20260722;
 extern const struct s2n_security_policy security_policy_test_all;
 


### PR DESCRIPTION
# Goal
Restrict the certificate signature preferences in CNSA2 INTEROP1 and INTEROP2 policies

## Why
INTEROP1 and INTEROP2 policies used the relaxed `20260722` certificate signature preferences, which accept non-CNSA strict algorithms such as SHA-256/SHA-512 and RSA-PSS variants.

## How
- Point INTEROP1 at `s2n_certificate_signature_preferences_20260220`
- Remove `security_policy_20260721` and register INTEROP2 directly against `security_policy_20260220`
- Update the policy snapshots to reflect the reduced list

## Callouts
INTEROP3 retains the broader `20260722` cert signature preferences.

## Testing
Updated unit test and policy snapshots to validate the cert sig changes.

Also fixed an unrelated typos check failure.

### Related
#6011

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
