### PR TITLE
feat(bindings): add signature_public_key_type to Connection

### DIFF
--- a/bindings/rust/extended/s2n-tls/src/connection.rs
+++ b/bindings/rust/extended/s2n-tls/src/connection.rs
@@ -1261,6 +1261,43 @@ impl Connection {
         }
     }
 
+    /// Returns a string describing the public key algorithm and parameters of
+    /// the leaf certificate for the given connection `mode`.
+    ///
+    /// Use [`Mode::Server`] to query the server certificate and [`Mode::Client`]
+    /// to query the client certificate. The returned string has one of the
+    /// following forms:
+    /// - RSA: `"rsa2048"`, `"rsa3072"`, `"rsa4096"`, or `"rsa<keysize>"`
+    /// - ECDSA: `"ecdsa_secp256r1"`, `"ecdsa_secp384r1"`, `"ecdsa_secp521r1"`
+    /// - ML-DSA: `"mldsa44"`, `"mldsa65"`, `"mldsa87"`
+    ///
+    /// Querying the peer's certificate ([`Mode::Client`] on a server, or
+    /// [`Mode::Server`] on a client) requires that the peer's certificate chain
+    /// has been validated during the handshake.
+    ///
+    /// Corresponds to [`s2n_conn_get_signature_public_key_type`].
+    pub fn signature_public_key_type(&self, mode: Mode) -> Result<String, Error> {
+        // The API writes a null-terminated string into a caller-provided
+        // buffer. 32 bytes comfortably fits every defined output (the longest
+        // is "ecdsa_secp256r1" at 16 bytes including the null terminator); a
+        // larger output would surface as S2N_ERR_INSUFFICIENT_MEM_SIZE.
+        let mut buffer = [0u8; 32];
+        let mut output_size = buffer.len() as u32;
+        unsafe {
+            s2n_conn_get_signature_public_key_type(
+                self.connection.as_ptr(),
+                mode.into(),
+                buffer.as_mut_ptr() as *mut std::ffi::c_char,
+                &mut output_size,
+            )
+            .into_result()?;
+        }
+
+        // `output_size` includes the null terminator; drop it before decoding.
+        let len = (output_size as usize).saturating_sub(1);
+        String::from_utf8(buffer[..len].to_vec()).map_err(|_| Error::INVALID_INPUT)
+    }
+
     /// Corresponds to [`s2n_connection_get_selected_digest_algorithm`].
     pub fn selected_hash_algorithm(&self) -> Result<HashAlgorithm, Error> {
         let mut hash_alg = s2n_tls_hash_algorithm::NONE;
@@ -1970,6 +2007,67 @@ mod tests {
             assert_eq!(test_pair.client.signature_scheme(), None);
             assert_eq!(test_pair.server.signature_scheme(), None);
         }
+        Ok(())
+    }
+
+    #[test]
+    fn signature_public_key_type_rsa() -> Result<(), Box<dyn std::error::Error>> {
+        // The default test cert is a 4096-bit RSA cert.
+        let config = build_config(&security::DEFAULT_TLS13)?;
+        let mut pair = TestPair::from_config(&config);
+        pair.handshake()?;
+
+        // The server's own certificate and the client's view of the peer
+        // (server) certificate should both report "rsa4096".
+        assert_eq!(
+            pair.server.signature_public_key_type(Mode::Server)?,
+            "rsa4096"
+        );
+        assert_eq!(
+            pair.client.signature_public_key_type(Mode::Server)?,
+            "rsa4096"
+        );
+
+        // No client auth was configured, so there is no validated client
+        // certificate to describe.
+        let err = pair
+            .server
+            .signature_public_key_type(Mode::Client)
+            .unwrap_err();
+        assert_eq!(err.name(), "S2N_ERR_CERT_NOT_VALIDATED");
+
+        Ok(())
+    }
+
+    #[test]
+    fn signature_public_key_type_ecdsa() -> Result<(), Box<dyn std::error::Error>> {
+        // Build a config that serves an ECDSA (secp256r1) certificate so we
+        // exercise a non-RSA output and the longest string variant.
+        let keypair = SniTestCerts::AlligatorEcdsa.get();
+        let config = {
+            let mut builder = crate::config::Builder::new();
+            builder.set_security_policy(&security::DEFAULT_TLS13)?;
+            builder.load_pem(keypair.cert(), keypair.key())?;
+            builder.set_verify_host_callback(
+                crate::testing::InsecureAcceptAllCertificatesHandler {},
+            )?;
+            builder.with_system_certs(false)?;
+            builder.trust_pem(keypair.cert())?;
+            builder.build()?
+        };
+
+        let mut pair = TestPair::from_config(&config);
+        pair.handshake()?;
+
+        assert_eq!(
+            pair.server.signature_public_key_type(Mode::Server)?,
+            "ecdsa_secp256r1"
+        );
+        assert_eq!(
+            pair.client.signature_public_key_type(Mode::Server)?,
+            "ecdsa_secp256r1"
+        );
+
         Ok(())
     }
 


### PR DESCRIPTION
# Goal

Add a Rust binding for the `s2n_conn_get_signature_public_key_type` C API

## Why
The C API lets an application query a human-readable description of the public key algorithm and parameters of a connection's leaf certificate (its own or the validated peer's). Rust consumers of s2n-tls had no safe way to call it. This binding exposes that capability idiomatically on `Connection`.

## How
1. Adds a safe wrapper method `signature_public_key_type(&self, mode: Mode)` on `Connection`. `Mode::Server` queries the server certificate; `Mode::Client` queries the client certificate.
2. The returned string has one of the forms: `rsa2048/rsa<keysize>`, `ecdsa_secp256r1/ecdsa_secp384r1/ecdsa _secp521r1`, or `mldsa44/mldsa65/mldsa87`.
3. The wrapper passes a fixed 32-byte stack buffer to the C API (which fills a caller-provided buffer), then decodes the written bytes, trimming the trailing null terminator.

## Testing
Two unit tests exercise the wrapper against real handshakes (using RSA/EC certs) and assert the output string from both the own and peer views.

### Related
#5963

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
