### PR TITLE
fix(metrics): normalize s2n signature

### DIFF
--- a/bindings/rust/standard/s2n-tls-metrics-schema/src/static_lists.rs
+++ b/bindings/rust/standard/s2n-tls-metrics-schema/src/static_lists.rs
@@ -69,17 +69,6 @@ impl FiniteCounter<CIPHER_COUNT> for Cipher {
     };
 }
 
-impl FromStr for Cipher {
-    type Err = ();
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        CIPHERS_AVAILABLE_IN_S2N
-            .iter()
-            .find(|info| info.iana_description == s)
-            .map(|info| info.cipher)
-            .ok_or(())
-    }
-}
-
 impl FiniteCounter<PROTOCOL_COUNT> for Version {
     const ELEMENTS: [Version; PROTOCOL_COUNT] = {
         let mut out = [Version(U16::new(0)); PROTOCOL_COUNT];
@@ -115,17 +104,6 @@ impl FiniteCounter<GROUP_COUNT> for Group {
     };
 }
 
-impl FromStr for Group {
-    type Err = ();
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        GROUPS_AVAILABLE_IN_S2N
-            .iter()
-            .find(|info| info.iana_description == s)
-            .map(|info| info.group)
-            .ok_or(())
-    }
-}
-
 impl FiniteCounter<SIGNATURE_COUNT> for Signature {
     const ELEMENTS: [Signature; SIGNATURE_COUNT] = {
         let mut out = [Signature(U16::new(0)); SIGNATURE_COUNT];
@@ -136,17 +114,6 @@ impl FiniteCounter<SIGNATURE_COUNT> for Signature {
         }
         out
     };
-}
-
-impl FromStr for Signature {
-    type Err = ();
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        SIGNATURE_SCHEMES_AVAILABLE_IN_S2N
-            .iter()
-            .find(|info| info.description == s)
-            .map(|info| info.signature)
-            .ok_or(())
-    }
 }
 
 impl FiniteCounter<DEFINED_ALERTS_COUNT> for Alert {
@@ -246,6 +213,13 @@ impl Cipher {
             .find(|info| info.openssl_name == name)
             .map(|info| info.cipher)
     }
+
+    pub fn from_iana_description(description: &str) -> Option<Self> {
+        CIPHERS_AVAILABLE_IN_S2N
+            .iter()
+            .find(|info| info.iana_description == description)
+            .map(|info| info.cipher)
+    }
 }
 
 impl Display for Cipher {
@@ -307,7 +281,7 @@ impl Signature {
     pub const rsa_pkcs1_sha512: Self = Signature(U16::new(0x0601));
 
     /// This is the list of signature algorithms that
-    /// - s2n-tls recognizes/generally support
+    /// - s2n-tls recognizes/generally supports
     /// - do not support TLS 1.3
     pub const SIG_ALGS_TLS13_UNSUPPORTED: &[Signature] = &[
         // SHA1 ecdsa schemes are not supported for TLS 1.3
@@ -326,6 +300,24 @@ impl Signature {
             .iter()
             .find(|info| info.signature == *self)
             .map(|info| info.description)
+    }
+
+    /// Look up a [`Signature`] from the name returned by
+    /// [`Connection::signature_scheme()`].
+    pub fn from_s2n_description(s2n_description: &str) -> Option<Self> {
+        // Map version-specific ECDSA names back to the base description used in
+        // the static list. Checked in `all_emittable_signature_names_resolve`
+        let normalized = match s2n_description {
+            "ecdsa_secp256r1_sha256" | "legacy_ecdsa_sha256" => "ecdsa_sha256",
+            "ecdsa_secp384r1_sha384" | "legacy_ecdsa_sha384" => "ecdsa_sha384",
+            "ecdsa_secp521r1_sha512" | "legacy_ecdsa_sha512" => "ecdsa_sha512",
+            other => other,
+        };
+
+        SIGNATURE_SCHEMES_AVAILABLE_IN_S2N
+            .iter()
+            .find(|info| info.description == normalized)
+            .map(|info| info.signature)
     }
 }
 
@@ -379,6 +371,13 @@ impl Group {
         GROUPS_AVAILABLE_IN_S2N
             .iter()
             .any(|info| info.group == *self)
+    }
+
+    pub fn from_iana_description(iana_description: &str) -> Option<Self> {
+        GROUPS_AVAILABLE_IN_S2N
+            .iter()
+            .find(|info| info.iana_description == iana_description)
+            .map(|info| info.group)
     }
 }
 
@@ -809,5 +808,45 @@ mod tests {
         for (constant, expected_name) in cases {
             assert_eq!(constant.known_description().unwrap(), *expected_name);
         }
+    }
+
+    #[test]
+    fn from_s2n_description_normalizes_ecdsa_names() {
+        // The base names returned for schemes without a signature curve resolve
+        // directly.
+        assert_eq!(
+            Signature::from_s2n_description("rsa_pss_rsae_sha256"),
+            Some(Signature::rsa_pss_rsae_sha256)
+        );
+
+        // ECDSA schemes share an IANA value across TLS versions, so
+        // `Connection::signature_scheme()` returns version-specific names that
+        // are not present verbatim in the static list. Both the TLS 1.3
+        // (`tls13_name`) and TLS 1.2 (`legacy_name`) forms must resolve to the
+        // base ECDSA signature.
+        for name in ["ecdsa_secp256r1_sha256", "legacy_ecdsa_sha256"] {
+            assert_eq!(
+                Signature::from_s2n_description(name),
+                Some(Signature::ecdsa_secp256r1_sha256),
+                "failed to resolve {name}"
+            );
+        }
+        for name in ["ecdsa_secp384r1_sha384", "legacy_ecdsa_sha384"] {
+            assert_eq!(
+                Signature::from_s2n_description(name),
+                Some(Signature::ecdsa_secp384r1_sha384),
+                "failed to resolve {name}"
+            );
+        }
+        for name in ["ecdsa_secp521r1_sha512", "legacy_ecdsa_sha512"] {
+            assert_eq!(
+                Signature::from_s2n_description(name),
+                Some(Signature::ecdsa_secp521r1_sha512),
+                "failed to resolve {name}"
+            );
+        }
+
+        // Unknown names still return None.
+        assert_eq!(Signature::from_s2n_description("not_a_scheme"), None);
     }
 }

--- a/bindings/rust/standard/s2n-tls-metrics-schema/tests/static_lists.rs
+++ b/bindings/rust/standard/s2n-tls-metrics-schema/tests/static_lists.rs
@@ -112,3 +112,69 @@ fn all_signature_schemes_in_static_list() {
     let schemes = all_available_signatures();
     assert_eq!(schemes.as_slice(), &SIGNATURE_SCHEMES_AVAILABLE_IN_S2N[..]);
 }
+
+/// Get both tls 1.3 and legacy names from s2n-tls
+fn emittable_names_from_s2n(scheme: &s2n_signature_scheme) -> Vec<&'static str> {
+    unsafe {
+        // Skip the "none" placeholder scheme, which is never a real negotiated
+        // signature and which `Connection::signature_scheme()` maps to `None`.
+        if scheme.iana_value == 0 {
+            return Vec::new();
+        }
+
+        if scheme.signature_curve.is_null() {
+            // No curve: the API always returns the base name.
+            vec![static_memory_to_str(scheme.name)]
+        } else {
+            // Curve present: the API returns the version-specific name. Both
+            // must be non-null in this case (the C code dereferences them).
+            assert!(
+                !scheme.tls13_name.is_null(),
+                "scheme with signature_curve missing tls13_name"
+            );
+            assert!(
+                !scheme.legacy_name.is_null(),
+                "scheme with signature_curve missing legacy_name"
+            );
+            vec![
+                static_memory_to_str(scheme.tls13_name),
+                static_memory_to_str(scheme.legacy_name),
+            ]
+        }
+    }
+}
+
+/// Every name that `Connection::signature_scheme()` can return, across all
+/// security policies, must be resolvable by `Signature::from_s2n_description`.
+#[test]
+fn all_emittable_signature_names_resolve() {
+    let names: HashSet<&'static str> = s2n_tls_sys_internal::security_policy_table()
+        .iter()
+        .flat_map(|sp| {
+            let sp = unsafe { &*sp.security_policy };
+            sp.signatures()
+                .iter()
+                .flat_map(|sig| emittable_names_from_s2n(sig))
+                .collect::<Vec<_>>()
+        })
+        .collect();
+
+    assert!(!names.is_empty(), "no signature names discovered");
+
+    for name in names {
+        let resolved = Signature::from_s2n_description(name);
+        assert!(
+            resolved.is_some(),
+            "from_s2n_description failed to resolve emittable name {name:?}"
+        );
+        // The resolved signature's IANA value must match the scheme that
+        // produced the name, confirming we mapped to the correct entry.
+        let sig = resolved.unwrap();
+        assert!(
+            SIGNATURE_SCHEMES_AVAILABLE_IN_S2N
+                .iter()
+                .any(|info| info.signature == sig),
+            "resolved signature for {name:?} is not in the static list"
+        );
+    }
+}

--- a/bindings/rust/standard/s2n-tls-metrics-subscriber/src/record.rs
+++ b/bindings/rust/standard/s2n-tls-metrics-subscriber/src/record.rs
@@ -62,8 +62,10 @@ impl NegotiatedParameters {
             }
         };
 
-        let group = success.group().and_then(|g| g.parse().ok());
-        let signature = conn.signature_scheme().and_then(|s| s.parse().ok());
+        let group = success.group().and_then(Group::from_iana_description);
+        let signature = conn
+            .signature_scheme()
+            .and_then(Signature::from_s2n_description);
 
         Ok(Self {
             version,
@@ -609,48 +611,54 @@ mod tests {
             .selected_key_exchange_group()
             .unwrap()
             .to_owned();
-        let expected_group_element: Group = expected_group.parse().unwrap();
+        let expected_group_element = Group::from_iana_description(&expected_group).unwrap();
         let slot = expected_group_element.slot_from_key().unwrap();
         assert_eq!(record.negotiated_groups.slots()[slot], 1);
 
         let expected_sig = result.client.signature_scheme().unwrap().to_owned();
-        let expected_sig_element: Signature = expected_sig.parse().unwrap();
+        let expected_sig_element: Signature =
+            Signature::from_s2n_description(&expected_sig).unwrap();
         let slot = expected_sig_element.slot_from_key().unwrap();
         assert_eq!(record.negotiated_signatures.slots()[slot], 1);
     }
 
     #[test]
     fn record_contents_supported_parameters() {
-        const EXPECTED_VERSIONS: &[&str] = &["TLSv1_3", "TLSv1_2"];
-        const EXPECTED_CIPHERS: &[&str] = &[
-            "TLS_AES_256_GCM_SHA384",
-            "TLS_AES_128_GCM_SHA256",
-            "TLS_CHACHA20_POLY1305_SHA256",
-            "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256",
-            "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
-            "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384",
-            "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
-            "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256",
-            "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256",
-            "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
-            "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384",
-            "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
-            "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256",
+        let expected_protocols: Vec<Version> = vec![Version::TLS_1_2, Version::TLS_1_3];
+        let expected_ciphers: Vec<Cipher> = vec![
+            Cipher::from_iana_description("TLS_AES_256_GCM_SHA384").unwrap(),
+            Cipher::from_iana_description("TLS_AES_128_GCM_SHA256").unwrap(),
+            Cipher::from_iana_description("TLS_CHACHA20_POLY1305_SHA256").unwrap(),
+            Cipher::from_iana_description("TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256").unwrap(),
+            Cipher::from_iana_description("TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256").unwrap(),
+            Cipher::from_iana_description("TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384").unwrap(),
+            Cipher::from_iana_description("TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384").unwrap(),
+            Cipher::from_iana_description("TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256").unwrap(),
+            Cipher::from_iana_description("TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256").unwrap(),
+            Cipher::from_iana_description("TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256").unwrap(),
+            Cipher::from_iana_description("TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384").unwrap(),
+            Cipher::from_iana_description("TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384").unwrap(),
+            Cipher::from_iana_description("TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256").unwrap(),
         ];
-        const EXPECTED_GROUPS: &[&str] = &["secp256r1", "secp384r1", "secp521r1", "x25519"];
-        const EXPECTED_SIGS: &[&str] = &[
-            "ecdsa_sha256",
-            "ecdsa_sha384",
-            "ecdsa_sha512",
-            "rsa_pkcs1_sha256",
-            "rsa_pkcs1_sha384",
-            "rsa_pkcs1_sha512",
-            "rsa_pss_rsae_sha256",
-            "rsa_pss_rsae_sha384",
-            "rsa_pss_rsae_sha512",
-            "rsa_pss_pss_sha256",
-            "rsa_pss_pss_sha384",
-            "rsa_pss_pss_sha512",
+        let expected_groups: Vec<Group> = vec![
+            Group::from_iana_description("secp256r1").unwrap(),
+            Group::from_iana_description("secp384r1").unwrap(),
+            Group::from_iana_description("secp521r1").unwrap(),
+            Group::from_iana_description("x25519").unwrap(),
+        ];
+        let expected_sigs: Vec<Signature> = vec![
+            Signature::from_s2n_description("ecdsa_sha256").unwrap(),
+            Signature::from_s2n_description("ecdsa_sha384").unwrap(),
+            Signature::from_s2n_description("ecdsa_sha512").unwrap(),
+            Signature::from_s2n_description("rsa_pkcs1_sha256").unwrap(),
+            Signature::from_s2n_description("rsa_pkcs1_sha384").unwrap(),
+            Signature::from_s2n_description("rsa_pkcs1_sha512").unwrap(),
+            Signature::from_s2n_description("rsa_pss_rsae_sha256").unwrap(),
+            Signature::from_s2n_description("rsa_pss_rsae_sha384").unwrap(),
+            Signature::from_s2n_description("rsa_pss_rsae_sha512").unwrap(),
+            Signature::from_s2n_description("rsa_pss_pss_sha256").unwrap(),
+            Signature::from_s2n_description("rsa_pss_pss_sha384").unwrap(),
+            Signature::from_s2n_description("rsa_pss_pss_sha512").unwrap(),
         ];
 
         let endpoint = TestEndpoint::new();
@@ -662,19 +670,13 @@ mod tests {
 
         fn assert_supported_matches<const N: usize, T>(
             counter: &FrozenCounter<N, T>,
-            expected: &[&str],
+            expected: &[T],
         ) where
-            T: FiniteCounter<N> + std::fmt::Display + std::str::FromStr<Err = ()>,
+            T: FiniteCounter<N> + std::fmt::Display,
         {
             let expected_slots: Vec<usize> = expected
                 .iter()
-                .map(|description| {
-                    description
-                        .parse::<T>()
-                        .unwrap_or_else(|()| panic!("unknown description {description}"))
-                        .slot_from_key()
-                        .unwrap()
-                })
+                .map(|description| description.slot_from_key().unwrap())
                 .collect();
 
             for (slot, &count) in counter.slots().iter().enumerate() {
@@ -687,10 +689,10 @@ mod tests {
             }
         }
 
-        assert_supported_matches(&record.supported_protocols, EXPECTED_VERSIONS);
-        assert_supported_matches(&record.supported_ciphers, EXPECTED_CIPHERS);
-        assert_supported_matches(&record.supported_groups, EXPECTED_GROUPS);
-        assert_supported_matches(&record.supported_signatures, EXPECTED_SIGS);
+        assert_supported_matches(&record.supported_protocols, &expected_protocols);
+        assert_supported_matches(&record.supported_ciphers, &expected_ciphers);
+        assert_supported_matches(&record.supported_groups, &expected_groups);
+        assert_supported_matches(&record.supported_signatures, &expected_sigs);
     }
 
     #[test]


### PR DESCRIPTION
# Goal
Fix an issue with signature calculation in the negotiated parameters method.

## Why
It is currently broken.

## How
Normalize the signatures first.

## Callouts
I also removed the "parse()" methods, because I kind of blame that on leading me down this path. Instead customers must now be explicit and call `from_iana_description` or similar. 

## Testing
Added a test confirming that all reachable security policy names in s2n-tls are correctly resolved.

I also checked that test and confirmed that all of the following show up in the "names"
```
    "legacy_ecdsa_sha256",
    "ecdsa_secp521r1_sha512",
    "rsa_pkcs1_sha1",
    "rsa_pss_pss_sha512",
    "rsa_pss_rsae_sha384",
    "ecdsa_secp384r1_sha384",
    "mldsa87",
    "legacy_rsa_md5_sha1",
    "legacy_ecdsa_sha512",
    "rsa_pss_pss_sha256",
    "rsa_pss_rsae_sha512",
    "legacy_rsa_sha224",
    "rsa_pkcs1_sha512",
    "legacy_ecdsa_sha384",
    "rsa_pkcs1_sha256",
    "ecdsa_sha1",
    "rsa_pss_pss_sha384",
    "ecdsa_secp256r1_sha256",
    "rsa_pss_rsae_sha256",
    "rsa_pkcs1_sha384",
    "mldsa65",
    "mldsa44",
    "legacy_ecdsa_sha224",
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
