### PR TITLE
fix: always free async offload op during connection teardown

### DIFF
--- a/api/unstable/async_offload.h
+++ b/api/unstable/async_offload.h
@@ -87,7 +87,13 @@ S2N_API extern int s2n_config_set_async_offload_callback(struct s2n_config *conf
  * Retrying s2n_negotiate() will produce the same result until s2n_async_offload_op_perform() is completed.
  * 
  * s2n_async_offload_op_perform() can only be called once for each triggered operation.
- * 
+ *
+ * The `op` is owned by s2n-tls and is freed together with its s2n_connection. The
+ * application MUST ensure any thread executing s2n_async_offload_op_perform() for a
+ * connection has finished before that connection is freed (s2n_connection_free) or
+ * reused (s2n_connection_wipe). s2n-tls does not synchronize with the perform thread,
+ * so freeing or wiping a connection during a perform call may cause a use-after-free.
+ *
  * @param op An opaque object representing the async operation
  */
 S2N_API extern int s2n_async_offload_op_perform(struct s2n_async_offload_op *op);

--- a/tests/unit/s2n_async_offload_cb_test.c
+++ b/tests/unit/s2n_async_offload_cb_test.c
@@ -45,6 +45,23 @@ int s2n_async_offload_test_callback(struct s2n_connection *conn, struct s2n_asyn
     return data->result;
 }
 
+/* A perform that always fails. s2n_async_offload_op_perform() only advances the
+ * op to S2N_ASYNC_COMPLETE on success, so using this leaves the op stuck in
+ * S2N_ASYNC_INVOKED, reproducing the failed-perform state that broke teardown. */
+static S2N_RESULT s2n_async_offload_test_failing_perform(struct s2n_async_offload_op *op)
+{
+    RESULT_BAIL(S2N_ERR_VERIFY_SIGNATURE);
+}
+
+/* Frees the heap allocation owned by the op below, so this regression test also
+ * exercises the op_data_free path (and lets valgrind confirm no leak). */
+static S2N_RESULT s2n_async_offload_test_op_data_free(struct s2n_async_offload_op *op)
+{
+    RESULT_ENSURE_REF(op);
+    RESULT_GUARD_POSIX(s2n_free(&op->op_data.async_pkey_verify.signature));
+    return S2N_RESULT_OK;
+}
+
 static int s2n_test_handshake_async(struct s2n_connection *server_conn, struct s2n_connection *client_conn,
         struct s2n_async_offload_cb_test *data)
 {
@@ -98,23 +115,6 @@ int main(int argc, char *argv[])
         EXPECT_FAILURE_WITH_ERRNO(s2n_async_offload_op_perform(NULL), S2N_ERR_NULL);
         struct s2n_async_offload_op test_op = { 0 };
         EXPECT_FAILURE_WITH_ERRNO(s2n_async_offload_op_perform(&test_op), S2N_ERR_INVALID_STATE);
-    }
-
-    /* Test: s2n_async_offload_op_wipe refuses to wipe an in-flight op */
-    {
-        struct s2n_async_offload_op op = { 0 };
-
-        /* Wipe succeeds when not invoked */
-        op.async_state = S2N_ASYNC_NOT_INVOKED;
-        EXPECT_OK(s2n_async_offload_op_wipe(&op));
-
-        /* Wipe succeeds when complete */
-        op.async_state = S2N_ASYNC_COMPLETE;
-        EXPECT_OK(s2n_async_offload_op_wipe(&op));
-
-        /* Wipe fails when still in flight */
-        op.async_state = S2N_ASYNC_INVOKED;
-        EXPECT_ERROR_WITH_ERRNO(s2n_async_offload_op_wipe(&op), S2N_ERR_ASYNC_BLOCKED);
     }
 
     /* clang-format off */
@@ -237,6 +237,34 @@ int main(int argc, char *argv[])
                 EXPECT_EQUAL(s2n_connection_get_actual_protocol_version(server_conn), S2N_TLS12);
             }
         }
+    }
+
+    /* Regression test: a failed s2n_async_offload_op_perform() leaves the op in
+     * S2N_ASYNC_INVOKED. s2n_connection_free() must still fully tear the
+     * connection down (returning S2N_SUCCESS) rather than short-circuiting on the
+     * in-flight op and leaking the connection. */
+    {
+        struct s2n_connection *conn = s2n_connection_new(S2N_SERVER);
+        EXPECT_NOT_NULL(conn);
+
+        struct s2n_async_offload_op *op = &conn->async_offload_op;
+        op->conn = conn;
+        op->type = S2N_ASYNC_OFFLOAD_PKEY_VERIFY;
+        op->perform = s2n_async_offload_test_failing_perform;
+        op->op_data_free = s2n_async_offload_test_op_data_free;
+
+        /* Give the op some owned data so teardown has something real to free. */
+        uint8_t sig_bytes[] = "test-signature";
+        EXPECT_SUCCESS(s2n_alloc(&op->op_data.async_pkey_verify.signature, sizeof(sig_bytes)));
+
+        /* Drive the op to INVOKED, then fail perform. Because perform fails, the
+         * op stays INVOKED instead of advancing to COMPLETE. */
+        op->async_state = S2N_ASYNC_INVOKED;
+        EXPECT_FAILURE_WITH_ERRNO(s2n_async_offload_op_perform(op), S2N_ERR_VERIFY_SIGNATURE);
+        EXPECT_EQUAL(op->async_state, S2N_ASYNC_INVOKED);
+
+        /* The fix: teardown is not short-circuited by the in-flight op. */
+        EXPECT_SUCCESS(s2n_connection_free(conn));
     }
 
     END_TEST();

--- a/tls/s2n_async_offload.c
+++ b/tls/s2n_async_offload.c
@@ -64,10 +64,17 @@ int s2n_async_offload_op_perform(struct s2n_async_offload_op *op)
     return S2N_SUCCESS;
 }
 
-S2N_RESULT s2n_async_offload_op_wipe(struct s2n_async_offload_op *op)
+/**
+ * Unconditionally releases the op's resources, regardless of async_state.
+ *
+ * This is the connection teardown path (s2n_connection_free / s2n_connection_wipe).
+ * It MUST always fully free the op, even if a failed s2n_async_offload_op_perform()
+ * left the op in S2N_ASYNC_INVOKED; otherwise the remainder of teardown is skipped
+ * and the connection leaks.
+ */
+S2N_RESULT s2n_async_offload_op_free(struct s2n_async_offload_op *op)
 {
     RESULT_ENSURE_REF(op);
-    RESULT_ENSURE(op->async_state != S2N_ASYNC_INVOKED, S2N_ERR_ASYNC_BLOCKED);
     if (op->op_data_free == NULL) {
         return S2N_RESULT_OK;
     }
@@ -80,6 +87,10 @@ S2N_RESULT s2n_async_offload_op_wipe(struct s2n_async_offload_op *op)
 /**
  * MUST be called at the end of each handshake state handler that may invoke async_offload_cb
  * to clean up the op object for its next use.
+ *
+ * Unlike s2n_async_offload_op_free(), this is the handshake-path cleanup and refuses
+ * to free an op that is still in flight (S2N_ASYNC_INVOKED): s2n still holds
+ * references to its data, so wiping mid-negotiation would be a logic error.
  */
 S2N_RESULT s2n_async_offload_op_reset(struct s2n_async_offload_op *op)
 {
@@ -90,7 +101,7 @@ S2N_RESULT s2n_async_offload_op_reset(struct s2n_async_offload_op *op)
     }
 
     RESULT_ENSURE(op->async_state == S2N_ASYNC_COMPLETE, S2N_ERR_INVALID_STATE);
-    RESULT_GUARD(s2n_async_offload_op_wipe(op));
+    RESULT_GUARD(s2n_async_offload_op_free(op));
     return S2N_RESULT_OK;
 }
 

--- a/tls/s2n_async_offload.h
+++ b/tls/s2n_async_offload.h
@@ -56,6 +56,6 @@ struct s2n_async_offload_op {
 };
 
 S2N_RESULT s2n_async_offload_cb_invoke(struct s2n_connection *conn, struct s2n_async_offload_op *op);
-S2N_RESULT s2n_async_offload_op_wipe(struct s2n_async_offload_op *op);
+S2N_RESULT s2n_async_offload_op_free(struct s2n_async_offload_op *op);
 S2N_RESULT s2n_async_offload_op_reset(struct s2n_async_offload_op *op);
 bool s2n_async_offload_op_is_in_allow_list(struct s2n_config *config, s2n_async_offload_op_type op_type);

--- a/tls/s2n_connection.c
+++ b/tls/s2n_connection.c
@@ -281,7 +281,7 @@ int s2n_connection_free(struct s2n_connection *conn)
     POSIX_GUARD(s2n_stuffer_free(&conn->handshake.io));
     POSIX_GUARD(s2n_stuffer_free(&conn->post_handshake.in));
     s2n_x509_validator_wipe(&conn->x509_validator);
-    POSIX_GUARD_RESULT(s2n_async_offload_op_wipe(&conn->async_offload_op));
+    POSIX_GUARD_RESULT(s2n_async_offload_op_free(&conn->async_offload_op));
     POSIX_GUARD(s2n_client_hello_free_raw_message(&conn->client_hello));
     POSIX_GUARD(s2n_free(&conn->application_protocols_overridden));
     POSIX_GUARD(s2n_free(&conn->cookie));
@@ -552,7 +552,7 @@ int s2n_connection_wipe(struct s2n_connection *conn)
     POSIX_GUARD(s2n_stuffer_free(&conn->in));
 
     POSIX_GUARD_RESULT(s2n_psk_parameters_wipe(&conn->psk_params));
-    POSIX_GUARD_RESULT(s2n_async_offload_op_wipe(&conn->async_offload_op));
+    POSIX_GUARD_RESULT(s2n_async_offload_op_free(&conn->async_offload_op));
 
     /* Wipe the I/O-related info and restore the original socket if necessary */
     POSIX_GUARD(s2n_connection_wipe_io(conn));


### PR DESCRIPTION
# Goal
Ensure a connection is always fully torn down, even when an async offload operation failed and is stuck in `S2N_ASYNC_INVOKED`

## Why
#6028 added a guard to `s2n_async_offload_op_wipe()` that refuses to wipe an op still in state `S2N_ASYNC_INVOKED`. But `s2n_async_offload_op_perform()` only advances the op to `S2N_ASYNC_COMPLETE` on success, so a failed perform leaves the op in `INVOKED` permanently.

Both connection-cleanup paths call the wipe under `POSIX_GUARD_RESULT` mid-teardown. When the guard trips `S2N_ERR_ASYNC_BLOCKED`, the guard returns early and every subsequent free is skipped, leaking information stored on connection.

## How
1. Renamed `s2n_async_offload_op_wipe()` to `s2n_async_offload_op_free()`, distinguished from `op_reset()` and indicating unconditional free on the teardown path.
2. Removed the `async_state != S2N_ASYNC_INVOKED` guard, so `op_free()` unconditionally releases the op's resources regardless of state.
3. Pointed both teardown call sites (`s2n_connection_free`, `s2n_connection_wipe`) at `s2n_async_offload_op_free`.
4. The handshake-path invariant is unchanged: `s2n_async_offload_op_reset()` still refuses to proceed unless the op is `S2N_ASYNC_COMPLETE`.

## Callouts
1. The removed guard was never a synchronization primitive; it was a non-atomic read of `async_state` on the main thread. Safety against concurrent teardown-vs-perform is an application responsibility, which is now documented explicitly in `async_offload.h`.
2. `s2n_async_offload_op_wipe()` is an internal function; renaming doesn't impact public APIs.

## Testing
- Removed the now-obsolete unit test that asserted `_wipe` rejects an in-flight op.
- Added a regression test that drives an op to `S2N_ASYNC_INVOKED`, runs a perform that always fails (leaving the op `INVOKED`), then asserts `s2n_connection_free()` returns `S2N_SUCCESS`. Under valgrind this also confirms no leak on the failed-perform teardown path.

### Related
#6028

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
