### PR TITLE
fix: Ensure that TLS1.3 ticket is not accepted on TLS1.2 codepath

### DIFF
--- a/bindings/rust/extended/s2n-tls/src/testing/resumption.rs
+++ b/bindings/rust/extended/s2n-tls/src/testing/resumption.rs
@@ -172,7 +172,7 @@ mod tests {
     // SessionTicket extension, so we model the malicious client directly: we craft
     // a serialized session that makes a TLS1.2 client (a) carry the genuine 138-byte
     // TLS1.3 ticket as its client_ticket (sent in the legacy extension) and (b) use
-    // an all-zero master secret, matching what the confused server will derive.
+    // an all-zero master secret, matching what a confused server would derive.
     #[test]
     fn tls13_ticket_on_tls12_path() -> Result<(), Box<dyn Error>> {
         const S2N_STATE_WITH_SESSION_TICKET: u8 = 1;

--- a/bindings/rust/extended/s2n-tls/src/testing/resumption.rs
+++ b/bindings/rust/extended/s2n-tls/src/testing/resumption.rs
@@ -222,7 +222,6 @@ mod tests {
         assert_eq!(full_session[0], S2N_STATE_WITH_SESSION_TICKET);
         let ticket_len = u16::from_be_bytes([full_session[1], full_session[2]]) as usize;
         let ticket = &full_session[3..3 + ticket_len];
-        println!("[repro] captured TLS1.3 ticket length = {}", ticket.len());
         assert_eq!(
             ticket.len(),
             138,

--- a/bindings/rust/extended/s2n-tls/src/testing/resumption.rs
+++ b/bindings/rust/extended/s2n-tls/src/testing/resumption.rs
@@ -164,4 +164,118 @@ mod tests {
         }
         Ok(())
     }
+
+    // End-to-end reproduction: a genuine TLS1.3 session ticket is accepted on the
+    // TLS1.2 resumption path, and the server completes an abbreviated ("resumed")
+    // handshake keyed by an all-zero master secret.
+    //
+    // The honest s2n client never places a TLS1.3 ticket in the legacy TLS1.2
+    // SessionTicket extension, so we model the malicious client directly: we craft
+    // a serialized session that makes a TLS1.2 client (a) carry the genuine 138-byte
+    // TLS1.3 ticket as its client_ticket (sent in the legacy extension) and (b) use
+    // an all-zero master secret, matching what the confused server will derive.
+    #[test]
+    fn tls13_ticket_on_tls12_path() -> Result<(), Box<dyn Error>> {
+        const S2N_STATE_WITH_SESSION_TICKET: u8 = 1;
+        const S2N_SERIALIZED_FORMAT_TLS12_V3: u8 = 4;
+        const S2N_TLS12: u8 = 33;
+        // TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 (the suite the RSA cert + 20240331 prefs negotiate).
+        const TLS12_CIPHER: [u8; 2] = [0xC0, 0x2F];
+
+        let keypair = CertKeyPair::default();
+
+        // Server allows both TLS1.2 and TLS1.3 (the common/default case) and holds
+        // the ticket key used to issue the TLS1.3 ticket.
+        let mut server_config_builder = Builder::new();
+        server_config_builder
+            .add_session_ticket_key(&KEYNAME, &KEY, SystemTime::now())?
+            .set_security_policy(&security::DEFAULT_TLS13)?
+            .load_pem(keypair.cert(), keypair.key())?;
+        let server_config = server_config_builder.build()?;
+
+        // Step 1: obtain a genuine server-issued TLS1.3 ticket via a normal handshake.
+        let handler = SessionTicketHandler::default();
+        let mut tls13_client_builder = Builder::new();
+        tls13_client_builder
+            .enable_session_tickets(true)?
+            .set_session_ticket_callback(handler.clone())?
+            .set_connection_initializer(handler.clone())?
+            .trust_pem(keypair.cert())?
+            .set_verify_host_callback(InsecureAcceptAllCertificatesHandler {})?
+            .set_security_policy(&security::DEFAULT_TLS13)?;
+        let tls13_client_config = tls13_client_builder.build()?;
+        {
+            let mut pair = TestPair::from_configs(&tls13_client_config, &server_config);
+            pair.client.set_waker(Some(&noop_waker()))?;
+            pair.handshake()?;
+            assert!(pair.client.poll_recv(&mut [0]).is_pending());
+        }
+
+        // The callback stored the full serialized session:
+        //   [format=WITH_SESSION_TICKET][ticket_len:u16][ticket bytes...][tls13 state...]
+        // Extract just the raw ticket bytes.
+        let full_session = handler
+            .stored_ticket
+            .lock()
+            .unwrap()
+            .clone()
+            .expect("no ticket captured");
+        assert_eq!(full_session[0], S2N_STATE_WITH_SESSION_TICKET);
+        let ticket_len = u16::from_be_bytes([full_session[1], full_session[2]]) as usize;
+        let ticket = &full_session[3..3 + ticket_len];
+        println!("[repro] captured TLS1.3 ticket length = {}", ticket.len());
+        assert_eq!(
+            ticket.len(),
+            138,
+            "default TLS1.3 ticket should be 138 bytes"
+        );
+
+        // Step 2: craft a TLS1.2 client session that carries this TLS1.3 ticket and a
+        // zero master secret.
+        let mut crafted = Vec::new();
+        crafted.push(S2N_STATE_WITH_SESSION_TICKET);
+        crafted.extend_from_slice(&(ticket.len() as u16).to_be_bytes());
+        crafted.extend_from_slice(ticket);
+        // TLS1.2 V3 outer state:
+        crafted.push(S2N_SERIALIZED_FORMAT_TLS12_V3);
+        crafted.push(S2N_TLS12);
+        crafted.extend_from_slice(&TLS12_CIPHER);
+        crafted.extend_from_slice(&0u64.to_be_bytes()); // issue time
+        crafted.extend_from_slice(&[0u8; 48]); // all-zero master secret
+        crafted.push(0); // ems_negotiated
+
+        // Malicious TLS1.2 client: force TLS1.2 so the ticket goes in the legacy
+        // SessionTicket extension.
+        let mut attacker_builder = Builder::new();
+        attacker_builder
+            .enable_session_tickets(true)?
+            .trust_pem(keypair.cert())?
+            .set_verify_host_callback(InsecureAcceptAllCertificatesHandler {})?
+            .set_security_policy(&security::TESTING_TLS12)?;
+        let attacker_config = attacker_builder.build()?;
+
+        use crate::connection::Builder as _;
+        let mut attacker = attacker_config.build_connection(crate::enums::Mode::Client)?;
+        attacker.set_session_ticket(&crafted)?;
+
+        let server = server_config.build_connection(crate::enums::Mode::Server)?;
+        let mut pair = TestPair::from_connections(attacker, server);
+        pair.client.set_waker(Some(&noop_waker()))?;
+
+        pair.handshake().expect("handshake should complete");
+        assert_eq!(
+            pair.server.actual_protocol_version()?,
+            crate::enums::Version::TLS12
+        );
+        assert!(
+            !pair.server.resumed(),
+            "server should not have accepted this session ticket"
+        );
+        assert!(
+            !pair.client.resumed(),
+            "client should have negotiated full handshake"
+        );
+
+        Ok(())
+    }
 }

--- a/bindings/rust/extended/s2n-tls/src/testing/resumption.rs
+++ b/bindings/rust/extended/s2n-tls/src/testing/resumption.rs
@@ -165,9 +165,8 @@ mod tests {
         Ok(())
     }
 
-    // End-to-end reproduction: a genuine TLS1.3 session ticket is accepted on the
-    // TLS1.2 resumption path, and the server completes an abbreviated ("resumed")
-    // handshake keyed by an all-zero master secret.
+    // Test that a genuine TLS1.3 session ticket is not accepted on the
+    // TLS1.2 resumption path.
     //
     // The honest s2n client never places a TLS1.3 ticket in the legacy TLS1.2
     // SessionTicket extension, so we model the malicious client directly: we craft

--- a/tests/unit/s2n_extended_master_secret_test.c
+++ b/tests/unit/s2n_extended_master_secret_test.c
@@ -124,6 +124,8 @@ int main(int argc, char **argv)
             conn->secure->cipher_suite = &s2n_ecdhe_ecdsa_with_aes_128_gcm_sha256;
             /* Original connection negotiated an EMS */
             conn->ems_negotiated = true;
+            /* A resumable session must have a valid (non-zero) master secret */
+            memset(conn->secrets.version.tls12.master_secret, 1, S2N_TLS_SECRET_LEN);
 
             struct s2n_stuffer ticket = { 0 };
             struct s2n_blob ticket_blob = { 0 };

--- a/tests/unit/s2n_resume_test.c
+++ b/tests/unit/s2n_resume_test.c
@@ -983,7 +983,6 @@ int main(int argc, char **argv)
 
             struct s2n_connection *conn = s2n_connection_new(S2N_CLIENT);
             EXPECT_NOT_NULL(conn);
-            conn->actual_protocol_version = S2N_TLS13;
 
             struct s2n_config *config = s2n_config_new();
             EXPECT_NOT_NULL(config);

--- a/tests/unit/s2n_resume_test.c
+++ b/tests/unit/s2n_resume_test.c
@@ -915,6 +915,7 @@ int main(int argc, char **argv)
 
             struct s2n_connection *conn = s2n_connection_new(S2N_SERVER);
             EXPECT_NOT_NULL(conn);
+            conn->actual_protocol_version = S2N_TLS13;
 
             struct s2n_config *config = s2n_config_new();
             EXPECT_NOT_NULL(config);
@@ -949,6 +950,7 @@ int main(int argc, char **argv)
 
             struct s2n_connection *conn = s2n_connection_new(S2N_SERVER);
             EXPECT_NOT_NULL(conn);
+            conn->actual_protocol_version = S2N_TLS13;
 
             struct s2n_config *config = s2n_config_new();
             EXPECT_NOT_NULL(config);
@@ -981,6 +983,7 @@ int main(int argc, char **argv)
 
             struct s2n_connection *conn = s2n_connection_new(S2N_CLIENT);
             EXPECT_NOT_NULL(conn);
+            conn->actual_protocol_version = S2N_TLS13;
 
             struct s2n_config *config = s2n_config_new();
             EXPECT_NOT_NULL(config);

--- a/tls/s2n_handshake_io.c
+++ b/tls/s2n_handshake_io.c
@@ -1057,6 +1057,10 @@ int s2n_conn_set_handshake_type(struct s2n_connection *conn)
              * Otherwise, we will perform a full handshake and then generate
              * a new session ticket. */
             if (s2n_result_is_ok(s2n_resume_decrypt_session(conn, &conn->client_ticket_to_decrypt))) {
+                /* Ensure that we have not been able to resume without setting the master secret */
+                uint8_t zero_block[S2N_TLS_SECRET_LEN] = { 0 };
+                POSIX_ENSURE(!s2n_constant_time_equals(conn->secrets.version.tls12.master_secret, zero_block, S2N_TLS_SECRET_LEN),
+                    S2N_ERR_KEY_CHECK);
                 return S2N_SUCCESS;
             }
 

--- a/tls/s2n_handshake_io.c
+++ b/tls/s2n_handshake_io.c
@@ -1060,7 +1060,8 @@ int s2n_conn_set_handshake_type(struct s2n_connection *conn)
                 /* Ensure that we have not been able to resume without setting the master secret */
                 uint8_t zero_block[S2N_TLS_SECRET_LEN] = { 0 };
                 POSIX_ENSURE(!s2n_constant_time_equals(conn->secrets.version.tls12.master_secret,
-                        zero_block, S2N_TLS_SECRET_LEN), S2N_ERR_KEY_CHECK);
+                                     zero_block, S2N_TLS_SECRET_LEN),
+                        S2N_ERR_KEY_CHECK);
                 return S2N_SUCCESS;
             }
 

--- a/tls/s2n_handshake_io.c
+++ b/tls/s2n_handshake_io.c
@@ -1059,8 +1059,8 @@ int s2n_conn_set_handshake_type(struct s2n_connection *conn)
             if (s2n_result_is_ok(s2n_resume_decrypt_session(conn, &conn->client_ticket_to_decrypt))) {
                 /* Ensure that we have not been able to resume without setting the master secret */
                 uint8_t zero_block[S2N_TLS_SECRET_LEN] = { 0 };
-                POSIX_ENSURE(!s2n_constant_time_equals(conn->secrets.version.tls12.master_secret, zero_block, S2N_TLS_SECRET_LEN),
-                    S2N_ERR_KEY_CHECK);
+                POSIX_ENSURE(!s2n_constant_time_equals(conn->secrets.version.tls12.master_secret,
+                        zero_block, S2N_TLS_SECRET_LEN), S2N_ERR_KEY_CHECK);
                 return S2N_SUCCESS;
             }
 

--- a/tls/s2n_resume.c
+++ b/tls/s2n_resume.c
@@ -313,7 +313,10 @@ static S2N_RESULT s2n_tls13_deserialize_session_state(struct s2n_connection *con
     uint8_t protocol_version = 0;
     RESULT_GUARD_POSIX(s2n_stuffer_read_uint8(from, &protocol_version));
     RESULT_ENSURE_GTE(protocol_version, S2N_TLS13);
-    RESULT_ENSURE(protocol_version == conn->actual_protocol_version, S2N_ERR_INVALID_SERIALIZED_SESSION_STATE);
+    // Clients don't know which protocol version will be negotiated at this stage
+    if (conn->mode == S2N_SERVER) {
+        RESULT_ENSURE(protocol_version == conn->actual_protocol_version, S2N_ERR_INVALID_SERIALIZED_SESSION_STATE);
+    }
 
     uint8_t iana_id[S2N_TLS_CIPHER_SUITE_LEN] = { 0 };
     RESULT_GUARD_POSIX(s2n_stuffer_read_bytes(from, iana_id, S2N_TLS_CIPHER_SUITE_LEN));

--- a/tls/s2n_resume.c
+++ b/tls/s2n_resume.c
@@ -313,6 +313,7 @@ static S2N_RESULT s2n_tls13_deserialize_session_state(struct s2n_connection *con
     uint8_t protocol_version = 0;
     RESULT_GUARD_POSIX(s2n_stuffer_read_uint8(from, &protocol_version));
     RESULT_ENSURE_GTE(protocol_version, S2N_TLS13);
+    RESULT_ENSURE(protocol_version == conn->actual_protocol_version, S2N_ERR_INVALID_SERIALIZED_SESSION_STATE);
 
     uint8_t iana_id[S2N_TLS_CIPHER_SUITE_LEN] = { 0 };
     RESULT_GUARD_POSIX(s2n_stuffer_read_bytes(from, iana_id, S2N_TLS_CIPHER_SUITE_LEN));

--- a/tls/s2n_resume.c
+++ b/tls/s2n_resume.c
@@ -313,7 +313,7 @@ static S2N_RESULT s2n_tls13_deserialize_session_state(struct s2n_connection *con
     uint8_t protocol_version = 0;
     RESULT_GUARD_POSIX(s2n_stuffer_read_uint8(from, &protocol_version));
     RESULT_ENSURE_GTE(protocol_version, S2N_TLS13);
-    // Clients don't know which protocol version will be negotiated at this stage
+    /* Clients don't know which protocol version will be negotiated at this stage */
     if (conn->mode == S2N_SERVER) {
         RESULT_ENSURE(protocol_version == conn->actual_protocol_version, S2N_ERR_INVALID_SERIALIZED_SESSION_STATE);
     }


### PR DESCRIPTION
# Goal
Fixes bug found where a TLS1.3 ticket set in the TLS1.2 session ticket extension could be accepted by the server.

## Why
Correctness issue.

## How
Added check in TLS1.3 deserialization that the actual protocol negotiated must be TLS1.3. Additionally I added a check that you cannot use a zeroed out key after TLS1.2 resumption.

## Callouts


## Testing
Includes test

### Related

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
