### PR TITLE
fix: cleanup dhparams in failure case

### DIFF
--- a/tests/cbmc/sources/make_common_datastructures.c
+++ b/tests/cbmc/sources/make_common_datastructures.c
@@ -348,7 +348,7 @@ struct s2n_config *cbmc_allocate_s2n_config()
 {
     struct s2n_config *s2n_config = malloc(sizeof(*s2n_config));
     PTR_ENSURE_REF(s2n_config);
-    s2n_config->dhparams                = cbmc_allocate_dh_params();
+    cbmc_populate_s2n_dh_params(&s2n_config->dhparams);
     s2n_config->domain_name_to_cert_map = cbmc_allocate_s2n_map();
     /* `s2n_config->default_certs_by_type` is never allocated.
      * If required, this initialization should be done in the proof harness.

--- a/tests/unit/s2n_config_test.c
+++ b/tests/unit/s2n_config_test.c
@@ -1425,5 +1425,22 @@ int main(int argc, char **argv)
         }
     };
 
+    /* Regression test for https://github.com/aws/s2n-tls/issues/6082:
+     * a failed s2n_config_add_dhparams() must not leave config->dhparams
+     * in a state that crashed the subsequent s2n_config_free(). */
+    {
+        /* Valid PEM boundaries, garbage contents. From the issue report. */
+        const char *invalid_dhparams =
+                "-----BEGIN DH PARAMETERS-----\n"
+                "test\n"
+                "-----END DH PARAMETERS-----";
+
+        struct s2n_config *config = s2n_config_new();
+        EXPECT_NOT_NULL(config);
+        EXPECT_FAILURE(s2n_config_add_dhparams(config, invalid_dhparams));
+        EXPECT_NULL(config->dhparams.dh);
+        EXPECT_SUCCESS(s2n_config_free(config));
+    };
+
     END_TEST();
 }

--- a/tls/s2n_config.c
+++ b/tls/s2n_config.c
@@ -374,12 +374,11 @@ int s2n_config_free_cert_chain_and_key(struct s2n_config *config)
 int s2n_config_free_dhparams(struct s2n_config *config)
 {
     POSIX_ENSURE_REF(config);
-    if (config->dhparams) {
-        POSIX_GUARD(s2n_dh_params_free(config->dhparams));
-    }
 
-    POSIX_GUARD(s2n_free_object((uint8_t **) &config->dhparams, sizeof(struct s2n_dh_params)));
-    return 0;
+    /* s2n_dh_params_free is safe to call when dh is NULL, so this handles
+     * both the configured and unconfigured cases. */
+    POSIX_GUARD(s2n_dh_params_free(&config->dhparams));
+    return S2N_SUCCESS;
 }
 
 S2N_CLEANUP_RESULT s2n_config_ptr_free(struct s2n_config **config)
@@ -772,20 +771,9 @@ int s2n_config_add_dhparams(struct s2n_config *config, const char *dhparams_pem)
     DEFER_CLEANUP(struct s2n_stuffer dhparams_in_stuffer = { 0 }, s2n_stuffer_free);
     DEFER_CLEANUP(struct s2n_stuffer dhparams_out_stuffer = { 0 }, s2n_stuffer_free);
     struct s2n_blob dhparams_blob = { 0 };
-    struct s2n_blob mem = { 0 };
 
-    /* Allocate the memory for the chain and key struct */
-    POSIX_GUARD(s2n_alloc(&mem, sizeof(struct s2n_dh_params)));
-    config->dhparams = (struct s2n_dh_params *) (void *) mem.data;
-
-    if (s2n_stuffer_alloc_ro_from_string(&dhparams_in_stuffer, dhparams_pem) != S2N_SUCCESS) {
-        s2n_free(&mem);
-        S2N_ERROR_PRESERVE_ERRNO();
-    }
-    if (s2n_stuffer_growable_alloc(&dhparams_out_stuffer, strlen(dhparams_pem)) != S2N_SUCCESS) {
-        s2n_free(&mem);
-        S2N_ERROR_PRESERVE_ERRNO();
-    }
+    POSIX_GUARD(s2n_stuffer_alloc_ro_from_string(&dhparams_in_stuffer, dhparams_pem));
+    POSIX_GUARD(s2n_stuffer_growable_alloc(&dhparams_out_stuffer, strlen(dhparams_pem)));
 
     /* Convert pem to asn1 and asn1 to the private key */
     POSIX_GUARD(s2n_stuffer_dhparams_from_pem(&dhparams_in_stuffer, &dhparams_out_stuffer));
@@ -794,9 +782,18 @@ int s2n_config_add_dhparams(struct s2n_config *config, const char *dhparams_pem)
     dhparams_blob.data = s2n_stuffer_raw_read(&dhparams_out_stuffer, dhparams_blob.size);
     POSIX_ENSURE_REF(dhparams_blob.data);
 
-    POSIX_GUARD(s2n_pkcs3_to_dh_params(config->dhparams, &dhparams_blob));
+    /* Parse into a temporary struct so that config->dhparams is only modified
+     * once parsing has fully succeeded. On failure, the DEFER_CLEANUP frees any
+     * DH that was allocated. */
+    DEFER_CLEANUP(struct s2n_dh_params dhparams = { 0 }, s2n_dh_params_free);
+    POSIX_GUARD(s2n_pkcs3_to_dh_params(&dhparams, &dhparams_blob));
 
-    return 0;
+    /* Release any previously configured dhparams before overwriting. */
+    POSIX_GUARD(s2n_config_free_dhparams(config));
+    config->dhparams = dhparams;
+    ZERO_TO_DISABLE_DEFER_CLEANUP(dhparams);
+
+    return S2N_SUCCESS;
 }
 
 int s2n_config_set_wall_clock(struct s2n_config *config, s2n_clock_time_nanoseconds clock_fn, void *ctx)

--- a/tls/s2n_config.h
+++ b/tls/s2n_config.h
@@ -110,7 +110,7 @@ struct s2n_config {
 
     unsigned ticket_forward_secrecy : 1;
 
-    struct s2n_dh_params *dhparams;
+    struct s2n_dh_params dhparams;
     /* Needed until we can deprecate s2n_config_add_cert_chain_and_key. This is
      * used to release memory allocated only in the deprecated API that the application 
      * does not have a reference to. */

--- a/tls/s2n_kex.c
+++ b/tls/s2n_kex.c
@@ -51,7 +51,7 @@ static S2N_RESULT s2n_check_dhe(const struct s2n_cipher_suite *cipher_suite, str
     RESULT_ENSURE_REF(conn->config);
     RESULT_ENSURE_REF(is_supported);
 
-    *is_supported = conn->config->dhparams != NULL;
+    *is_supported = conn->config->dhparams.dh != NULL;
 
     return S2N_RESULT_OK;
 }

--- a/tls/s2n_server_key_exchange.c
+++ b/tls/s2n_server_key_exchange.c
@@ -297,7 +297,7 @@ int s2n_dhe_server_key_send(struct s2n_connection *conn, struct s2n_blob *data_t
     struct s2n_stuffer *out = &conn->handshake.io;
 
     /* Duplicate the DH key from the config */
-    POSIX_GUARD(s2n_dh_params_copy(conn->config->dhparams, &conn->kex_params.server_dh_params));
+    POSIX_GUARD(s2n_dh_params_copy(&conn->config->dhparams, &conn->kex_params.server_dh_params));
 
     /* Generate an ephemeral key */
     POSIX_GUARD(s2n_dh_generate_ephemeral_key(&conn->kex_params.server_dh_params));


### PR DESCRIPTION
# Goal
Fix a seg-fault in the config free path.

## Why
seg-faults are bad. More seriously, this was flagged by a customer: https://github.com/aws/s2n-tls/issues/6082

## How
the `s2n_dh_paramn` consisted of a single field, but we were storing it as a separately allocated struct, instead of just storing the value on the config.

So we switch to storing the `s2n_dh_params` _value_ onto the config. This means we just read into the stack allocated `s2n_dh_params`, which makes the failure case cleanup much easier to read about.

## Testing
Added a regression test.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
