### PR TITLE
feat(metrics-subscriber): expose compatibility profile allow-lists

### DIFF
--- a/bindings/rust/standard/s2n-tls-metrics-subscriber/src/compatibility.rs
+++ b/bindings/rust/standard/s2n-tls-metrics-subscriber/src/compatibility.rs
@@ -7,6 +7,48 @@
 use crate::{parsing::ClientHelloSupportedParameters, record::NegotiatedParameters};
 use s2n_tls_metrics_schema::static_lists::{Cipher, Group, Signature, Version};
 
+/// A read-only view of a single compatibility profile's allow-lists.
+///
+/// This exposes only the static allow-list data for a profile; it does not
+/// expose any handshake-evaluation behavior.
+#[derive(Debug, Clone, Copy)]
+pub struct TlsProfileSpec {
+    pub allowed_versions: &'static [Version],
+    pub allowed_ciphers: &'static [Cipher],
+    pub allowed_groups: &'static [Group],
+    pub allowed_signatures: &'static [Signature],
+}
+
+/// Stable identifiers for the TLS compatibility profiles measured by this crate.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum CompatibilityProfile {
+    General20251201,
+    Fips20251201,
+    Cnsa1,
+    Cnsa2,
+}
+
+impl CompatibilityProfile {
+    /// Returns the read-only allow-list [`TlsProfileSpec`] for this profile.
+    pub fn spec(self) -> TlsProfileSpec {
+        fn spec_of<P: TlsProfile>() -> TlsProfileSpec {
+            TlsProfileSpec {
+                allowed_versions: P::ALLOWED_VERSIONS,
+                allowed_ciphers: P::ALLOWED_CIPHERS,
+                allowed_groups: P::ALLOWED_GROUPS,
+                allowed_signatures: P::ALLOWED_SIGNATURES,
+            }
+        }
+
+        match self {
+            CompatibilityProfile::General20251201 => spec_of::<General20251201>(),
+            CompatibilityProfile::Fips20251201 => spec_of::<Fips20251201>(),
+            CompatibilityProfile::Cnsa1 => spec_of::<Cnsa1>(),
+            CompatibilityProfile::Cnsa2 => spec_of::<Cnsa2>(),
+        }
+    }
+}
+
 pub(crate) trait TlsProfile {
     const ALLOWED_VERSIONS: &[Version];
     const ALLOWED_CIPHERS: &[Cipher];

--- a/bindings/rust/standard/s2n-tls-metrics-subscriber/src/lib.rs
+++ b/bindings/rust/standard/s2n-tls-metrics-subscriber/src/lib.rs
@@ -3,7 +3,7 @@
 
 mod bounded_set;
 mod client_issue;
-mod compatibility;
+pub mod compatibility;
 pub(crate) mod counter;
 pub mod detector;
 #[cfg(feature = "fuzzing")]


### PR DESCRIPTION
# Goal
<!-- What is the PR doing? -->
Expose the compatibility profiles' allow-lists (versions, ciphers, groups, signatures) as a public, read-only API.

## Why
<!-- Why is this PR necessary? -->
The per-profile allow-lists are currently crate-private. Making them public lets downstream consumers read the permitted parameters and validate a set of parameters against them.

## How
<!-- How is this PR accomplishing its goals? -->
Adds a `TlsProfileSpec` view and a `CompatibilityProfile` enum with a `spec()` accessor that reads directly from the existing per-profile allow-list constants, keeping a single source of truth. The profile trait and its implementors stay crate-private; only the static allow-list data is exposed.

## Testing
<!-- How is it tested? -->
Covered by the existing test suite.

### Related
<!-- E.g. "resolves #3456" -->
N/A
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.