### PR TITLE
feat(metrics): skip export when record is zero

### DIFF
--- a/bindings/rust/standard/s2n-tls-metrics-subscriber/src/lib.rs
+++ b/bindings/rust/standard/s2n-tls-metrics-subscriber/src/lib.rs
@@ -63,6 +63,14 @@ impl MetricRecord {
     pub(crate) fn as_schema(&self) -> &s2n_tls_metrics_schema::record::MetricRecord {
         &self.0
     }
+
+    /// Returns `true` if no handshakes (successful, failed, or synthetic) were aggregated.
+    pub(crate) fn is_empty(&self) -> bool {
+        let handshake = &self.0.handshake;
+        handshake.handshake_success_count == 0
+            && handshake.handshake_failure_count == 0
+            && handshake.synthetic_traffic_count == 0
+    }
 }
 
 impl serde::Serialize for MetricRecord {

--- a/bindings/rust/standard/s2n-tls-metrics-subscriber/src/record.rs
+++ b/bindings/rust/standard/s2n-tls-metrics-subscriber/src/record.rs
@@ -795,18 +795,17 @@ mod tests {
         );
     }
 
-    /// A record with no handshakes should be entirely empty/default.
+    /// A record with no handshakes should not be exported at all.
     #[test]
     fn empty_record() {
         let endpoint = TestEndpoint::new();
 
         endpoint.subscriber.finish_record();
         let records = endpoint.sink.records.lock().unwrap();
-        let mut record = records[0].as_schema().handshake.clone();
-
-        // ignore the freeze time, since that "default" value is set to the Unix Epoch.
-        record.freeze_time = SystemTime::UNIX_EPOCH;
-        assert_eq!(record, FrozenHandshakeRecord::default());
+        assert!(
+            records.is_empty(),
+            "an empty record (no handshakes) should not be exported"
+        );
     }
 
     /// ARBITRARY_POLICY_1 (20240503 / default_tls13) should be compatible with

--- a/bindings/rust/standard/s2n-tls-metrics-subscriber/src/subscriber.rs
+++ b/bindings/rust/standard/s2n-tls-metrics-subscriber/src/subscriber.rs
@@ -185,6 +185,9 @@ impl<S: TelemetrySink> AggregatedMetricsSubscriber<S> {
             attribution: self.inner.attribution.clone().into_schema(),
             handshake,
         });
+        if record.is_empty() {
+            return;
+        }
         export_pipeline.sink.export_record(record);
         self.inner
             .last_export_epoch_ms
@@ -239,19 +242,13 @@ impl<S: TelemetrySink> Drop for MetricSubscriberInner<S> {
         let Ok(handshake) = export_pipeline.metric_receiver.try_recv() else {
             return;
         };
-        // Don't export an empty record. If no handshakes (successful, failed, or
-        // synthetic) were aggregated since the last export, there's nothing
-        // meaningful to report, so skip the export entirely.
-        if handshake.handshake_success_count == 0
-            && handshake.handshake_failure_count == 0
-            && handshake.synthetic_traffic_count == 0
-        {
-            return;
-        }
         let record = MetricRecord::new(s2n_tls_metrics_schema::record::MetricRecord {
             attribution: self.attribution.clone().into_schema(),
             handshake,
         });
+        if record.is_empty() {
+            return;
+        }
         export_pipeline.sink.export_record(record);
     }
 }
@@ -367,20 +364,19 @@ mod tests {
         endpoint.client_handshake(&ARBITRARY_POLICY_1);
         endpoint.subscriber.finish_record();
 
-        // Third: empty record (no handshakes)
+        // Third: no handshakes
         endpoint.subscriber.finish_record();
 
         let records = endpoint.sink.records.lock().unwrap();
         assert_eq!(
             records.len(),
-            3,
-            "expected 3 records from 3 finish_record calls"
+            2,
+            "expected 2 records; the empty finish_record call should be skipped"
         );
 
         // Verify handshake counts
         assert_eq!(records[0].as_schema().handshake.handshake_success_count, 2);
         assert_eq!(records[1].as_schema().handshake.handshake_success_count, 1);
-        assert_eq!(records[2].as_schema().handshake.handshake_success_count, 0);
     }
 
     /// Dropping the subscriber should flush any events aggregated since the


### PR DESCRIPTION
# Goal
Reduce the number of useless exports.

## Why
The reduce the strain on TelemetrySink components.

## How
If a record is empty, don't bother sending it to the telemetry sink.

## Testing
Added a new unit test.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
