### PR TITLE
Clear negotiate_in_use on all s2n_negotiate error paths

### DIFF
--- a/tests/unit/s2n_handshake_io_errors_test.c
+++ b/tests/unit/s2n_handshake_io_errors_test.c
@@ -16,6 +16,7 @@
 #include "api/s2n.h"
 #include "s2n_test.h"
 #include "testlib/s2n_testlib.h"
+#include "tls/s2n_connection.h"
 #include "utils/s2n_result.h"
 
 int main(int argc, char **argv)
@@ -42,6 +43,11 @@ int main(int argc, char **argv)
 
         /* Error did not trigger blinding */
         EXPECT_EQUAL(s2n_connection_get_delay(server_conn), 0);
+
+        /* negotiate_in_use must be cleared so a retry is not stuck on REENTRANCY */
+        EXPECT_FALSE(server_conn->negotiate_in_use);
+        EXPECT_FAILURE_WITH_ERRNO(s2n_negotiate(server_conn, &blocked), S2N_ERR_IO_BLOCKED);
+        EXPECT_FALSE(server_conn->negotiate_in_use);
 
         EXPECT_SUCCESS(s2n_connection_free(server_conn));
     };

--- a/tls/s2n_handshake_io.c
+++ b/tls/s2n_handshake_io.c
@@ -1741,12 +1741,10 @@ int s2n_negotiate_impl(struct s2n_connection *conn, s2n_blocked_status *blocked)
     return S2N_SUCCESS;
 }
 
-int s2n_negotiate(struct s2n_connection *conn, s2n_blocked_status *blocked)
+/* Performs negotiate timing/metrics work that may early-return via POSIX_GUARD.
+ * Called only while conn->negotiate_in_use is true; the caller clears the flag. */
+static int s2n_negotiate_with_timing(struct s2n_connection *conn, s2n_blocked_status *blocked)
 {
-    POSIX_ENSURE_REF(conn);
-    POSIX_ENSURE(!conn->negotiate_in_use, S2N_ERR_REENTRANCY);
-    conn->negotiate_in_use = true;
-
     /* We use the default monotonic clock so that we can avoid referencing any
      * item on the config until after the client hello callback is invoked. */
     uint64_t negotiate_start = 0;
@@ -1788,6 +1786,19 @@ int s2n_negotiate(struct s2n_connection *conn, s2n_blocked_status *blocked)
         s2n_errno = saved_errno;
         _s2n_debug_info = saved_debug_info;
     }
+
+    return result;
+}
+
+int s2n_negotiate(struct s2n_connection *conn, s2n_blocked_status *blocked)
+{
+    POSIX_ENSURE_REF(conn);
+    POSIX_ENSURE(!conn->negotiate_in_use, S2N_ERR_REENTRANCY);
+    conn->negotiate_in_use = true;
+
+    /* Keep fallible POSIX_GUARD work in the helper so this flag is cleared on
+     * every return path, including early errors (#5796). */
+    int result = s2n_negotiate_with_timing(conn, blocked);
 
     conn->negotiate_in_use = false;
     return result;


### PR DESCRIPTION
# Goal
Clear `conn->negotiate_in_use` on every exit from `s2n_negotiate` after the flag is set, so early `POSIX_GUARD` failures cannot permanently deadlock the connection with `S2N_ERR_REENTRANCY`.

## Why
`s2n_negotiate` set `negotiate_in_use = true`, then ran several `POSIX_GUARD` / `POSIX_GUARD_RESULT` calls that return early on failure and skipped the final `negotiate_in_use = false`. After any of those failures, later `s2n_negotiate` calls on the same connection fail with `S2N_ERR_REENTRANCY`.

## How
I moved the fallible timing/metrics work into a static helper `s2n_negotiate_with_timing`. `s2n_negotiate` now only sets the flag, calls the helper, clears the flag, and returns. Early returns from the helper no longer leave the reentrancy flag stuck.

## Callouts
I kept the change scoped to `s2n_negotiate` / #5796. `s2n_send` / `s2n_recv` use a similar pattern but are out of scope here.

## Testing
- Extended `tests/unit/s2n_handshake_io_errors_test.c` so a blocked negotiate clears `negotiate_in_use` and a second call still returns `S2N_ERR_IO_BLOCKED` (not `S2N_ERR_REENTRANCY`).
- Syntax-checked the patched `tls/s2n_handshake_io.c` with gcc; full unit suite not run in this environment.

### Related
Fixes #5796

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.